### PR TITLE
update pascal_voc tutorial

### DIFF
--- a/docs/tutorials/datasets/pascal_voc.py
+++ b/docs/tutorials/datasets/pascal_voc.py
@@ -33,7 +33,7 @@ which will automatically download and extract the data into ``~/.mxnet/datasets/
    The total time to prepare the dataset depends on your Internet speed and disk
    performance. For example, it often takes 10 min on AWS EC2 with EBS.
 
-You can skip the download step if if you have already downloaded the following required files
+You can skip the download step if you have already downloaded the following required files
 
 +------------------------------------------------------------------------------------------------------------------------+--------+------------------------------------------+
 | Filename                                                                                                               | Size   | SHA-1                                    |


### PR DESCRIPTION
@zhreshold 

i changed a few things:

1. changed from `--dir` to `--download-dir`. the former is confusion. and we need to keep args consistent between scripts. 

2. double check the correctness "'Bounding boxes (num_boxes, bottom_x, bottom_y, upper_x, upper_y)"

3. replace last the train_ssd.py with a better tutorial

4. i changed the import style according to google style: only import package, not individual functions and classes. 