### PR TITLE
Fix bug in DeNormalize

### DIFF
--- a/gluoncv/utils/viz/segmentation.py
+++ b/gluoncv/utils/viz/segmentation.py
@@ -44,7 +44,7 @@ class DeNormalize(HybridBlock):
         self.std = mx.nd.array(std, ctx=mx.cpu(0))
 
     def hybrid_forward(self, F, x):
-        return x * self.std .reshape(shape=(3, 1, 1)) - self.mean.reshape(shape=(3, 1, 1))
+        return x * self.std .reshape(shape=(3, 1, 1)) + self.mean.reshape(shape=(3, 1, 1))
 
 
 def _getvocpallete(num_cls):


### PR DESCRIPTION
Normalize is defined as:
```
output[i] = (input[i] - mi) / si
```
Denormalize should be defined as:
```
output[i] = input[i] * si + mi
```