### PR TITLE
Fix windows bug with filename

### DIFF
--- a/docs/tutorials/detection/demo_ssd.py
+++ b/docs/tutorials/detection/demo_ssd.py
@@ -42,7 +42,7 @@ net = model_zoo.get_model('ssd_512_resnet50_v1_voc', pretrained=True)
 
 im_fname = utils.download('https://github.com/dmlc/web-data/blob/master/' +
                           'gluoncv/detection/street_small.jpg?raw=true',
-                         fname='street_small.jpg')
+                          path='street_small.jpg')
 x, img = data.transforms.presets.ssd.load_test(im_fname, short=512)
 print('Shape of pre-processed image:', x.shape)
 

--- a/docs/tutorials/detection/demo_ssd.py
+++ b/docs/tutorials/detection/demo_ssd.py
@@ -41,7 +41,8 @@ net = model_zoo.get_model('ssd_512_resnet50_v1_voc', pretrained=True)
 # of `x` is 1.
 
 im_fname = utils.download('https://github.com/dmlc/web-data/blob/master/' +
-                          'gluoncv/detection/street_small.jpg?raw=true')
+                          'gluoncv/detection/street_small.jpg?raw=true',
+                         fname='street_small.jpg')
 x, img = data.transforms.presets.ssd.load_test(im_fname, short=512)
 print('Shape of pre-processed image:', x.shape)
 


### PR DESCRIPTION
windows does not like 'street_small.jpg?raw=true' as filename.
see: https://discuss.mxnet.io/t/invalid-argument-street-small-jpg-raw-true/1065

https://github.com/dmlc/gluon-cv/issues/132