### PR TITLE
Fixed resnet_v2a parameter initialization context bug

### DIFF
--- a/gluoncv/model_zoo/faster_rcnn/resnet50_v2a.py
+++ b/gluoncv/model_zoo/faster_rcnn/resnet50_v2a.py
@@ -139,5 +139,5 @@ def resnet50_v2a(pretrained=False, root='~/.mxnet/models', ctx=mx.cpu(0), **kwar
         model.load_params(get_model_file('resnet%d_v%da'%(50, 2),
                                          root=root), ctx=ctx, allow_missing=True)
         for v in model.collect_params(select='init_scale|init_mean').values():
-            v.initialize(force_reinit=True)
+            v.initialize(force_reinit=True, ctx=ctx)
     return model


### PR DESCRIPTION
Current code initializes the init_scale/init_mean params on CPU regardless of what the given context is. This causes issues if you want to initialize all parameters on the GPU. This PR fixes this issue by explicitly passing ctx to the initializer function.