### PR TITLE
Fix missing imports and undefined names

### DIFF
--- a/gluoncv/data/mscoco/pycocotools/coco.py
+++ b/gluoncv/data/mscoco/pycocotools/coco.py
@@ -56,12 +56,17 @@ import itertools
 # from . import mask as maskUtils
 import os
 from collections import defaultdict
-import sys
-PYTHON_VERSION = sys.version_info[0]
-if PYTHON_VERSION == 2:
-    from urllib import urlretrieve
-elif PYTHON_VERSION == 3:
+
+try:                 # Python 2
     from urllib.request import urlretrieve
+except ImportError:  # Python 3
+    from urllib import urlretrieve
+
+try:                 # Python 2
+    basestring
+except NameError:    # Python 3
+    basestring = (str, )
+
 
 class COCO:
     def __init__(self, annotation_file=None):
@@ -303,7 +308,7 @@ class COCO:
 
         print('Loading and preparing results...')
         tic = time.time()
-        if type(resFile) == str or type(resFile) == unicode:
+        if isinstance(resFile, basestring):
             anns = json.load(open(resFile))
         elif type(resFile) == np.ndarray:
             anns = self.loadNumpyAnnotations(resFile)

--- a/gluoncv/data/transforms/image.py
+++ b/gluoncv/data/transforms/image.py
@@ -128,7 +128,7 @@ def random_pca_lighting(src, alphastd, eigval=None, eigvec=None):
 
     """
     if alphastd <= 0:
-        return img
+        return src
 
     if eigval is None:
         eigval = np.array([55.46, 4.794, 1.148])

--- a/gluoncv/model_zoo/syncbn.py
+++ b/gluoncv/model_zoo/syncbn.py
@@ -4,6 +4,8 @@ import threading
 from mxnet import autograd, test_utils
 from mxnet.gluon import HybridBlock
 
+import numpy as np
+
 
 class BatchNorm(HybridBlock):
     """Cross-GPU Synchronized Batch normalization (SyncBN)

--- a/gluoncv/utils/block.py
+++ b/gluoncv/utils/block.py
@@ -1,6 +1,7 @@
 """Utility functions for gluon parameters."""
 import re
 
+
 def set_lr_mult(net, pattern, mult=1.0, verbose=False):
     """Reset lr_mult to new value for all parameters that match :obj:`pattern`
 
@@ -27,4 +28,4 @@ def set_lr_mult(net, pattern, mult=1.0, verbose=False):
             continue
         value.lr_mult = mult
         if verbose:
-            print("Set lr_mult of {} to {}".format(param.name, mult))
+            print("Set lr_mult of {} to {}".format(value.name, mult))


### PR DESCRIPTION
Fix some but not all issues raised in flake8 testing of https://github.com/dmlc/gluon-cv on Python 3.6

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./gluoncv/data/mscoco/pycocotools/coco.py:267:41: F821 undefined name 'm'
                        img = np.ones( (m.shape[0], m.shape[1], 3) )
                                        ^
./gluoncv/data/mscoco/pycocotools/coco.py:267:53: F821 undefined name 'm'
                        img = np.ones( (m.shape[0], m.shape[1], 3) )
                                                    ^
./gluoncv/data/mscoco/pycocotools/coco.py:274:52: F821 undefined name 'm'
                        ax.imshow(np.dstack( (img, m*0.5) ))
                                                   ^
./gluoncv/data/mscoco/pycocotools/coco.py:306:53: F821 undefined name 'unicode'
        if type(resFile) == str or type(resFile) == unicode:
                                                    ^
./gluoncv/data/mscoco/pycocotools/coco.py:436:16: F821 undefined name 'm'
        return m
               ^
./gluoncv/data/transforms/image.py:131:16: F821 undefined name 'img'
        return img
               ^
./gluoncv/model_zoo/syncbn.py:108:12: F821 undefined name 'np'
        if np.dtype(dtype).name == 'float16':
           ^
./gluoncv/model_zoo/ssd/vgg_atrous.py:121:29: F821 undefined name 'stage'
                            stage.add(nn.BatchNorm())
                            ^
./gluoncv/utils/block.py:30:52: F821 undefined name 'param'
            print("Set lr_mult of {} to {}".format(param.name, mult))
                                                   ^
9     F821 undefined name 'm'
9
```