### PR TITLE
Improve SE block by AdaptiveAvgPool2D

### DIFF
--- a/gluoncv/model_zoo/resnext.py
+++ b/gluoncv/model_zoo/resnext.py
@@ -64,10 +64,9 @@ class Block(HybridBlock):
 
         if use_se:
             self.se = nn.HybridSequential(prefix='')
-            self.se.add(nn.GlobalAvgPool2D())
-            self.se.add(nn.Conv2D(channels // 4, kernel_size=1, use_bias=False))
+            self.se.add(nn.Dense(channels // 4, use_bias=False))
             self.se.add(nn.Activation('relu'))
-            self.se.add(nn.Conv2D(channels * 4, kernel_size=1, use_bias=False))
+            self.se.add(nn.Dense(channels * 4, use_bias=False))
             self.se.add(nn.Activation('sigmoid'))
         else:
             self.se = None
@@ -86,8 +85,9 @@ class Block(HybridBlock):
         x = self.body(x)
 
         if self.se:
-            w = self.se(x)
-            x = F.broadcast_mul(x, w)
+            w = F.contrib.AdaptiveAvgPooling2D(x, output_size=1)
+            w = self.se(w)
+            x = F.broadcast_mul(x, w.expand_dims(axis=2).expand_dims(axis=2))
 
         if self.downsample:
             residual = self.downsample(residual)

--- a/gluoncv/model_zoo/se_resnet.py
+++ b/gluoncv/model_zoo/se_resnet.py
@@ -142,18 +142,6 @@ class SE_BottleneckV1(HybridBlock):
     def hybrid_forward(self, F, x):
         residual = x
 
-
-        if downsample:
-            self.downsample = nn.HybridSequential(prefix='')
-            self.downsample.add(nn.Conv2D(channels, kernel_size=1, strides=stride,
-                                          use_bias=False, in_channels=in_channels))
-            self.downsample.add(nn.BatchNorm())
-        else:
-            self.downsample = None
-
-    def hybrid_forward(self, F, x):
-        residual = x
-
         x = self.body(x)
 
         w = F.contrib.AdaptiveAvgPooling2D(x, output_size=1)
@@ -196,18 +184,6 @@ class SE_BasicBlockV2(HybridBlock):
         self.se.add(nn.Activation('relu'))
         self.se.add(nn.Dense(channels, use_bias=False))
         self.se.add(nn.Activation('sigmoid'))
-
-        if downsample:
-            self.downsample = nn.HybridSequential(prefix='')
-            self.downsample.add(nn.Conv2D(channels, kernel_size=1, strides=stride,
-                                          use_bias=False, in_channels=in_channels))
-            self.downsample.add(nn.BatchNorm())
-        else:
-            self.downsample = None
-
-    def hybrid_forward(self, F, x):
-        residual = x
-
 
         if downsample:
             self.downsample = nn.Conv2D(channels, 1, stride, use_bias=False,
@@ -265,18 +241,6 @@ class SE_BottleneckV2(HybridBlock):
         self.se.add(nn.Activation('relu'))
         self.se.add(nn.Dense(channels, use_bias=False))
         self.se.add(nn.Activation('sigmoid'))
-
-        if downsample:
-            self.downsample = nn.HybridSequential(prefix='')
-            self.downsample.add(nn.Conv2D(channels, kernel_size=1, strides=stride,
-                                          use_bias=False, in_channels=in_channels))
-            self.downsample.add(nn.BatchNorm())
-        else:
-            self.downsample = None
-
-    def hybrid_forward(self, F, x):
-        residual = x
-
 
         if downsample:
             self.downsample = nn.Conv2D(channels, 1, stride, use_bias=False,

--- a/gluoncv/model_zoo/se_resnet.py
+++ b/gluoncv/model_zoo/se_resnet.py
@@ -67,10 +67,9 @@ class SE_BasicBlockV1(HybridBlock):
         self.body.add(nn.BatchNorm())
 
         self.se = nn.HybridSequential(prefix='')
-        self.se.add(nn.GlobalAvgPool2D())
-        self.se.add(nn.Conv2D(channels//16, kernel_size=1, use_bias=False))
+        self.se.add(nn.Dense(channels//16, use_bias=False))
         self.se.add(nn.Activation('relu'))
-        self.se.add(nn.Conv2D(channels, kernel_size=1, use_bias=False))
+        self.se.add(nn.Dense(channels, use_bias=False))
         self.se.add(nn.Activation('sigmoid'))
 
         if downsample:
@@ -85,8 +84,10 @@ class SE_BasicBlockV1(HybridBlock):
         residual = x
 
         x = self.body(x)
-        w = self.se(x)
-        x = F.broadcast_mul(x, w)
+
+        w = F.contrib.AdaptiveAvgPooling2D(x, output_size=1)
+        w = self.se(w)
+        x = F.broadcast_mul(x, w.expand_dims(axis=2).expand_dims(axis=2))
 
         if self.downsample:
             residual = self.downsample(residual)
@@ -125,10 +126,9 @@ class SE_BottleneckV1(HybridBlock):
         self.body.add(nn.BatchNorm())
 
         self.se = nn.HybridSequential(prefix='')
-        self.se.add(nn.GlobalAvgPool2D())
-        self.se.add(nn.Conv2D(channels//16, kernel_size=1, use_bias=False))
+        self.se.add(nn.Dense(channels//16, use_bias=False))
         self.se.add(nn.Activation('relu'))
-        self.se.add(nn.Conv2D(channels, kernel_size=1, use_bias=False))
+        self.se.add(nn.Dense(channels, use_bias=False))
         self.se.add(nn.Activation('sigmoid'))
 
         if downsample:
@@ -142,9 +142,23 @@ class SE_BottleneckV1(HybridBlock):
     def hybrid_forward(self, F, x):
         residual = x
 
+
+        if downsample:
+            self.downsample = nn.HybridSequential(prefix='')
+            self.downsample.add(nn.Conv2D(channels, kernel_size=1, strides=stride,
+                                          use_bias=False, in_channels=in_channels))
+            self.downsample.add(nn.BatchNorm())
+        else:
+            self.downsample = None
+
+    def hybrid_forward(self, F, x):
+        residual = x
+
         x = self.body(x)
-        w = self.se(x)
-        x = F.broadcast_mul(x, w)
+
+        w = F.contrib.AdaptiveAvgPooling2D(x, output_size=1)
+        w = self.se(w)
+        x = F.broadcast_mul(x, w.expand_dims(axis=2).expand_dims(axis=2))
 
         if self.downsample:
             residual = self.downsample(residual)
@@ -178,11 +192,22 @@ class SE_BasicBlockV2(HybridBlock):
         self.conv2 = _conv3x3(channels, 1, channels)
 
         self.se = nn.HybridSequential(prefix='')
-        self.se.add(nn.GlobalAvgPool2D())
-        self.se.add(nn.Conv2D(channels//16, kernel_size=1, use_bias=False))
+        self.se.add(nn.Dense(channels//16, use_bias=False))
         self.se.add(nn.Activation('relu'))
-        self.se.add(nn.Conv2D(channels, kernel_size=1, use_bias=False))
+        self.se.add(nn.Dense(channels, use_bias=False))
         self.se.add(nn.Activation('sigmoid'))
+
+        if downsample:
+            self.downsample = nn.HybridSequential(prefix='')
+            self.downsample.add(nn.Conv2D(channels, kernel_size=1, strides=stride,
+                                          use_bias=False, in_channels=in_channels))
+            self.downsample.add(nn.BatchNorm())
+        else:
+            self.downsample = None
+
+    def hybrid_forward(self, F, x):
+        residual = x
+
 
         if downsample:
             self.downsample = nn.Conv2D(channels, 1, stride, use_bias=False,
@@ -202,8 +227,9 @@ class SE_BasicBlockV2(HybridBlock):
         x = F.Activation(x, act_type='relu')
         x = self.conv2(x)
 
-        w = self.se(x)
-        x = F.broadcast_mul(x, w)
+        w = F.contrib.AdaptiveAvgPooling2D(x, output_size=1)
+        w = self.se(w)
+        x = F.broadcast_mul(x, w.expand_dims(axis=2).expand_dims(axis=2))
 
         return x + residual
 
@@ -235,11 +261,22 @@ class SE_BottleneckV2(HybridBlock):
         self.conv3 = nn.Conv2D(channels, kernel_size=1, strides=1, use_bias=False)
 
         self.se = nn.HybridSequential(prefix='')
-        self.se.add(nn.GlobalAvgPool2D())
-        self.se.add(nn.Conv2D(channels//16, kernel_size=1, use_bias=False))
+        self.se.add(nn.Dense(channels//16, use_bias=False))
         self.se.add(nn.Activation('relu'))
-        self.se.add(nn.Conv2D(channels, kernel_size=1, use_bias=False))
+        self.se.add(nn.Dense(channels, use_bias=False))
         self.se.add(nn.Activation('sigmoid'))
+
+        if downsample:
+            self.downsample = nn.HybridSequential(prefix='')
+            self.downsample.add(nn.Conv2D(channels, kernel_size=1, strides=stride,
+                                          use_bias=False, in_channels=in_channels))
+            self.downsample.add(nn.BatchNorm())
+        else:
+            self.downsample = None
+
+    def hybrid_forward(self, F, x):
+        residual = x
+
 
         if downsample:
             self.downsample = nn.Conv2D(channels, 1, stride, use_bias=False,
@@ -263,8 +300,9 @@ class SE_BottleneckV2(HybridBlock):
         x = F.Activation(x, act_type='relu')
         x = self.conv3(x)
 
-        w = self.se(x)
-        x = F.broadcast_mul(x, w)
+        w = F.contrib.AdaptiveAvgPooling2D(x, output_size=1)
+        w = self.se(w)
+        x = F.broadcast_mul(x, w.expand_dims(axis=2).expand_dims(axis=2))
 
         return x + residual
 


### PR DESCRIPTION
The current `nn.GlobalAvgPool2D` is slow in backpropagation. By switching to `contrib.AdaptiveAvgPooling2D`, training speed on dummy data increases from 462 images/sec to 643 images/sec for `se_resnext50_32x4d`.