### PR TITLE
fix imagenet resnext

### DIFF
--- a/gluoncv/model_zoo/resnext.py
+++ b/gluoncv/model_zoo/resnext.py
@@ -57,7 +57,7 @@ class Block(HybridBlock):
         self.body.add(nn.BatchNorm())
         self.body.add(nn.Activation('relu'))
         self.body.add(nn.Conv2D(group_width, kernel_size=3, strides=stride, padding=1,
-                                use_bias=False))
+                                groups=cardinality, use_bias=False))
         self.body.add(nn.BatchNorm())
         self.body.add(nn.Activation('relu'))
         self.body.add(nn.Conv2D(channels * 4, kernel_size=1, use_bias=False))


### PR DESCRIPTION
I missed the `groups=cardinality` for imagenet model definition. It is there for cifar though.

Thanks to  @sxjscience  for the catch