### PR TITLE
fix VOC07 average_precision error

### DIFF
--- a/gluoncv/utils/metrics/voc_detection.py
+++ b/gluoncv/utils/metrics/voc_detection.py
@@ -270,6 +270,8 @@ class VOC07MApMetric(VOCMApMetric):
         ----------
         ap as float
         """
+        if rec is None or prec is None:
+            return np.nan
         ap = 0.
         for t in np.arange(0., 1.1, 0.1):
             if np.sum(rec >= t) == 0:


### PR DESCRIPTION
 Fix VOC07MApMetric._average_precision() error when rec is None or prec is None
See: https://github.com/dmlc/gluon-cv/issues/165