### PR TITLE
add faster rcnn coco dataset

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ stage("Unit Test") {
         conda list
         make clean
         # from https://stackoverflow.com/questions/19548957/can-i-force-pip-to-reinstall-the-current-version
-        pip install --upgrade --force-reinstall .
+        pip install --upgrade --force-reinstall --no-deps .
         env
         export LD_LIBRARY_PATH=/usr/local/cuda-8.0/lib64
         export MPLBACKEND=Agg
@@ -59,7 +59,7 @@ stage("Unit Test") {
         conda list
         make clean
         # from https://stackoverflow.com/questions/19548957/can-i-force-pip-to-reinstall-the-current-version
-        pip install --upgrade --force-reinstall .
+        pip install --upgrade --force-reinstall --no-deps .
         env
         export LD_LIBRARY_PATH=/usr/local/cuda-8.0/lib64
         export MPLBACKEND=Agg

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,8 @@ stage("Unit Test") {
         conda activate gluon_cv_py2_test
         conda list
         make clean
-        pip install --force-reinstall .
+        # from https://stackoverflow.com/questions/19548957/can-i-force-pip-to-reinstall-the-current-version
+        pip install --upgrade --force-reinstall .
         env
         export LD_LIBRARY_PATH=/usr/local/cuda-8.0/lib64
         export MPLBACKEND=Agg
@@ -57,7 +58,8 @@ stage("Unit Test") {
         conda activate gluon_cv_py3_test
         conda list
         make clean
-        pip install --force-reinstall .
+        # from https://stackoverflow.com/questions/19548957/can-i-force-pip-to-reinstall-the-current-version
+        pip install --upgrade --force-reinstall .
         env
         export LD_LIBRARY_PATH=/usr/local/cuda-8.0/lib64
         export MPLBACKEND=Agg

--- a/docs/build.yml
+++ b/docs/build.yml
@@ -8,7 +8,7 @@ dependencies:
 - sphinx_rtd_theme
 - pip:
   - sphinx-gallery
-  - mxnet-cu80==1.3.0b20180621
+  - mxnet-cu80==1.3.0b20180713
   # - guzzle_sphinx_theme
   - recommonmark
   - Image

--- a/docs/tutorials/detection/demo_faster_rcnn.py
+++ b/docs/tutorials/detection/demo_faster_rcnn.py
@@ -55,6 +55,6 @@ x, orig_img = data.transforms.presets.rcnn.load_test(im_fname)
 # results. We slice the results for the first image and feed them into `plot_bbox`:
 
 box_ids, scores, bboxes = net(x)
-ax = utils.viz.plot_bbox(orig_img, bboxes, scores, box_ids, class_names=net.classes)
+ax = utils.viz.plot_bbox(orig_img, bboxes[0], scores[0], box_ids[0], class_names=net.classes)
 
 plt.show()

--- a/docs/tutorials/detection/train_faster_rcnn_voc.py
+++ b/docs/tutorials/detection/train_faster_rcnn_voc.py
@@ -185,8 +185,8 @@ cids, scores, bboxes = net(x)
 # Faster-RCNN network behave differently during training mode:
 from mxnet import autograd
 with autograd.train_mode():
-    gt_box = bboxes.expand_dims(0)
     # this time we need ground-truth to generate high quality roi proposals during training
+    gt_box = mx.nd.zeros(shape=(1, 1, 4))
     cls_preds, box_preds, roi, samples, matches, rpn_score, rpn_box, anchors = net(x, gt_box)
 
 ##############################################################################

--- a/gluoncv/data/mscoco/detection.py
+++ b/gluoncv/data/mscoco/detection.py
@@ -33,6 +33,8 @@ class COCODetection(VisionDataset):
     skip_empty : bool, default is True
         Whether skip images with no valid object. This should be `True` in training, otherwise
         it will cause undefined behavior.
+    use_crowd : bool, default is True
+        Whether use boxes labeled as crowd instance.
 
     """
     CLASSES = ['person', 'bicycle', 'car', 'motorcycle', 'airplane', 'bus', 'train',
@@ -51,12 +53,13 @@ class COCODetection(VisionDataset):
 
     def __init__(self, root=os.path.join('~', '.mxnet', 'datasets', 'coco'),
                  splits=('instances_val2017',), transform=None, min_object_area=0,
-                 skip_empty=True):
+                 skip_empty=True, use_crowd=True):
         super(COCODetection, self).__init__(root)
         self._root = os.path.expanduser(root)
         self._transform = transform
         self._min_object_area = min_object_area
         self._skip_empty = skip_empty
+        self._use_crowd = use_crowd
         if isinstance(splits, mx.base.string_types):
             splits = [splits]
         self._splits = splits
@@ -148,7 +151,7 @@ class COCODetection(VisionDataset):
                 continue
             if obj.get('ignore', 0) == 1:
                 continue
-            if obj['iscrowd']:
+            if not self._use_crowd and obj['iscrowd']:
                 continue
             # convert from (x, y, w, h) to (xmin, ymin, xmax, ymax) and clip bound
             xmin, ymin, xmax, ymax = bbox_clip_xyxy(bbox_xywh_to_xyxy(obj['bbox']), width, height)

--- a/gluoncv/data/mscoco/detection.py
+++ b/gluoncv/data/mscoco/detection.py
@@ -148,6 +148,8 @@ class COCODetection(VisionDataset):
                 continue
             if obj.get('ignore', 0) == 1:
                 continue
+            if obj['iscrowd']:
+                continue
             # convert from (x, y, w, h) to (xmin, ymin, xmax, ymax) and clip bound
             xmin, ymin, xmax, ymax = bbox_clip_xyxy(bbox_xywh_to_xyxy(obj['bbox']), width, height)
             # require non-zero box area

--- a/gluoncv/data/transforms/presets/rcnn.py
+++ b/gluoncv/data/transforms/presets/rcnn.py
@@ -126,7 +126,7 @@ class FasterRCNNDefaultTrainTransform(object):
         """Apply transform to training image/label."""
         # resize shorter side but keep in max_size
         h, w, _ = src.shape
-        img = timage.resize_short_within(src, self._short, self._max_size)
+        img = timage.resize_short_within(src, self._short, self._max_size, interp=1)
         bbox = tbbox.resize(label, (w, h), (img.shape[1], img.shape[0]))
 
         # random horizontal flip
@@ -177,7 +177,7 @@ class FasterRCNNDefaultValTransform(object):
         """Apply transform to validation image/label."""
         # resize shorter side but keep in max_size
         h, w, _ = src.shape
-        img = timage.resize_short_within(src, self._short, self._max_size)
+        img = timage.resize_short_within(src, self._short, self._max_size, interp=1)
         # no scaling ground-truth, return image scaling ratio instead
         bbox = tbbox.resize(label, (w, h), (img.shape[1], img.shape[0]))
         im_scale = h / float(img.shape[0])

--- a/gluoncv/model_zoo/faster_rcnn/faster_rcnn.py
+++ b/gluoncv/model_zoo/faster_rcnn/faster_rcnn.py
@@ -422,7 +422,7 @@ def faster_rcnn_resnet50_v2a_coco(pretrained=False, pretrained_base=True, **kwar
         name='resnet50_v2a', dataset='coco', pretrained=pretrained,
         features=features, top_features=top_features, classes=classes,
         roi_mode='align', roi_size=(14, 14), stride=16,
-        nms_thresh=0.3, nms_topk=400, post_nms=100,
+        nms_thresh=0.5, nms_topk=-1, post_nms=-1,
         train_patterns=train_patterns,
         rpn_channel=1024, base_size=16, scales=(2, 4, 8, 16, 32),
         ratios=(0.5, 1, 2), alloc_size=(128, 128), rpn_nms_thresh=0.7,

--- a/gluoncv/model_zoo/faster_rcnn/faster_rcnn.py
+++ b/gluoncv/model_zoo/faster_rcnn/faster_rcnn.py
@@ -10,6 +10,8 @@ from ..rcnn import RCNN
 from ..rpn import RPN
 
 __all__ = ['FasterRCNN', 'get_faster_rcnn',
+           'faster_rcnn_resnet50_v1b_voc',
+           'faster_rcnn_resnet50_v1b_coco',
            'faster_rcnn_resnet50_v2a_voc',
            'faster_rcnn_resnet50_v2a_coco',]
 
@@ -345,7 +347,7 @@ def faster_rcnn_resnet50_v1b_coco(pretrained=False, pretrained_base=True, **kwar
         name='resnet50_v1b', dataset='coco', pretrained=pretrained,
         features=features, top_features=top_features, classes=classes,
         roi_mode='align', roi_size=(14, 14), stride=16,
-        nms_thresh=0.3, nms_topk=400, post_nms=100,
+        nms_thresh=0.5, nms_topk=-1, post_nms=-1,
         train_patterns=train_patterns,
         rpn_channel=1024, base_size=16, scales=(2, 4, 8, 16, 32),
         ratios=(0.5, 1, 2), alloc_size=(128, 128), rpn_nms_thresh=0.7,

--- a/gluoncv/model_zoo/faster_rcnn/faster_rcnn.py
+++ b/gluoncv/model_zoo/faster_rcnn/faster_rcnn.py
@@ -155,7 +155,8 @@ class FasterRCNN(RCNN):
             boxes.
 
         """
-        def _tolist(x):
+        def _split_batch(x, batch_size):
+            x = F.split(x, axis=0, num_outputs=batch_size, squeeze_axis=False)
             if isinstance(x, list):
                 return x
             else:
@@ -210,10 +211,10 @@ class FasterRCNN(RCNN):
         # rpn_boxes (B, N, 4) -> B * (1, N, 4)
         rpn_boxes = F.split(rpn_box, axis=0, num_outputs=self._max_batch, squeeze_axis=False)
         # cls_ids, scores (B, C, N, 1) -> B * (C, N, 1)
-        cls_ids = _tolist(F.split(cls_ids, axis=0, num_outputs=self._max_batch, squeeze_axis=True))
-        scores = _tolist(F.split(scores, axis=0, num_outputs=self._max_batch, squeeze_axis=True))
+        cls_ids = _split_batch(cls_ids, batch_size=self._max_batch)
+        scores = _split_batch(scores, batch_size=self._max_batch)
         # box_preds (B, C, N, 4) -> B * (C, N, 4)
-        box_preds = _tolist(F.split(box_pred, axis=0, num_outputs=self._max_batch, squeeze_axis=True))
+        box_preds = _split_batch(box_pred, batch_size=self._max_batch)
 
         # per batch predict, nms, each class has topk outputs
         results = []

--- a/gluoncv/model_zoo/faster_rcnn/faster_rcnn.py
+++ b/gluoncv/model_zoo/faster_rcnn/faster_rcnn.py
@@ -172,7 +172,8 @@ class FasterRCNN(RCNN):
         if self._roi_mode == 'pool':
             pooled_feat = F.ROIPooling(feat, rpn_roi, self._roi_size, 1. / self._stride)
         elif self._roi_mode == 'align':
-            pooled_feat = F.contrib.ROIAlign(feat, rpn_roi, self._roi_size, 1. / self._stride)
+            pooled_feat = F.contrib.ROIAlign(feat, rpn_roi, self._roi_size, 1. / self._stride,
+                                             sample_ratio=2)
         else:
             raise ValueError("Invalid roi mode: {}".format(self._roi_mode))
 

--- a/gluoncv/model_zoo/faster_rcnn/faster_rcnn.py
+++ b/gluoncv/model_zoo/faster_rcnn/faster_rcnn.py
@@ -202,12 +202,13 @@ class FasterRCNN(RCNN):
         result = F.concat(*results, dim=0).expand_dims(0)
 
         # per class nms
+        # only support batch=1
         if self.nms_thresh > 0 and self.nms_thresh < 1:
             result = F.contrib.box_nms(
                 result, overlap_thresh=self.nms_thresh, topk=self.nms_topk,
-                id_index=0, score_index=1, coord_start=2)
+                id_index=0, score_index=1, coord_start=2).squeeze(axis=0)
             if self.post_nms > 0:
-                result = result.slice_axis(axis=1, begin=0, end=self.post_nms).squeeze(axis=0)
+                result = result.slice_axis(axis=0, begin=0, end=self.post_nms)
         ids = F.slice_axis(result, axis=-1, begin=0, end=1)
         scores = F.slice_axis(result, axis=-1, begin=1, end=2)
         bboxes = F.slice_axis(result, axis=-1, begin=2, end=6)

--- a/gluoncv/model_zoo/faster_rcnn/faster_rcnn.py
+++ b/gluoncv/model_zoo/faster_rcnn/faster_rcnn.py
@@ -34,6 +34,8 @@ class FasterRCNN(RCNN):
     stride : int, default is 16
         Feature map stride with respect to original image.
         This is usually the ratio between original image size and feature map size.
+    clip : float, default is None
+        Clip bounding box target to this value.
     nms_thresh : float, default is 0.3.
         Non-maximum suppression threshold. You can speficy < 0 or > 1 to disable NMS.
     nms_topk : int, default is 400
@@ -96,7 +98,7 @@ class FasterRCNN(RCNN):
 
     """
     def __init__(self, features, top_features, classes,
-                 roi_mode='align', roi_size=(14, 14), stride=16,
+                 roi_mode='align', roi_size=(14, 14), stride=16, clip=None,
                  nms_thresh=0.3, nms_topk=400, post_nms=100, train_patterns=None,
                  rpn_channel=1024, base_size=16, scales=(0.5, 1, 2),
                  ratios=(8, 16, 32), alloc_size=(128, 128), rpn_nms_thresh=0.7,
@@ -106,7 +108,7 @@ class FasterRCNN(RCNN):
         super(FasterRCNN, self).__init__(
             features=features, top_features=top_features, classes=classes,
             roi_mode=roi_mode, roi_size=roi_size, stride=stride,
-            nms_thresh=nms_thresh, nms_topk=nms_topk, post_nms=post_nms,
+            clip=clip, nms_thresh=nms_thresh, nms_topk=nms_topk, post_nms=post_nms,
             train_patterns=train_patterns, **kwargs)
         self._max_batch = 1  # currently only support batch size = 1
         self._num_sample = num_sample
@@ -116,7 +118,7 @@ class FasterRCNN(RCNN):
             self.rpn = RPN(
                 channels=rpn_channel, stride=stride, base_size=base_size,
                 scales=scales, ratios=ratios, alloc_size=alloc_size,
-                nms_thresh=rpn_nms_thresh, train_pre_nms=rpn_train_pre_nms,
+                clip=clip, nms_thresh=rpn_nms_thresh, train_pre_nms=rpn_train_pre_nms,
                 train_post_nms=rpn_train_post_nms, test_pre_nms=rpn_test_pre_nms,
                 test_post_nms=rpn_test_post_nms, min_size=rpn_min_size)
             self.sampler = RCNNTargetSampler(
@@ -305,7 +307,7 @@ def faster_rcnn_resnet50_v1b_voc(pretrained=False, pretrained_base=True, **kwarg
     return get_faster_rcnn(
         name='resnet50_v1b', dataset='voc', pretrained=pretrained,
         features=features, top_features=top_features, classes=classes,
-        roi_mode='align', roi_size=(14, 14), stride=16,
+        roi_mode='align', roi_size=(14, 14), stride=16, clip=None,
         nms_thresh=0.3, nms_topk=400, post_nms=100,
         train_patterns=train_patterns,
         rpn_channel=1024, base_size=16, scales=(2, 4, 8, 16, 32),
@@ -352,7 +354,7 @@ def faster_rcnn_resnet50_v1b_coco(pretrained=False, pretrained_base=True, **kwar
     return get_faster_rcnn(
         name='resnet50_v1b', dataset='coco', pretrained=pretrained,
         features=features, top_features=top_features, classes=classes,
-        roi_mode='align', roi_size=(14, 14), stride=16,
+        roi_mode='align', roi_size=(14, 14), stride=16, clip=4.42,
         nms_thresh=0.5, nms_topk=-1, post_nms=-1,
         train_patterns=train_patterns,
         rpn_channel=1024, base_size=16, scales=(2, 4, 8, 16, 32),
@@ -399,7 +401,7 @@ def faster_rcnn_resnet50_v2a_voc(pretrained=False, pretrained_base=True, **kwarg
     return get_faster_rcnn(
         name='resnet50_v2a', dataset='voc', pretrained=pretrained,
         features=features, top_features=top_features, classes=classes,
-        roi_mode='align', roi_size=(14, 14), stride=16,
+        roi_mode='align', roi_size=(14, 14), stride=16, clip=None,
         nms_thresh=0.3, nms_topk=400, post_nms=100,
         train_patterns=train_patterns,
         rpn_channel=1024, base_size=16, scales=(2, 4, 8, 16, 32),
@@ -446,7 +448,7 @@ def faster_rcnn_resnet50_v2a_coco(pretrained=False, pretrained_base=True, **kwar
     return get_faster_rcnn(
         name='resnet50_v2a', dataset='coco', pretrained=pretrained,
         features=features, top_features=top_features, classes=classes,
-        roi_mode='align', roi_size=(14, 14), stride=16,
+        roi_mode='align', roi_size=(14, 14), stride=16, clip=4.42,
         nms_thresh=0.5, nms_topk=-1, post_nms=-1,
         train_patterns=train_patterns,
         rpn_channel=1024, base_size=16, scales=(2, 4, 8, 16, 32),
@@ -488,7 +490,7 @@ def faster_rcnn_resnet50_v2_voc(pretrained=False, pretrained_base=True, **kwargs
     return get_faster_rcnn(
         name='resnet50_v2', dataset='voc', pretrained=pretrained,
         features=features, top_features=top_features, classes=classes,
-        roi_mode='align', roi_size=(14, 14), stride=16,
+        roi_mode='align', roi_size=(14, 14), stride=16, clip=None,
         nms_thresh=0.3, nms_topk=400, post_nms=100,
         train_patterns=train_patterns,
         rpn_channel=1024, base_size=16, scales=(2, 4, 8, 16, 32),

--- a/gluoncv/model_zoo/faster_rcnn/faster_rcnn.py
+++ b/gluoncv/model_zoo/faster_rcnn/faster_rcnn.py
@@ -217,7 +217,7 @@ class FasterRCNN(RCNN):
             res = F.concat(*[cls_id, score, bbox], dim=-1)
             # res (C, self.nms_topk, 6)
             res = F.contrib.box_nms(
-                res, overlap_thresh=self.nms_thresh, topk=self.nms_topk,
+                res, overlap_thresh=self.nms_thresh, topk=self.nms_topk, valid_thresh=0.0001,
                 id_index=0, score_index=1, coord_start=2, force_suppress=True)
             # res (C * self.nms_topk, 6)
             res = res.reshape((-3, 0))

--- a/gluoncv/model_zoo/faster_rcnn/faster_rcnn.py
+++ b/gluoncv/model_zoo/faster_rcnn/faster_rcnn.py
@@ -95,8 +95,8 @@ class FasterRCNN(RCNN):
             self.rpn = RPN(rpn_channel, stride, scales=scales, ratios=ratios,
                            train_pre_nms=rpn_train_pre_nms, train_post_nms=rpn_train_post_nms,
                            test_pre_nms=rpn_test_pre_nms, test_post_nms=rpn_test_post_nms)
-            self.sampler = RCNNTargetSampler(num_sample, pos_iou_thresh, neg_iou_thresh_high,
-                                             neg_iou_thresh_low, pos_ratio)
+            self.sampler = RCNNTargetSampler(self._max_batch, rpn_test_post_nms,
+                                             num_sample, pos_iou_thresh, pos_ratio)
 
     @property
     def target_generator(self):

--- a/gluoncv/model_zoo/faster_rcnn/faster_rcnn.py
+++ b/gluoncv/model_zoo/faster_rcnn/faster_rcnn.py
@@ -155,8 +155,8 @@ class FasterRCNN(RCNN):
             boxes.
 
         """
-        def _split_batch(x, batch_size):
-            x = F.split(x, axis=0, num_outputs=batch_size, squeeze_axis=False)
+        def _split(x, axis, num_outputs, squeeze_axis):
+            x = F.split(x, axis=axis, num_outputs=num_outputs, squeeze_axis=squeeze_axis)
             if isinstance(x, list):
                 return x
             else:
@@ -209,12 +209,12 @@ class FasterRCNN(RCNN):
         box_pred = box_pred.transpose((0, 2, 1, 3))
 
         # rpn_boxes (B, N, 4) -> B * (1, N, 4)
-        rpn_boxes = F.split(rpn_box, axis=0, num_outputs=self._max_batch, squeeze_axis=False)
+        rpn_boxes = _split(rpn_box, axis=0, num_outputs=self._max_batch, squeeze_axis=False)
         # cls_ids, scores (B, C, N, 1) -> B * (C, N, 1)
-        cls_ids = _split_batch(cls_ids, batch_size=self._max_batch)
-        scores = _split_batch(scores, batch_size=self._max_batch)
+        cls_ids = _split(cls_ids, axis=0, num_outputs=self._max_batch, squeeze_axis=True)
+        scores = _split(scores, axis=0, num_outputs=self._max_batch, squeeze_axis=True)
         # box_preds (B, C, N, 4) -> B * (C, N, 4)
-        box_preds = _split_batch(box_pred, batch_size=self._max_batch)
+        box_preds = _split(box_pred, axis=0, num_outputs=self._max_batch, squeeze_axis=True)
 
         # per batch predict, nms, each class has topk outputs
         results = []

--- a/gluoncv/model_zoo/faster_rcnn/faster_rcnn.py
+++ b/gluoncv/model_zoo/faster_rcnn/faster_rcnn.py
@@ -155,6 +155,11 @@ class FasterRCNN(RCNN):
             boxes.
 
         """
+        def _tolist(x):
+            if isinstance(x, list):
+                return x
+            else:
+                return [x]
         feat = self.features(x)
         # RPN proposals
         if autograd.is_training():
@@ -205,10 +210,10 @@ class FasterRCNN(RCNN):
         # rpn_boxes (B, N, 4) -> B * (1, N, 4)
         rpn_boxes = F.split(rpn_box, axis=0, num_outputs=self._max_batch, squeeze_axis=False)
         # cls_ids, scores (B, C, N, 1) -> B * (C, N, 1)
-        cls_ids = F.split(cls_ids, axis=0, num_outputs=self._max_batch, squeeze_axis=True)
-        scores = F.split(scores, axis=0, num_outputs=self._max_batch, squeeze_axis=True)
+        cls_ids = _tolist(F.split(cls_ids, axis=0, num_outputs=self._max_batch, squeeze_axis=True))
+        scores = _tolist(F.split(scores, axis=0, num_outputs=self._max_batch, squeeze_axis=True))
         # box_preds (B, C, N, 4) -> B * (C, N, 4)
-        box_preds = F.split(box_pred, axis=0, num_outputs=self._max_batch, squeeze_axis=True)
+        box_preds = _tolist(F.split(box_pred, axis=0, num_outputs=self._max_batch, squeeze_axis=True))
 
         # per batch predict, nms, each class has topk outputs
         results = []

--- a/gluoncv/model_zoo/faster_rcnn/faster_rcnn.py
+++ b/gluoncv/model_zoo/faster_rcnn/faster_rcnn.py
@@ -286,7 +286,7 @@ def faster_rcnn_resnet50_v1b_voc(pretrained=False, pretrained_base=True, **kwarg
     from ...data import VOCDetection
     classes = VOCDetection.CLASSES
     pretrained_base = False if pretrained else pretrained_base
-    base_network = resnet50_v1b(pretrained=pretrained_base, dilated=False)
+    base_network = resnet50_v1b(pretrained=pretrained_base, dilated=False, use_global_stats=True)
     features = nn.HybridSequential()
     top_features = nn.HybridSequential()
     for layer in ['conv1', 'bn1', 'relu', 'maxpool', 'layer1', 'layer2', 'layer3']:
@@ -333,7 +333,7 @@ def faster_rcnn_resnet50_v1b_coco(pretrained=False, pretrained_base=True, **kwar
     from ...data import COCODetection
     classes = COCODetection.CLASSES
     pretrained_base = False if pretrained else pretrained_base
-    base_network = resnet50_v1b(pretrained=pretrained_base, dilated=False)
+    base_network = resnet50_v1b(pretrained=pretrained_base, dilated=False, use_global_stats=True)
     features = nn.HybridSequential()
     top_features = nn.HybridSequential()
     for layer in ['conv1', 'bn1', 'relu', 'maxpool', 'layer1', 'layer2', 'layer3']:

--- a/gluoncv/model_zoo/faster_rcnn/faster_rcnn.py
+++ b/gluoncv/model_zoo/faster_rcnn/faster_rcnn.py
@@ -109,7 +109,7 @@ class FasterRCNN(RCNN):
         self._max_batch = 1  # currently only support batch size = 1
         self._num_sample = num_sample
         self._rpn_test_post_nms = rpn_test_post_nms
-        self._target_generator = RCNNTargetGenerator(self.num_class)
+        self._target_generator = {RCNNTargetGenerator(self.num_class)}
         with self.name_scope():
             self.rpn = RPN(
                 channels=rpn_channel, stride=stride, base_size=base_size,
@@ -131,7 +131,7 @@ class FasterRCNN(RCNN):
             The RCNN target generator
 
         """
-        return self._target_generator
+        return list(self._target_generator)[0]
 
     # pylint: disable=arguments-differ
     def hybrid_forward(self, F, x, gt_box=None):

--- a/gluoncv/model_zoo/faster_rcnn/faster_rcnn.py
+++ b/gluoncv/model_zoo/faster_rcnn/faster_rcnn.py
@@ -118,7 +118,7 @@ class FasterRCNN(RCNN):
                 train_post_nms=rpn_train_post_nms, test_pre_nms=rpn_test_pre_nms,
                 test_post_nms=rpn_test_post_nms, min_size=rpn_min_size)
             self.sampler = RCNNTargetSampler(
-                num_image=self._max_batch, num_proposal=rpn_test_post_nms,
+                num_image=self._max_batch, num_proposal=rpn_train_post_nms,
                 num_sample=num_sample, pos_iou_thresh=pos_iou_thresh, pos_ratio=pos_ratio)
 
     @property

--- a/gluoncv/model_zoo/faster_rcnn/faster_rcnn.py
+++ b/gluoncv/model_zoo/faster_rcnn/faster_rcnn.py
@@ -23,38 +23,15 @@ class FasterRCNN(RCNN):
         Base feature extractor before feature pooling layer.
     top_features : gluon.HybridBlock
         Tail feature extractor after feature pooling layer.
-    train_patterns : str
-        Matching pattern for trainable parameters.
-    scales : iterable of float
-        The areas of anchor boxes.
-        We use the following form to compute the shapes of anchors:
-
-        .. math::
-
-            width_{anchor} = size_{base} \times scale \times \sqrt{ 1 / ratio}
-            height_{anchor} = size_{base} \times scale \times \sqrt{ratio}
-
-    ratios : iterable of float
-        The aspect ratios of anchor boxes. We expect it to be a list or tuple.
     classes : iterable of str
         Names of categories, its length is ``num_class``.
-    roi_mode : str
+    roi_mode : str, default is align
         ROI pooling mode. Currently support 'pool' and 'align'.
-    roi_size : tuple of int, length 2
+    roi_size : tuple of int, length 2, default is (14, 14)
         (height, width) of the ROI region.
     stride : int, default is 16
         Feature map stride with respect to original image.
         This is usually the ratio between original image size and feature map size.
-    rpn_channel : int, default is 1024
-        Channel number used in RPN convolutional layers.
-    rpn_train_pre_nms : int, default is 12000
-        Filter top proposals before NMS in training of RPN.
-    rpn_train_post_nms : int, default is 2000
-        Return top proposal results after NMS in training of RPN.
-    rpn_test_pre_nms : int, default is 6000
-        Filter top proposals before NMS in testing of RPN.
-    rpn_test_post_nms : int, default is 300
-        Return top proposal results after NMS in testing of RPN.
     nms_thresh : float, default is 0.3.
         Non-maximum suppression threshold. You can speficy < 0 or > 1 to disable NMS.
     nms_topk : int, default is 400
@@ -64,39 +41,85 @@ class FasterRCNN(RCNN):
         Only return top `post_nms` detection results, the rest is discarded. The number is
         based on COCO dataset which has maximum 100 objects per image. You can adjust this
         number if expecting more objects. You can use -1 to return all detections.
+    train_patterns : str
+        Matching pattern for trainable parameters.
+    rpn_channel : int, default is 1024
+        Channel number used in RPN convolutional layers.
+    base_size : int
+        The width(and height) of reference anchor box.
+    scales : iterable of float, default is (8, 16, 32)
+        The areas of anchor boxes.
+        We use the following form to compute the shapes of anchors:
+
+        .. math::
+
+            width_{anchor} = size_{base} \times scale \times \sqrt{ 1 / ratio}
+            height_{anchor} = size_{base} \times scale \times \sqrt{ratio}
+
+    ratios : iterable of float, default is (0.5, 1, 2)
+        The aspect ratios of anchor boxes. We expect it to be a list or tuple.
+    alloc_size : tuple of int
+        Allocate size for the anchor boxes as (H, W).
+        Usually we generate enough anchors for large feature map, e.g. 128x128.
+        Later in inference we can have variable input sizes,
+        at which time we can crop corresponding anchors from this large
+        anchor map so we can skip re-generating anchors for each input.
+    rpn_train_pre_nms : int, default is 12000
+        Filter top proposals before NMS in training of RPN.
+    rpn_train_post_nms : int, default is 2000
+        Return top proposal results after NMS in training of RPN.
+    rpn_test_pre_nms : int, default is 6000
+        Filter top proposals before NMS in testing of RPN.
+    rpn_test_post_nms : int, default is 300
+        Return top proposal results after NMS in testing of RPN.
+    rpn_nms_thresh : float, default is 0.7
+        IOU threshold for NMS. It is used to remove overlapping proposals.
+    train_pre_nms : int, default is 12000
+        Filter top proposals before NMS in training.
+    train_post_nms : int, default is 2000
+        Return top proposal results after NMS in training.
+    test_pre_nms : int, default is 6000
+        Filter top proposals before NMS in testing.
+    test_post_nms : int, default is 300
+        Return top proposal results after NMS in testing.
+    rpn_min_size : int, default is 16
+        Proposals whose size is smaller than ``min_size`` will be discarded.
     num_sample : int, default is 128
         Number of samples for RCNN targets.
     pos_iou_thresh : float, default is 0.5
         Proposal whose IOU larger than ``pos_iou_thresh`` is regarded as positive samples.
-    neg_iou_thresh_high : float, default is 0.5
-        Proposal whose IOU smaller than ``neg_iou_thresh_high``
-        and larger than ``neg_iou_thresh_low`` is regarded as negative samples.
-        Proposals with IOU in between ``pos_iou_thresh`` and ``neg_iou_thresh`` are
-        ignored.
-    neg_iou_thresh_low : float, default is 0.0
-        See ``neg_iou_thresh_high``.
     pos_ratio : float, default is 0.25
         ``pos_ratio`` defines how many positive samples (``pos_ratio * num_sample``) is
         to be sampled.
 
     """
-    def __init__(self, features, top_features, scales, ratios, classes, roi_mode, roi_size,
-                 stride=16, rpn_channel=1024, rpn_train_pre_nms=12000, rpn_train_post_nms=2000,
-                 rpn_test_pre_nms=6000, rpn_test_post_nms=300,
-                 num_sample=128, pos_iou_thresh=0.5, neg_iou_thresh_high=0.5,
-                 neg_iou_thresh_low=0.0, pos_ratio=0.25, **kwargs):
+    def __init__(self, features, top_features, classes,
+                 roi_mode='align', roi_size=(14, 14), stride=16,
+                 nms_thresh=0.3, nms_topk=400, post_nms=100, train_patterns=None,
+                 rpn_channel=1024, base_size=16, scales=(0.5, 1, 2),
+                 ratios=(8, 16, 32), alloc_size=(128, 128), rpn_nms_thresh=0.7,
+                 rpn_train_pre_nms=12000, rpn_train_post_nms=2000,
+                 rpn_test_pre_nms=6000, rpn_test_post_nms=300, rpn_min_size=16,
+                 num_sample=128, pos_iou_thresh=0.5, pos_ratio=0.25, **kwargs):
         super(FasterRCNN, self).__init__(
-            features, top_features, classes, roi_mode, roi_size, **kwargs)
-        self.stride = stride
+            features=features, top_features=top_features, classes=classes,
+            roi_mode=roi_mode, roi_size=roi_size, stride=stride,
+            nms_thresh=nms_thresh, nms_topk=nms_topk, post_nms=post_nms,
+            train_patterns=train_patterns, **kwargs)
         self._max_batch = 1  # currently only support batch size = 1
-        self._max_roi = 100000  # maximum allowed ROIs
-        self._target_generator = set([RCNNTargetGenerator(self.num_class)])
+        self._num_sample = num_sample
+        self._rpn_test_post_nms = rpn_test_post_nms
+        self._target_generator = RCNNTargetGenerator(self.num_class)
         with self.name_scope():
-            self.rpn = RPN(rpn_channel, stride, scales=scales, ratios=ratios,
-                           train_pre_nms=rpn_train_pre_nms, train_post_nms=rpn_train_post_nms,
-                           test_pre_nms=rpn_test_pre_nms, test_post_nms=rpn_test_post_nms)
-            self.sampler = RCNNTargetSampler(self._max_batch, rpn_test_post_nms,
-                                             num_sample, pos_iou_thresh, pos_ratio)
+            self.rpn = RPN(
+                channels=rpn_channel, stride=stride, base_size=base_size,
+                scales=scales, ratios=ratios, alloc_size=alloc_size,
+                nms_thresh=rpn_nms_thresh, train_pre_nms=rpn_train_pre_nms,
+                train_post_nms=rpn_train_post_nms, test_pre_nms=rpn_test_pre_nms,
+                test_post_nms=rpn_test_post_nms, min_size=rpn_min_size)
+            self.sampler = RCNNTargetSampler(
+                num_image=self._max_batch, num_proposal=rpn_test_post_nms,
+                num_sample=num_sample, pos_iou_thresh=pos_iou_thresh, pos_ratio=pos_ratio)
 
     @property
     def target_generator(self):
@@ -108,7 +131,7 @@ class FasterRCNN(RCNN):
             The RCNN target generator
 
         """
-        return list(self._target_generator)[0]
+        return self._target_generator
 
     # pylint: disable=arguments-differ
     def hybrid_forward(self, F, x, gt_box=None):
@@ -133,36 +156,31 @@ class FasterRCNN(RCNN):
         feat = self.features(x)
         # RPN proposals
         if autograd.is_training():
-            _, rpn_box, raw_rpn_score, raw_rpn_box, anchors = self.rpn(
-                feat, F.zeros_like(x))
-            # sample 128 roi
-            assert gt_box is not None
+            _, rpn_box, raw_rpn_score, raw_rpn_box, anchors = self.rpn(feat, F.zeros_like(x))
             rpn_box, samples, matches = self.sampler(rpn_box, gt_box)
         else:
             _, rpn_box = self.rpn(feat, F.zeros_like(x))
 
         # create batchid for roi
+        num_roi = self._num_sample if autograd.is_training() else self._rpn_test_post_nms
         with autograd.pause():
-            roi_batchid = F.arange(
-                0, self._max_batch, repeat=self._max_roi).reshape(
-                    (-1, self._max_roi))
-            roi_batchid = F.slice_like(roi_batchid, rpn_box * 0, axes=(0, 1))
+            roi_batchid = F.arange(0, self._max_batch, repeat=num_roi)
+            # remove batch dim because ROIPooling require 2d input
             rpn_roi = F.concat(*[roi_batchid.reshape((-1, 1)), rpn_box.reshape((-1, 4))], dim=-1)
 
         # ROI features
         if self._roi_mode == 'pool':
-            pooled_feat = F.ROIPooling(feat, rpn_roi, self._roi_size, 1. / self.stride)
+            pooled_feat = F.ROIPooling(feat, rpn_roi, self._roi_size, 1. / self._stride)
         elif self._roi_mode == 'align':
-            pooled_feat = F.contrib.ROIAlign(feat, rpn_roi, self._roi_size, 1. / self.stride)
+            pooled_feat = F.contrib.ROIAlign(feat, rpn_roi, self._roi_size, 1. / self._stride)
         else:
             raise ValueError("Invalid roi mode: {}".format(self._roi_mode))
+
         # RCNN prediction
         top_feat = self.top_features(pooled_feat)
-        # top_feat = F.Pooling(top_feat, global_pool=True, pool_type='avg', kernel=self._roi_size)
         top_feat = self.global_avg_pool(top_feat)
         cls_pred = self.class_predictor(top_feat)
-        box_pred = self.box_predictor(top_feat).reshape(
-            (-1, self.num_class, 4)).transpose((1, 0, 2))
+        box_pred = self.box_predictor(top_feat).reshape((-1, self.num_class, 4))
 
         # no need to convert bounding boxes in training, just return
         if autograd.is_training():
@@ -171,8 +189,8 @@ class FasterRCNN(RCNN):
                     raw_rpn_score, raw_rpn_box, anchors)
 
         # translate bboxes
-        bboxes = self.box_decoder(box_pred, self.box_to_center(rpn_box)).split(
-            axis=0, num_outputs=self.num_class, squeeze_axis=True)
+        bboxes = self.box_decoder(box_pred.transpose((1, 0, 2)), self.box_to_center(rpn_box))
+        bboxes = F.split(bboxes, axis=0, num_outputs=self.num_class, squeeze_axis=True)
         cls_ids, scores = self.cls_decoder(F.softmax(cls_pred, axis=-1))
         results = []
         for i in range(self.num_class):
@@ -180,9 +198,10 @@ class FasterRCNN(RCNN):
             score = scores.slice_axis(axis=-1, begin=i, end=i+1)
             # per class results
             per_result = F.concat(*[cls_id, score, bboxes[i]], dim=-1)
-
             results.append(per_result)
         result = F.concat(*results, dim=0).expand_dims(0)
+
+        # per class nms
         if self.nms_thresh > 0 and self.nms_thresh < 1:
             result = F.contrib.box_nms(
                 result, overlap_thresh=self.nms_thresh, topk=self.nms_topk,
@@ -194,9 +213,7 @@ class FasterRCNN(RCNN):
         bboxes = F.slice_axis(result, axis=-1, begin=2, end=6)
         return ids, scores, bboxes
 
-def get_faster_rcnn(name, features, top_features, scales, ratios, classes,
-                    roi_mode, roi_size, dataset, stride=16,
-                    rpn_channel=1024, pretrained=False, ctx=mx.cpu(),
+def get_faster_rcnn(name, dataset, pretrained=False, ctx=mx.cpu(),
                     root=os.path.join('~', '.mxnet', 'models'), **kwargs):
     r"""Utility function to return faster rcnn networks.
 
@@ -204,34 +221,8 @@ def get_faster_rcnn(name, features, top_features, scales, ratios, classes,
     ----------
     name : str
         Model name.
-    features : gluon.HybridBlock
-        Base feature extractor before feature pooling layer.
-    top_features : gluon.HybridBlock
-        Tail feature extractor after feature pooling layer.
-    scales : iterable of float
-        The areas of anchor boxes.
-        We use the following form to compute the shapes of anchors:
-
-        .. math::
-
-            width_{anchor} = size_{base} \times scale \times \sqrt{ 1 / ratio}
-            height_{anchor} = size_{base} \times scale \times \sqrt{ratio}
-
-    ratios : iterable of float
-        The aspect ratios of anchor boxes. We expect it to be a list or tuple.
-    classes : iterable of str
-        Names of categories, its length is ``num_class``.
-    roi_mode : str
-        ROI pooling mode. Currently support 'pool' and 'align'.
-    roi_size : tuple of int, length 2
-        (height, width) of the ROI region.
     dataset : str
         The name of dataset.
-    stride : int, default is 16
-        Feature map stride with respect to original image.
-        This is usually the ratio between original image size and feature map size.
-    rpn_channel : int, default is 1024
-        Channel number used in RPN convolutional layers.
     pretrained : bool, optional, default is False
         Load pretrained weights.
     ctx : mxnet.Context
@@ -245,8 +236,7 @@ def get_faster_rcnn(name, features, top_features, scales, ratios, classes,
         The Faster-RCNN network.
 
     """
-    net = FasterRCNN(features, top_features, scales, ratios, classes, roi_mode, roi_size,
-                     stride=stride, rpn_channel=rpn_channel, **kwargs)
+    net = FasterRCNN(**kwargs)
     if pretrained:
         from ..model_store import get_model_file
         full_name = '_'.join(('faster_rcnn', name, dataset))
@@ -287,11 +277,18 @@ def faster_rcnn_resnet50_v1b_voc(pretrained=False, pretrained_base=True, **kwarg
     for layer in ['layer4']:
         top_features.add(getattr(base_network, layer))
     train_patterns = '|'.join(['.*dense', '.*rpn', '.*down(2|3|4)_conv', '.*layers(2|3|4)_conv'])
-    return get_faster_rcnn('resnet50_v1b', features, top_features, scales=(2, 4, 8, 16, 32),
-                           ratios=(0.5, 1, 2), classes=classes, dataset='voc',
-                           roi_mode='align', roi_size=(14, 14), stride=16,
-                           rpn_channel=1024, train_patterns=train_patterns,
-                           pretrained=pretrained, **kwargs)
+    return get_faster_rcnn(
+        name='resnet50_v1b', dataset='voc', pretrained=pretrained,
+        features=features, top_features=top_features, classes=classes,
+        roi_mode='align', roi_size=(14, 14), stride=16,
+        nms_thresh=0.3, nms_topk=400, post_nms=100,
+        train_patterns=train_patterns,
+        rpn_channel=1024, base_size=16, scales=(2, 4, 8, 16, 32),
+        ratios=(0.5, 1, 2), alloc_size=(128, 128), rpn_nms_thresh=0.7,
+        rpn_train_pre_nms=12000, rpn_train_post_nms=2000,
+        rpn_test_pre_nms=6000, rpn_test_post_nms=300, rpn_min_size=16,
+        num_sample=128, pos_iou_thresh=0.5, pos_ratio=0.25,
+        **kwargs)
 
 def faster_rcnn_resnet50_v1b_coco(pretrained=False, pretrained_base=True, **kwargs):
     r"""Faster RCNN model from the paper
@@ -327,12 +324,18 @@ def faster_rcnn_resnet50_v1b_coco(pretrained=False, pretrained_base=True, **kwar
     for layer in ['layer4']:
         top_features.add(getattr(base_network, layer))
     train_patterns = '|'.join(['.*dense', '.*rpn', '.*down(2|3|4)_conv', '.*layers(2|3|4)_conv'])
-    return get_faster_rcnn('resnet50_v1b', features, top_features, scales=(2, 4, 8, 16, 32),
-                           ratios=(0.5, 1, 2), classes=classes, dataset='coco',
-                           roi_mode='align', roi_size=(14, 14), stride=16,
-                           rpn_channel=1024, train_patterns=train_patterns,
-                           pretrained=pretrained, num_sample=512, rpn_test_post_nms=1000,
-                           **kwargs)
+    return get_faster_rcnn(
+        name='resnet50_v1b', dataset='coco', pretrained=pretrained,
+        features=features, top_features=top_features, classes=classes,
+        roi_mode='align', roi_size=(14, 14), stride=16,
+        nms_thresh=0.3, nms_topk=400, post_nms=100,
+        train_patterns=train_patterns,
+        rpn_channel=1024, base_size=16, scales=(2, 4, 8, 16, 32),
+        ratios=(0.5, 1, 2), alloc_size=(128, 128), rpn_nms_thresh=0.7,
+        rpn_train_pre_nms=12000, rpn_train_post_nms=2000,
+        rpn_test_pre_nms=6000, rpn_test_post_nms=1000, rpn_min_size=16,
+        num_sample=512, pos_iou_thresh=0.5, pos_ratio=0.25,
+        **kwargs)
 
 def faster_rcnn_resnet50_v2a_voc(pretrained=False, pretrained_base=True, **kwargs):
     r"""Faster RCNN model from the paper
@@ -368,11 +371,18 @@ def faster_rcnn_resnet50_v2a_voc(pretrained=False, pretrained_base=True, **kwarg
     for layer in ['layer4']:
         top_features.add(getattr(base_network, layer))
     train_patterns = '|'.join(['.*dense', '.*rpn', '.*stage(2|3|4)_conv'])
-    return get_faster_rcnn('resnet50_v2a', features, top_features, scales=(2, 4, 8, 16, 32),
-                           ratios=(0.5, 1, 2), classes=classes, dataset='voc',
-                           roi_mode='align', roi_size=(14, 14), stride=16,
-                           rpn_channel=1024, train_patterns=train_patterns,
-                           pretrained=pretrained, **kwargs)
+    return get_faster_rcnn(
+        name='resnet50_v2a', dataset='voc', pretrained=pretrained,
+        features=features, top_features=top_features, classes=classes,
+        roi_mode='align', roi_size=(14, 14), stride=16,
+        nms_thresh=0.3, nms_topk=400, post_nms=100,
+        train_patterns=train_patterns,
+        rpn_channel=1024, base_size=16, scales=(2, 4, 8, 16, 32),
+        ratios=(0.5, 1, 2), alloc_size=(128, 128), rpn_nms_thresh=0.7,
+        rpn_train_pre_nms=12000, rpn_train_post_nms=2000,
+        rpn_test_pre_nms=6000, rpn_test_post_nms=300, rpn_min_size=16,
+        num_sample=128, pos_iou_thresh=0.5, pos_ratio=0.25,
+        **kwargs)
 
 def faster_rcnn_resnet50_v2a_coco(pretrained=False, pretrained_base=True, **kwargs):
     r"""Faster RCNN model from the paper
@@ -408,12 +418,18 @@ def faster_rcnn_resnet50_v2a_coco(pretrained=False, pretrained_base=True, **kwar
     for layer in ['layer4']:
         top_features.add(getattr(base_network, layer))
     train_patterns = '|'.join(['.*dense', '.*rpn', '.*stage(2|3|4)_conv'])
-    return get_faster_rcnn('resnet50_v2a', features, top_features, scales=(2, 4, 8, 16, 32),
-                           ratios=(0.5, 1, 2), classes=classes, dataset='coco',
-                           roi_mode='align', roi_size=(14, 14), stride=16,
-                           rpn_channel=1024, train_patterns=train_patterns,
-                           pretrained=pretrained, num_sample=512, rpn_test_post_nms=1000,
-                           **kwargs)
+    return get_faster_rcnn(
+        name='resnet50_v2a', dataset='coco', pretrained=pretrained,
+        features=features, top_features=top_features, classes=classes,
+        roi_mode='align', roi_size=(14, 14), stride=16,
+        nms_thresh=0.3, nms_topk=400, post_nms=100,
+        train_patterns=train_patterns,
+        rpn_channel=1024, base_size=16, scales=(2, 4, 8, 16, 32),
+        ratios=(0.5, 1, 2), alloc_size=(128, 128), rpn_nms_thresh=0.7,
+        rpn_train_pre_nms=12000, rpn_train_post_nms=2000,
+        rpn_test_pre_nms=6000, rpn_test_post_nms=1000, rpn_min_size=16,
+        num_sample=512, pos_iou_thresh=0.5, pos_ratio=0.25,
+        **kwargs)
 
 def faster_rcnn_resnet50_v2_voc(pretrained=False, pretrained_base=True, **kwargs):
     r"""Faster RCNN model from the paper
@@ -444,8 +460,15 @@ def faster_rcnn_resnet50_v2_voc(pretrained=False, pretrained_base=True, **kwargs
     features = base_network.features[:8]
     top_features = base_network.features[8:11]
     train_patterns = '|'.join(['.*dense', '.*rpn', '.*stage(2|3|4)_conv'])
-    return get_faster_rcnn('resnet50_v2', features, top_features, scales=(2, 4, 8, 16, 32),
-                           ratios=(0.5, 1, 2), classes=classes, dataset='voc',
-                           roi_mode='align', roi_size=(14, 14), stride=16,
-                           rpn_channel=1024, train_patterns=train_patterns,
-                           pretrained=pretrained, **kwargs)
+    return get_faster_rcnn(
+        name='resnet50_v2', dataset='voc', pretrained=pretrained,
+        features=features, top_features=top_features, classes=classes,
+        roi_mode='align', roi_size=(14, 14), stride=16,
+        nms_thresh=0.3, nms_topk=400, post_nms=100,
+        train_patterns=train_patterns,
+        rpn_channel=1024, base_size=16, scales=(2, 4, 8, 16, 32),
+        ratios=(0.5, 1, 2), alloc_size=(128, 128), rpn_nms_thresh=0.7,
+        rpn_train_pre_nms=12000, rpn_train_post_nms=2000,
+        rpn_test_pre_nms=6000, rpn_test_post_nms=300, rpn_min_size=16,
+        num_sample=128, pos_iou_thresh=0.5, pos_ratio=0.25,
+        **kwargs)

--- a/gluoncv/model_zoo/faster_rcnn/faster_rcnn.py
+++ b/gluoncv/model_zoo/faster_rcnn/faster_rcnn.py
@@ -184,7 +184,6 @@ class FasterRCNN(RCNN):
 
         # no need to convert bounding boxes in training, just return
         if autograd.is_training():
-            box_pred = box_pred.transpose((1, 0, 2))
             return (cls_pred, box_pred, rpn_box, samples, matches,
                     raw_rpn_score, raw_rpn_box, anchors)
 

--- a/gluoncv/model_zoo/faster_rcnn/faster_rcnn.py
+++ b/gluoncv/model_zoo/faster_rcnn/faster_rcnn.py
@@ -224,7 +224,7 @@ class FasterRCNN(RCNN):
             results.append(res)
 
         # result B * (C * topk, 6) -> (B, C * topk, 6)
-        result = F.stack(*results, dim=0)
+        result = F.stack(*results, axis=0)
         ids = F.slice_axis(result, axis=-1, begin=0, end=1)
         scores = F.slice_axis(result, axis=-1, begin=1, end=2)
         bboxes = F.slice_axis(result, axis=-1, begin=2, end=6)

--- a/gluoncv/model_zoo/faster_rcnn/rcnn_target.py
+++ b/gluoncv/model_zoo/faster_rcnn/rcnn_target.py
@@ -73,7 +73,8 @@ class RCNNTargetSampler(gluon.HybridBlock):
                 mask = F.where(pos_mask, F.ones_like(mask), mask)
 
                 # shuffle mask
-                rand = F.random.uniform(0, 1, shape=(self._num_proposal + 100,)).slice_like(ious_argmax)
+                rand = F.random.uniform(0, 1, shape=(self._num_proposal + 100,))
+                rand = F.slice_like(rand, ious_argmax)
                 index = F.argsort(rand)
                 mask = F.take(mask, index)
                 ious_argmax = F.take(ious_argmax, index)
@@ -81,7 +82,8 @@ class RCNNTargetSampler(gluon.HybridBlock):
                 # sample pos and neg samples
                 order = F.argsort(mask, is_ascend=False)
                 topk = F.slice_axis(order, axis=0, begin=0, end=self._max_pos)
-                bottomk = F.slice_axis(order, axis=0, begin=-(self._num_sample - self._max_pos), end=None)
+                num_neg = self._num_sample - self._max_pos
+                bottomk = F.slice_axis(order, axis=0, begin=-num_neg, end=None)
                 selected = F.concat(topk, bottomk, dim=0)
 
                 # output

--- a/gluoncv/model_zoo/faster_rcnn/rcnn_target.py
+++ b/gluoncv/model_zoo/faster_rcnn/rcnn_target.py
@@ -4,7 +4,6 @@ from __future__ import absolute_import
 from mxnet import gluon
 from mxnet import autograd
 from ...nn.coder import MultiClassEncoder, NormalizedPerClassBoxCenterEncoder
-from ...nn.matcher import MaximumMatcher
 
 
 class RCNNTargetSampler(gluon.HybridBlock):
@@ -12,62 +11,93 @@ class RCNNTargetSampler(gluon.HybridBlock):
 
     Parameters
     ----------
+    num_image: int, default is 1
+        Number of input images.
+    num_proposal: int, default is 2000
+        Number of input proposals.
     num_sample : int, default is 128
         Number of samples for RCNN targets.
     pos_iou_thresh : float, default is 0.5
         Proposal whose IOU larger than ``pos_iou_thresh`` is regarded as positive samples.
-    neg_iou_thresh_high : float, default is 0.5
-        Proposal whose IOU smaller than ``neg_iou_thresh_high``
-        and larger than ``neg_iou_thresh_low``
-        is regarded as negative samples.
-        Proposals with IOU in between ``pos_iou_thresh`` and ``neg_iou_thresh`` are
-        ignored.
-    neg_iou_thresh_low : float, default is 0.0
-        See ``neg_iou_thresh_high``.
+        Proposal whose IOU smaller than ``pos_iou_thresh`` is regarded as negative samples.
     pos_ratio : float, default is 0.25
         ``pos_ratio`` defines how many positive samples (``pos_ratio * num_sample``) is
         to be sampled.
 
     """
-    def __init__(self, num_sample=128, pos_iou_thresh=0.5, neg_iou_thresh_high=0.5,
-                 neg_iou_thresh_low=0.0, pos_ratio=0.25):
+    def __init__(self, num_image=1, num_proposal=2000, num_sample=128,
+                 pos_iou_thresh=0.5, pos_ratio=0.25):
         super(RCNNTargetSampler, self).__init__()
+        self._num_image = num_image
+        self._num_proposal = num_proposal
         self._num_sample = num_sample
+        self._max_pos = int(round(num_sample * pos_ratio))
         self._pos_iou_thresh = pos_iou_thresh
-        self._neg_iou_thresh_high = neg_iou_thresh_high
-        self._neg_iou_thresh_low = neg_iou_thresh_low
-        self._pos_ratio = pos_ratio
-        self._matcher = MaximumMatcher(pos_iou_thresh)
 
     #pylint: disable=arguments-differ
-    def hybrid_forward(self, F, roi, gt_box):
-        """
-        Only support batch_size=1 now.
+    def hybrid_forward(self, F, rois, gt_boxes):
+        """Handle B=self._num_image by a for loop.
+
+        Parameters
+        ----------
+        rois: (B, self._num_input, 4) encoded in (x1, y1, x2, y2).
+        gt_boxes: (B, M, 4) encoded in (x1, y1, x2, y2), invalid box should have area of 0.
+
+        Returns
+        -------
+        rois: (B, self._num_sample, 4), randomly drawn from proposals
+        samples: (B, self._num_sample), value +1: positive / -1: negative.
+        matches: (B, self._num_sample), value between [0, M)
+
         """
         with autograd.pause():
-            # cocnat rpn roi with ground truths
-            all_roi = F.concat(roi.squeeze(axis=0), gt_box.squeeze(axis=0), dim=0)
-            # calculate ious between (N, 4) anchors and (M, 4) bbox ground-truths
-            # ious is (N, M)
-            ious = F.contrib.box_iou(all_roi, gt_box, format='corner').transpose((1, 0, 2))
-            matches = self._matcher(ious)
-            samples = F.Custom(matches, ious, op_type='quota_sampler',
-                               num_sample=self._num_sample,
-                               pos_thresh=self._pos_iou_thresh,
-                               neg_thresh_high=self._neg_iou_thresh_high,
-                               neg_thresh_low=self._neg_iou_thresh_low,
-                               pos_ratio=self._pos_ratio)
-            samples = samples.squeeze(axis=0)   # remove batch axis
-            matches = matches.squeeze(axis=0)
+            # collect results into list
+            new_rois = []
+            new_samples = []
+            new_matches = []
+            for i in range(self._num_image):
+                roi = F.squeeze(F.slice_axis(rois, axis=0, begin=i, end=i+1), axis=0)
+                gt_box = F.squeeze(F.slice_axis(gt_boxes, axis=0, begin=i, end=i+1), axis=0)
 
-            # shuffle and argsort, take first num_sample samples
-            sf_samples = F.where(samples == 0, F.ones_like(samples) * -999, samples)
-            indices = F.argsort(sf_samples, is_ascend=False).slice_axis(
-                axis=0, begin=0, end=self._num_sample)
-            new_roi = all_roi.take(indices).expand_dims(0)
-            new_samples = samples.take(indices).expand_dims(0)
-            new_matches = matches.take(indices).expand_dims(0)
-        return new_roi, new_samples, new_matches
+                # concat rpn roi with ground truth
+                all_roi = F.concat(roi, gt_box, dim=0)
+                # calculate (N, M) ious between (N, 4) anchors and (M, 4) bbox ground-truths
+                # cannot do batch op, will get (B, N, B, M) ious
+                ious = F.contrib.box_iou(all_roi, gt_box, format='corner')
+                # match to argmax iou
+                ious_max = ious.max(axis=-1)
+                ious_argmax = ious.argmax(axis=-1)
+                # init with -1, which are neg samples
+                mask = F.ones_like(ious_max) * -1
+                # mark positive samples with 1
+                pos_mask = ious_max >= self._pos_iou_thresh
+                mask = F.where(pos_mask, F.ones_like(mask), mask)
+
+                # shuffle mask
+                rand = F.random.uniform(0, 1, shape=(self._num_proposal,))
+                index = F.argsort(rand)
+                mask = F.take(mask, index)
+                ious_argmax = F.take(ious_argmax, index)
+
+                # sample pos and neg samples
+                order = F.argsort(mask, is_ascend=False)
+                topk = F.slice_axis(order, axis=0, begin=0, end=self._max_pos)
+                bottomk = F.slice_axis(order, axis=0, begin=-(self._num_sample - self._max_pos), end=None)
+                selected = F.concat(topk, bottomk, dim=0)
+
+                # output
+                indices = F.take(index, selected)
+                samples = F.take(mask, selected)
+                matches = F.take(ious_argmax, selected)
+
+                new_rois.append(all_roi.take(indices))
+                new_samples.append(samples)
+                new_matches.append(matches)
+            # stack all samples together
+            new_rois = F.stack(*new_rois, axis=0)
+            new_samples = F.stack(*new_samples, axis=0)
+            new_matches = F.stack(*new_matches, axis=0)
+        return new_rois, new_samples, new_matches
 
 
 class RCNNTargetGenerator(gluon.Block):

--- a/gluoncv/model_zoo/faster_rcnn/rcnn_target.py
+++ b/gluoncv/model_zoo/faster_rcnn/rcnn_target.py
@@ -74,7 +74,7 @@ class RCNNTargetSampler(gluon.HybridBlock):
                 mask = F.where(pos_mask, F.ones_like(mask), mask)
 
                 # shuffle mask
-                rand = F.random.uniform(0, 1, shape=(self._num_proposal,))
+                rand = F.random.uniform(0, 1, shape=(self._num_proposal + 100,)).slice_like(ious_argmax)
                 index = F.argsort(rand)
                 mask = F.take(mask, index)
                 ious_argmax = F.take(ious_argmax, index)

--- a/gluoncv/model_zoo/faster_rcnn/rcnn_target.py
+++ b/gluoncv/model_zoo/faster_rcnn/rcnn_target.py
@@ -11,22 +11,21 @@ class RCNNTargetSampler(gluon.HybridBlock):
 
     Parameters
     ----------
-    num_image: int, default is 1
+    num_image: int
         Number of input images.
-    num_proposal: int, default is 2000
+    num_proposal: int
         Number of input proposals.
-    num_sample : int, default is 128
+    num_sample : int
         Number of samples for RCNN targets.
-    pos_iou_thresh : float, default is 0.5
+    pos_iou_thresh : float
         Proposal whose IOU larger than ``pos_iou_thresh`` is regarded as positive samples.
         Proposal whose IOU smaller than ``pos_iou_thresh`` is regarded as negative samples.
-    pos_ratio : float, default is 0.25
+    pos_ratio : float
         ``pos_ratio`` defines how many positive samples (``pos_ratio * num_sample``) is
         to be sampled.
 
     """
-    def __init__(self, num_image=1, num_proposal=2000, num_sample=128,
-                 pos_iou_thresh=0.5, pos_ratio=0.25):
+    def __init__(self, num_image, num_proposal, num_sample, pos_iou_thresh, pos_ratio):
         super(RCNNTargetSampler, self).__init__()
         self._num_image = num_image
         self._num_proposal = num_proposal

--- a/gluoncv/model_zoo/model_zoo.py
+++ b/gluoncv/model_zoo/model_zoo.py
@@ -50,6 +50,8 @@ def get_model(name, **kwargs):
         'ssd_512_resnet152_v2_voc': ssd_512_resnet152_v2_voc,
         'ssd_512_mobilenet1_0_voc': ssd_512_mobilenet1_0_voc,
         'ssd_512_mobilenet1_0_coco': ssd_512_mobilenet1_0_coco,
+        'faster_rcnn_resnet50_v1b_voc': faster_rcnn_resnet50_v1b_voc,
+        'faster_rcnn_resnet50_v1b_coco': faster_rcnn_resnet50_v1b_coco,
         'faster_rcnn_resnet50_v2a_voc': faster_rcnn_resnet50_v2a_voc,
         'faster_rcnn_resnet50_v2a_coco': faster_rcnn_resnet50_v2a_coco,
         'cifar_resnet20_v1': cifar_resnet20_v1,

--- a/gluoncv/model_zoo/rcnn/rcnn.py
+++ b/gluoncv/model_zoo/rcnn/rcnn.py
@@ -19,12 +19,12 @@ class RCNN(gluon.HybridBlock):
         Tail feature extractor after feature pooling layer.
     classes : iterable of str
         Names of categories, its length is ``num_class``.
-    roi_mode : str
-        ROI pooling mode. Currently support 'pool' and 'align'.
-    roi_size : tuple of int, length 2
-        (height, width) of the ROI region.
-    clip: float
-        Clip bounding box target to this value.
+    short : int
+        Input image short side size.
+    max_size : int
+        Maximum size of input image long side.
+    train_patterns : str
+        Matching pattern for trainable parameters.
     nms_thresh : float
         Non-maximum suppression threshold. You can speficy < 0 or > 1 to disable NMS.
     nms_topk : int
@@ -34,39 +34,58 @@ class RCNN(gluon.HybridBlock):
         Only return top `post_nms` detection results, the rest is discarded. The number is
         based on COCO dataset which has maximum 100 objects per image. You can adjust this
         number if expecting more objects. You can use -1 to return all detections.
-    train_patterns : str
-        Matching pattern for trainable parameters.
+    roi_mode : str
+        ROI pooling mode. Currently support 'pool' and 'align'.
+    roi_size : tuple of int, length 2
+        (height, width) of the ROI region.
+    stride : int
+        Stride of network features.
+    clip: float
+        Clip bounding box target to this value.
 
     Attributes
     ----------
-    num_class : int
-        Number of positive categories.
     classes : iterable of str
         Names of categories, its length is ``num_class``.
+    num_class : int
+        Number of positive categories.
+    short : int
+        Input image short side size.
+    max_size : int
+        Maximum size of input image long side.
+    train_patterns : str
+        Matching pattern for trainable parameters.
     nms_thresh : float
         Non-maximum suppression threshold. You can speficy < 0 or > 1 to disable NMS.
     nms_topk : int
         Apply NMS to top k detection results, use -1 to disable so that every Detection
          result is used in NMS.
-    train_patterns : str
-        Matching pattern for trainable parameters.
+    post_nms : int
+        Only return top `post_nms` detection results, the rest is discarded. The number is
+        based on COCO dataset which has maximum 100 objects per image. You can adjust this
+        number if expecting more objects. You can use -1 to return all detections.
 
     """
-    def __init__(self, features, top_features, classes, roi_mode, roi_size, stride,
-                 clip, nms_thresh, nms_topk, post_nms, train_patterns, **kwargs):
+    def __init__(self, features, top_features, classes,
+                 short, max_size, train_patterns,
+                 nms_thresh, nms_topk, post_nms,
+                 roi_mode, roi_size, stride, clip, **kwargs):
         super(RCNN, self).__init__(**kwargs)
         self.classes = classes
         self.num_class = len(classes)
+        self.short = short
+        self.max_size = max_size
+        self.train_patterns = train_patterns
+        self.nms_thresh = nms_thresh
+        self.nms_topk = nms_topk
+        self.post_nms = post_nms
+
         assert self.num_class > 0, "Invalid number of class : {}".format(self.num_class)
         assert roi_mode.lower() in ['align', 'pool'], "Invalid roi_mode: {}".format(roi_mode)
         self._roi_mode = roi_mode.lower()
         assert len(roi_size) == 2, "Require (h, w) as roi_size, given {}".format(roi_size)
         self._roi_size = roi_size
         self._stride = stride
-        self.nms_thresh = nms_thresh
-        self.nms_topk = nms_topk
-        self.post_nms = post_nms
-        self.train_patterns = train_patterns
 
         with self.name_scope():
             self.features = features

--- a/gluoncv/model_zoo/rcnn/rcnn.py
+++ b/gluoncv/model_zoo/rcnn/rcnn.py
@@ -23,12 +23,12 @@ class RCNN(gluon.HybridBlock):
         ROI pooling mode. Currently support 'pool' and 'align'.
     roi_size : tuple of int, length 2
         (height, width) of the ROI region.
-    nms_thresh : float, default is 0.3.
+    nms_thresh : float
         Non-maximum suppression threshold. You can speficy < 0 or > 1 to disable NMS.
-    nms_topk : int, default is 400
+    nms_topk : int
         Apply NMS to top k detection results, use -1 to disable so that every Detection
          result is used in NMS.
-    post_nms : int, default is 100
+    post_nms : int
         Only return top `post_nms` detection results, the rest is discarded. The number is
         based on COCO dataset which has maximum 100 objects per image. You can adjust this
         number if expecting more objects. You can use -1 to return all detections.
@@ -50,8 +50,8 @@ class RCNN(gluon.HybridBlock):
         Matching pattern for trainable parameters.
 
     """
-    def __init__(self, features, top_features, classes, roi_mode, roi_size,
-                 nms_thresh=0.3, nms_topk=400, post_nms=100, train_patterns=None, **kwargs):
+    def __init__(self, features, top_features, classes, roi_mode, roi_size, stride,
+                 nms_thresh, nms_topk, post_nms, train_patterns, **kwargs):
         super(RCNN, self).__init__(**kwargs)
         self.classes = classes
         self.num_class = len(classes)
@@ -60,6 +60,7 @@ class RCNN(gluon.HybridBlock):
         self._roi_mode = roi_mode.lower()
         assert len(roi_size) == 2, "Require (h, w) as roi_size, given {}".format(roi_size)
         self._roi_size = roi_size
+        self._stride = stride
         self.nms_thresh = nms_thresh
         self.nms_topk = nms_topk
         self.post_nms = post_nms

--- a/gluoncv/model_zoo/rcnn/rcnn.py
+++ b/gluoncv/model_zoo/rcnn/rcnn.py
@@ -101,7 +101,7 @@ class RCNN(gluon.HybridBlock):
             return self.collect_params(self.train_patterns)
         return self.collect_params(select)
 
-    def set_nms(self, nms_thresh, nms_topk, post_nms):
+    def set_nms(self, nms_thresh=0.3, nms_topk=400, post_nms=100):
         """Set NMS parameters to the network.
 
         .. Note::
@@ -110,12 +110,12 @@ class RCNN(gluon.HybridBlock):
 
         Parameters
         ----------
-        nms_thresh : float.
+        nms_thresh : float, default is 0.3.
             Non-maximum suppression threshold. You can speficy < 0 or > 1 to disable NMS.
-        nms_topk : int
+        nms_topk : int, default is 400
             Apply NMS to top k detection results, use -1 to disable so that every Detection
              result is used in NMS.
-        post_nms : int
+        post_nms : int, default is 100
             Only return top `post_nms` detection results, the rest is discarded. The number is
             based on COCO dataset which has maximum 100 objects per image. You can adjust this
             number if expecting more objects. You can use -1 to return all detections.

--- a/gluoncv/model_zoo/rcnn/rcnn.py
+++ b/gluoncv/model_zoo/rcnn/rcnn.py
@@ -23,6 +23,8 @@ class RCNN(gluon.HybridBlock):
         ROI pooling mode. Currently support 'pool' and 'align'.
     roi_size : tuple of int, length 2
         (height, width) of the ROI region.
+    clip: float
+        Clip bounding box target to this value.
     nms_thresh : float
         Non-maximum suppression threshold. You can speficy < 0 or > 1 to disable NMS.
     nms_topk : int
@@ -51,7 +53,7 @@ class RCNN(gluon.HybridBlock):
 
     """
     def __init__(self, features, top_features, classes, roi_mode, roi_size, stride,
-                 nms_thresh, nms_topk, post_nms, train_patterns, **kwargs):
+                 clip, nms_thresh, nms_topk, post_nms, train_patterns, **kwargs):
         super(RCNN, self).__init__(**kwargs)
         self.classes = classes
         self.num_class = len(classes)
@@ -76,7 +78,7 @@ class RCNN(gluon.HybridBlock):
                 self.num_class * 4, weight_initializer=mx.init.Normal(0.001))
             self.cls_decoder = MultiPerClassDecoder(num_class=self.num_class+1)
             self.box_to_center = BBoxCornerToCenter()
-            self.box_decoder = NormalizedBoxCenterDecoder()
+            self.box_decoder = NormalizedBoxCenterDecoder(clip=clip)
 
     def collect_train_params(self, select=None):
         """Collect trainable params.

--- a/gluoncv/model_zoo/rcnn/rcnn.py
+++ b/gluoncv/model_zoo/rcnn/rcnn.py
@@ -101,7 +101,7 @@ class RCNN(gluon.HybridBlock):
             return self.collect_params(self.train_patterns)
         return self.collect_params(select)
 
-    def set_nms(self, nms_thresh=0.3, nms_topk=400, post_nms=100):
+    def set_nms(self, nms_thresh, nms_topk, post_nms):
         """Set NMS parameters to the network.
 
         .. Note::
@@ -110,12 +110,12 @@ class RCNN(gluon.HybridBlock):
 
         Parameters
         ----------
-        nms_thresh : float, default is 0.3.
+        nms_thresh : float.
             Non-maximum suppression threshold. You can speficy < 0 or > 1 to disable NMS.
-        nms_topk : int, default is 400
+        nms_topk : int
             Apply NMS to top k detection results, use -1 to disable so that every Detection
              result is used in NMS.
-        post_nms : int, default is 100
+        post_nms : int
             Only return top `post_nms` detection results, the rest is discarded. The number is
             based on COCO dataset which has maximum 100 objects per image. You can adjust this
             number if expecting more objects. You can use -1 to return all detections.

--- a/gluoncv/model_zoo/rpn/anchor.py
+++ b/gluoncv/model_zoo/rpn/anchor.py
@@ -34,8 +34,7 @@ class RPNAnchorGenerator(gluon.HybridBlock):
         anchor map so we can skip re-generating anchors for each input.
 
     """
-    def __init__(self, stride, base_size=16, ratios=(0.5, 1, 2), scales=(8, 16, 32),
-                 alloc_size=(128, 128), **kwargs):
+    def __init__(self, stride, base_size, ratios, scales, alloc_size, **kwargs):
         super(RPNAnchorGenerator, self).__init__(**kwargs)
         if not base_size:
             raise ValueError("Invalid base_size: {}.".format(base_size))

--- a/gluoncv/model_zoo/rpn/proposal.py
+++ b/gluoncv/model_zoo/rpn/proposal.py
@@ -15,24 +15,24 @@ class RPNProposal(gluon.HybridBlock):
 
     Parameters
     ----------
-    nms_thresh : float, default is 0.7
+    nms_thresh : float
         IOU threshold for NMS. It is used to remove overlapping proposals.
-    train_pre_nms : int, default is 12000
+    train_pre_nms : int
         Filter top proposals before NMS in training.
-    train_post_nms : int, default is 2000
+    train_post_nms : int
         Return top proposal results after NMS in training.
-    test_pre_nms : int, default is 6000
+    test_pre_nms : int
         Filter top proposals before NMS in testing.
-    test_post_nms : int, default is 300
+    test_post_nms : int
         Return top proposal results after NMS in testing.
-    min_size : int, default is 16
+    min_size : int
         Proposals whose size is smaller than ``min_size`` will be discarded.
     stds : tuple of float
         Standard deviation to be multiplied from encoded regression targets.
         These values must be the same as stds used in RPNTargetGenerator.
     """
-    def __init__(self, nms_thresh=0.7, train_pre_nms=12000, train_post_nms=2000,
-                 test_pre_nms=6000, test_post_nms=300, min_size=16, stds=(1., 1., 1., 1.)):
+    def __init__(self, nms_thresh, train_pre_nms, train_post_nms,
+                 test_pre_nms, test_post_nms, min_size, stds):
         super(RPNProposal, self).__init__()
         self._box_to_center = BBoxCornerToCenter()
         self._box_decoder = NormalizedBoxCenterDecoder(stds=stds)

--- a/gluoncv/model_zoo/rpn/proposal.py
+++ b/gluoncv/model_zoo/rpn/proposal.py
@@ -15,6 +15,8 @@ class RPNProposal(gluon.HybridBlock):
 
     Parameters
     ----------
+    clip : float
+        Clip bounding box target to this value.
     nms_thresh : float
         IOU threshold for NMS. It is used to remove overlapping proposals.
     train_pre_nms : int
@@ -31,11 +33,11 @@ class RPNProposal(gluon.HybridBlock):
         Standard deviation to be multiplied from encoded regression targets.
         These values must be the same as stds used in RPNTargetGenerator.
     """
-    def __init__(self, nms_thresh, train_pre_nms, train_post_nms,
+    def __init__(self, clip, nms_thresh, train_pre_nms, train_post_nms,
                  test_pre_nms, test_post_nms, min_size, stds):
         super(RPNProposal, self).__init__()
         self._box_to_center = BBoxCornerToCenter()
-        self._box_decoder = NormalizedBoxCenterDecoder(stds=stds)
+        self._box_decoder = NormalizedBoxCenterDecoder(stds=stds, clip=clip)
         self._clipper = BBoxClipToImage()
         # self._compute_area = BBoxArea()
         self._nms_thresh = nms_thresh

--- a/gluoncv/model_zoo/rpn/proposal.py
+++ b/gluoncv/model_zoo/rpn/proposal.py
@@ -3,7 +3,7 @@ from __future__  import absolute_import
 
 from mxnet import autograd
 from mxnet import gluon
-from ...nn.bbox import BBoxCornerToCenter
+from ...nn.bbox import BBoxCornerToCenter, BBoxClipToImage
 from ...nn.coder import NormalizedBoxCenterDecoder
 
 
@@ -36,7 +36,7 @@ class RPNProposal(gluon.HybridBlock):
         super(RPNProposal, self).__init__()
         self._box_to_center = BBoxCornerToCenter()
         self._box_decoder = NormalizedBoxCenterDecoder(stds=stds)
-        # self._clipper = BBoxClipToImage()
+        self._clipper = BBoxClipToImage()
         # self._compute_area = BBoxArea()
         self._nms_thresh = nms_thresh
         self._train_pre_nms = max(1, train_pre_nms)
@@ -62,8 +62,8 @@ class RPNProposal(gluon.HybridBlock):
             roi = self._box_decoder(bbox_pred, self._box_to_center(anchor))
 
             # clip rois to image's boundary
-            roi = F.Custom(roi, img, op_type='bbox_clip_to_image')
-            # roi = self._clipper(roi, width, height)
+            # roi = F.Custom(roi, img, op_type='bbox_clip_to_image')
+            roi = self._clipper(roi, img)
 
             # remove bounding boxes that don't meet the min_size constraint
             # by setting them to (-1, -1, -1, -1)

--- a/gluoncv/model_zoo/rpn/rpn.py
+++ b/gluoncv/model_zoo/rpn/rpn.py
@@ -38,6 +38,8 @@ class RPN(gluon.HybridBlock):
         Later in inference we can have variable input sizes,
         at which time we can crop corresponding anchors from this large
         anchor map so we can skip re-generating anchors for each input.
+    clip : float
+        Clip bounding box target to this value.
     nms_thresh : float
         IOU threshold for NMS. It is used to remove overlapping proposals.
     train_pre_nms : int
@@ -53,7 +55,7 @@ class RPN(gluon.HybridBlock):
 
     """
     def __init__(self, channels, stride, base_size, scales, ratios, alloc_size,
-                 nms_thresh, train_pre_nms, train_post_nms,
+                 clip, nms_thresh, train_pre_nms, train_post_nms,
                  test_pre_nms, test_post_nms, min_size, **kwargs):
         super(RPN, self).__init__(**kwargs)
         weight_initializer = mx.init.Normal(0.01)
@@ -62,7 +64,7 @@ class RPN(gluon.HybridBlock):
                 stride, base_size, ratios, scales, alloc_size)
             anchor_depth = self.anchor_generator.num_depth
             self.region_proposaler = RPNProposal(
-                nms_thresh, train_pre_nms, train_post_nms,
+                clip, nms_thresh, train_pre_nms, train_post_nms,
                 test_pre_nms, test_post_nms, min_size, stds=(1., 1., 1., 1.))
             self.conv1 = nn.HybridSequential()
             self.conv1.add(nn.Conv2D(channels, 3, 1, 1, weight_initializer=weight_initializer))

--- a/gluoncv/model_zoo/rpn/rpn.py
+++ b/gluoncv/model_zoo/rpn/rpn.py
@@ -21,8 +21,6 @@ class RPN(gluon.HybridBlock):
         This is usually the ratio between original image size and feature map size.
     base_size : int
         The width(and height) of reference anchor box.
-    ratios : iterable of float
-        The aspect ratios of anchor boxes. We expect it to be a list or tuple.
     scales : iterable of float
         The areas of anchor boxes.
         We use the following form to compute the shapes of anchors:
@@ -32,49 +30,42 @@ class RPN(gluon.HybridBlock):
             width_{anchor} = size_{base} \times scale \times \sqrt{ 1 / ratio}
             height_{anchor} = size_{base} \times scale \times \sqrt{ratio}
 
+    ratios : iterable of float
+        The aspect ratios of anchor boxes. We expect it to be a list or tuple.
     alloc_size : tuple of int
         Allocate size for the anchor boxes as (H, W).
         Usually we generate enough anchors for large feature map, e.g. 128x128.
         Later in inference we can have variable input sizes,
         at which time we can crop corresponding anchors from this large
         anchor map so we can skip re-generating anchors for each input.
-    nms_thresh : float, default is 0.7
+    nms_thresh : float
         IOU threshold for NMS. It is used to remove overlapping proposals.
-    train_pre_nms : int, default is 12000
+    train_pre_nms : int
         Filter top proposals before NMS in training.
-    train_post_nms : int, default is 2000
+    train_post_nms : int
         Return top proposal results after NMS in training.
-    test_pre_nms : int, default is 6000
+    test_pre_nms : int
         Filter top proposals before NMS in testing.
-    test_post_nms : int, default is 300
+    test_post_nms : int
         Return top proposal results after NMS in testing.
-    min_size : int, default is 16
+    min_size : int
         Proposals whose size is smaller than ``min_size`` will be discarded.
-    stds : tuple of float
-        Standard deviation to be multiplied from encoded regression targets.
-        These values must be the same as stds used in RPNTargetGenerator.
-    weight_initializer : mxnet.initializer, default is mx.init.Normal(0.01)
-        Weight intializer for RPN convolutional layers.
 
     """
-    def __init__(self, channels, stride, base_size=16, ratios=(0.5, 1, 2),
-                 scales=(8, 16, 32), alloc_size=(128, 128),
-                 nms_thresh=0.7, train_pre_nms=12000, train_post_nms=2000,
-                 test_pre_nms=6000, test_post_nms=300, min_size=16, stds=(1., 1., 1., 1.),
-                 weight_initializer=None, **kwargs):
+    def __init__(self, channels, stride, base_size, scales, ratios, alloc_size,
+                 nms_thresh, train_pre_nms, train_post_nms,
+                 test_pre_nms, test_post_nms, min_size, **kwargs):
         super(RPN, self).__init__(**kwargs)
-        if weight_initializer is None:
-            weight_initializer = mx.init.Normal(0.01)
+        weight_initializer = mx.init.Normal(0.01)
         with self.name_scope():
             self.anchor_generator = RPNAnchorGenerator(
                 stride, base_size, ratios, scales, alloc_size)
             anchor_depth = self.anchor_generator.num_depth
             self.region_proposaler = RPNProposal(
                 nms_thresh, train_pre_nms, train_post_nms,
-                test_pre_nms, test_post_nms, min_size, stds)
+                test_pre_nms, test_post_nms, min_size, stds=(1., 1., 1., 1.))
             self.conv1 = nn.HybridSequential()
-            self.conv1.add(
-                nn.Conv2D(channels, 3, 1, 1, weight_initializer=weight_initializer))
+            self.conv1.add(nn.Conv2D(channels, 3, 1, 1, weight_initializer=weight_initializer))
             self.conv1.add(nn.Activation('relu'))
             # use sigmoid instead of softmax, reduce channel numbers
             self.score = nn.Conv2D(anchor_depth, 1, 1, 0, weight_initializer=weight_initializer)

--- a/gluoncv/nn/bbox.py
+++ b/gluoncv/nn/bbox.py
@@ -141,6 +141,7 @@ class BBoxClipToImage(gluon.HybridBlock):
         (B, N, 4) Bounding box coordinates.
 
         """
+        x = F.maximum(x, 0.0)
         # window [B, 2] -> reverse hw -> tile [B, 4] -> [B, 1, 4], boxes [B, N, 4]
         window = F.shape_array(img).slice_axis(axis=0, begin=2, end=None).expand_dims(0)
         m = F.tile(F.reverse(window, axis=1), reps=(2,)).reshape((0, -4, 1, -1))

--- a/gluoncv/nn/bbox.py
+++ b/gluoncv/nn/bbox.py
@@ -142,6 +142,6 @@ class BBoxClipToImage(gluon.HybridBlock):
 
         """
         # window [B, 2] -> reverse hw -> tile [B, 4] -> [B, 1, 4], boxes [B, N, 4]
-        window = F.shape_array(img).slice_axis(axis=0, begin=1, end=None).expand_dims(0)
+        window = F.shape_array(img).slice_axis(axis=0, begin=2, end=None).expand_dims(0)
         m = F.tile(F.reverse(window, axis=1), reps=(2,)).reshape((0, -4, 1, -1))
         return F.broadcast_minimum(x, F.cast(m, dtype='float32'))

--- a/gluoncv/nn/bbox.py
+++ b/gluoncv/nn/bbox.py
@@ -125,6 +125,10 @@ class BBoxArea(gluon.HybridBlock):
 
 
 class BBoxClipToImage(gluon.HybridBlock):
+    """Clip bounding box coordinates to image boundaries.
+    If multiple images are supplied and padded, must have additional inputs
+    of accurate image shape.
+    """
     def __init__(self, **kwargs):
         super(BBoxClipToImage, self).__init__(**kwargs)
 

--- a/gluoncv/nn/bbox.py
+++ b/gluoncv/nn/bbox.py
@@ -122,3 +122,26 @@ class BBoxArea(gluon.HybridBlock):
         width = F.where(width > 0, width, F.zeros_like(width))
         height = F.where(height > 0, height, F.zeros_like(height))
         return width * height
+
+
+class BBoxClipToImage(gluon.HybridBlock):
+    def __init__(self, **kwargs):
+        super(BBoxClipToImage, self).__init__(**kwargs)
+
+    def hybrid_forward(self, F, x, img):
+        """If images are padded, must have additional inputs for clipping
+
+        Parameters
+        ----------
+        x: (B, N, 4) Bounding box coordinates.
+        img: (B, C, H, W) Image tensor.
+
+        Returns
+        -------
+        (B, N, 4) Bounding box coordinates.
+
+        """
+        # window [B, 2] -> reverse hw -> tile [B, 4] -> [B, 1, 4], boxes [B, N, 4]
+        window = F.shape_array(img).slice_axis(axis=0, begin=1, end=None).expand_dims(0)
+        m = F.tile(F.reverse(window, axis=1), reps=(2,)).reshape((0, -4, 1, -1))
+        return F.broadcast_minimum(x, F.cast(m, dtype='float32'))

--- a/gluoncv/nn/coder.py
+++ b/gluoncv/nn/coder.py
@@ -153,7 +153,8 @@ class NormalizedBoxCenterDecoder(gluon.HybridBlock):
         If given, bounding box target will be clipped to this value.
 
     """
-    def __init__(self, stds=(0.1, 0.1, 0.2, 0.2), means=(0., 0., 0., 0.), convert_anchor=False, clip=None):
+    def __init__(self, stds=(0.1, 0.1, 0.2, 0.2), means=(0., 0., 0., 0.),
+                 convert_anchor=False, clip=None):
         super(NormalizedBoxCenterDecoder, self).__init__()
         assert len(stds) == 4, "Box Encoder requires 4 std values."
         self._stds = stds

--- a/gluoncv/nn/coder.py
+++ b/gluoncv/nn/coder.py
@@ -32,13 +32,33 @@ class NormalizedBoxCenterEncoder(gluon.Block):
             self.corner_to_center = BBoxCornerToCenter(split=True)
 
     def forward(self, samples, matches, anchors, refs):
-        """Forward"""
+        """Not HybridBlock due to use of matches.shape
+
+        Parameters
+        ----------
+        samples: (B, N) value +1 (positive), -1 (negative), 0 (ignore)
+        matches: (B, N) value range [0, M)
+        anchors: (B, N, 4) encoded in corner
+        refs: (B, M, 4) encoded in corner
+
+        Returns
+        -------
+        targets: (B, N, 4) transform anchors to refs picked according to matches
+        masks: (B, N, 4) only positive anchors has targets
+
+        """
         F = nd
         # TODO(zhreshold): batch_pick, take multiple elements?
-        ref_boxes = nd.repeat(refs.reshape((0, 1, -1, 4)), axis=1, repeats=matches.shape[1])
-        ref_boxes = nd.split(ref_boxes, axis=-1, num_outputs=4, squeeze_axis=True)
-        ref_boxes = nd.concat(*[F.pick(ref_boxes[i], matches, axis=2).reshape((0, -1, 1)) \
+        # refs [B, M, 4], anchors [B, N, 4], samples [B, N], matches [B, N]
+        # refs [B, M, 4] -> reshape [B, 1, M, 4] -> repeat [B, N, M, 4]
+        ref_boxes = F.repeat(refs.reshape((0, 1, -1, 4)), axis=1, repeats=matches.shape[1])
+        # refs [B, N, M, 4] -> 4 * [B, N, M]
+        ref_boxes = F.split(ref_boxes, axis=-1, num_outputs=4, squeeze_axis=True)
+        # refs 4 * [B, N, M] -> pick from matches [B, N, 1] -> concat to [B, N, 4]
+        ref_boxes = F.concat(*[F.pick(ref_boxes[i], matches, axis=2).reshape((0, -1, 1)) \
             for i in range(4)], dim=2)
+        # transform based on x, y, w, h
+        # g [B, N, 4], a [B, N, 4] -> codecs [B, N, 4]
         g = self.corner_to_center(ref_boxes)
         a = self.corner_to_center(anchors)
         t0 = ((g[0] - a[0]) / a[2] - self._means[0]) / self._stds[0]
@@ -46,7 +66,9 @@ class NormalizedBoxCenterEncoder(gluon.Block):
         t2 = (F.log(g[2] / a[2]) - self._means[2]) / self._stds[2]
         t3 = (F.log(g[3] / a[3]) - self._means[3]) / self._stds[3]
         codecs = F.concat(t0, t1, t2, t3, dim=2)
+        # samples [B, N] -> [B, N, 1] -> [B, N, 4] -> boolean
         temp = F.tile(samples.reshape((0, -1, 1)), reps=(1, 1, 4)) > 0.5
+        # fill targets and masks [B, N, 4]
         targets = F.where(temp, codecs, F.zeros_like(codecs))
         masks = F.where(temp, F.ones_like(temp), F.zeros_like(temp))
         return targets, masks
@@ -70,38 +92,45 @@ class NormalizedPerClassBoxCenterEncoder(gluon.Block):
         assert len(stds) == 4, "Box Encoder requires 4 std values."
         assert num_class > 0, "Number of classes must be positive"
         self._num_class = num_class
-        self._stds = stds
-        self._means = means
         with self.name_scope():
-            self.corner_to_center = BBoxCornerToCenter(split=True)
+            self.class_agnostic_encoder = NormalizedBoxCenterEncoder(stds=stds, means=means)
 
     def forward(self, samples, matches, anchors, labels, refs):
-        """Encode BBox One entry per category"""
+        """Encode BBox One entry per category
+
+        Parameters
+        ----------
+        samples: (B, N) value +1 (positive), -1 (negative), 0 (ignore)
+        matches: (B, N) value range [0, M)
+        anchors: (B, N, 4) encoded in corner
+        labels: (B, N) value range [0, self._num_class), excluding background
+        refs: (B, M, 4) encoded in corner
+
+        Returns
+        -------
+        targets: (C, B, N, 4) transform anchors to refs picked according to matches
+        masks: (C, B, N, 4) only positive anchors of the correct class has targets
+
+        """
         F = nd
-        ref_boxes = F.repeat(refs.reshape((0, 1, -1, 4)), axis=1, repeats=matches.shape[1])
-        ref_boxes = F.split(ref_boxes, axis=-1, num_outputs=4, squeeze_axis=True)
-        ref_boxes = F.concat(*[F.pick(ref_boxes[i], matches, axis=2).reshape((0, -1, 1)) \
-            for i in range(4)], dim=2)
+        # refs [B, M, 4], anchors [B, N, 4], samples [B, N], matches [B, N]
+        # encoded targets [B, N, 4], masks [B, N, 4]
+        targets, masks = self.class_agnostic_encoder(samples, matches, anchors, refs)
+        # labels [B, M] -> [B, N, M]
         ref_labels = F.repeat(labels.reshape((0, 1, -1)), axis=1, repeats=matches.shape[1])
+        # labels [B, N, M] -> pick from matches [B, N] -> [B, N, 1]
         ref_labels = F.pick(ref_labels, matches, axis=2).reshape((0, -1, 1))
-        g = self.corner_to_center(ref_boxes)
-        a = self.corner_to_center(anchors)
-        t0 = ((g[0] - a[0]) / a[2] - self._means[0]) / self._stds[0]
-        t1 = ((g[1] - a[1]) / a[3] - self._means[1]) / self._stds[1]
-        t2 = (F.log(g[2] / a[2]) - self._means[2]) / self._stds[2]
-        t3 = (F.log(g[3] / a[3]) - self._means[3]) / self._stds[3]
-        codecs = F.concat(t0, t1, t2, t3, dim=2)
-        temp = F.tile(samples.reshape((0, -1, 1)), reps=(1, 1, 4)) > 0.5
-        targets = F.where(temp, codecs, F.zeros_like(codecs))
-        masks = F.where(temp, F.ones_like(temp), F.zeros_like(temp))
+        # expand class agnostic targets to per class targets
         out_targets = []
         out_masks = []
         for cid in range(self._num_class):
+            # boolean array [B, N, 1]
             same_cid = ref_labels == cid
             # keep orig targets
             out_targets.append(targets)
-            # but mask out the one not belong to this class
+            # but mask out the one not belong to this class [B, N, 1] -> [B, N, 4]
             out_masks.append(masks * same_cid.repeat(axis=-1, repeats=4))
+        # targets, masks C * [B, N, 4] -> [C, B, N, 4] -> [B, N, C, 4]
         all_targets = F.stack(*out_targets, axis=0)
         all_masks = F.stack(*out_masks, axis=0)
         return all_targets, all_masks
@@ -164,9 +193,27 @@ class MultiClassEncoder(gluon.HybridBlock):
         self._ignore_label = ignore_label
 
     def hybrid_forward(self, F, samples, matches, refs):
+        """HybridBlock, handle multi batch correctly
+
+        Parameters
+        ----------
+        samples: (B, N), value +1 (positive), -1 (negative), 0 (ignore)
+        matches: (B, N), value range [0, M)
+        refs: (B, M), value range [0, num_fg_class), excluding background
+
+        Returns
+        -------
+        targets: (B, N), value range [0, num_fg_class + 1), including background
+
+        """
+        # samples (B, N) (+1, -1, 0: ignore), matches (B, N) [0, M), refs (B, M)
+        # reshape refs (B, M) -> (B, 1, M) -> (B, N, M)
         refs = F.repeat(refs.reshape((0, 1, -1)), axis=1, repeats=matches.shape[1])
+        # ids (B, N, M) -> (B, N), value [0, M + 1), 0 reserved for background class
         target_ids = F.pick(refs, matches, axis=2) + 1
+        # samples 0: set ignore samples to ignore_label
         targets = F.where(samples > 0.5, target_ids, nd.ones_like(target_ids) * self._ignore_label)
+        # samples -1: set negative samples to 0
         targets = F.where(samples < -0.5, nd.zeros_like(targets), targets)
         return targets
 
@@ -200,6 +247,7 @@ class MultiClassDecoder(gluon.HybridBlock):
         cls_id = F.where(mask, cls_id, F.ones_like(cls_id) * -1)
         scores = F.where(mask, scores, F.zeros_like(scores))
         return cls_id, scores
+
 
 class MultiPerClassDecoder(gluon.HybridBlock):
     """Decode classification results.

--- a/scripts/detection/faster_rcnn/demo_faster_rcnn.py
+++ b/scripts/detection/faster_rcnn/demo_faster_rcnn.py
@@ -38,9 +38,9 @@ if __name__ == '__main__':
 
     # grab some image if not specified
     if not args.images.strip():
-        gcv.utils.download("https://cloud.githubusercontent.com/assets/3307514/" +
-            "20012568/cbc2d6f6-a27d-11e6-94c3-d35a9cb47609.jpg", 'street.jpg')
-        image_list = ['street.jpg']
+        gcv.utils.download('https://github.com/dmlc/web-data/blob/master/' +
+                           'gluoncv/detection/biking.jpg?raw=true', 'biking.jpg')
+        image_list = ['biking.jpg']
     else:
         image_list = [x.strip() for x in args.images.split(',') if x.strip()]
 
@@ -54,7 +54,7 @@ if __name__ == '__main__':
     ax = None
     for image in image_list:
         x, img = presets.rcnn.load_test(image, short=args.short, max_size=args.max_size)
-        ids, scores, bboxes = [xx.asnumpy() for xx in net(x)]
+        ids, scores, bboxes = [xx[0].asnumpy() for xx in net(x)]
         ax = gcv.utils.viz.plot_bbox(img, bboxes, scores, ids,
                                      class_names=net.classes, ax=ax)
         plt.show()

--- a/scripts/detection/faster_rcnn/demo_faster_rcnn.py
+++ b/scripts/detection/faster_rcnn/demo_faster_rcnn.py
@@ -10,10 +10,6 @@ def parse_args():
     parser = argparse.ArgumentParser(description='Test with Faster RCNN networks.')
     parser.add_argument('--network', type=str, default='faster_rcnn_resnet50_v2a_voc',
                         help="Faster RCNN full network name")
-    parser.add_argument('--short', type=str, default='',
-                        help='Resize image to the given short side side, default to 600 for voc.')
-    parser.add_argument('--max-size', type=str, default='',
-                        help='Max size of either side of image, default to 1000 for voc.')
     parser.add_argument('--images', type=str, default='',
                         help='Test images, use comma to split multiple.')
     parser.add_argument('--gpus', type=str, default='0',
@@ -21,13 +17,6 @@ def parse_args():
     parser.add_argument('--pretrained', type=str, default='True',
                         help='Load weights from previously saved parameters. You can specify parameter file name.')
     args = parser.parse_args()
-    dataset = args.network.split('_')[-1]
-    if dataset == 'voc':
-        args.short = int(args.short) if args.short else 600
-        args.max_size = int(args.max_size) if args.max_size else 1000
-    elif dataset == 'coco':
-        args.short = int(args.short) if args.short else 800
-        args.max_size = int(args.max_size) if args.max_size else 1333
     return args
 
 if __name__ == '__main__':
@@ -53,7 +42,7 @@ if __name__ == '__main__':
 
     ax = None
     for image in image_list:
-        x, img = presets.rcnn.load_test(image, short=args.short, max_size=args.max_size)
+        x, img = presets.rcnn.load_test(image, short=net.short, max_size=net.max_size)
         ids, scores, bboxes = [xx[0].asnumpy() for xx in net(x)]
         ax = gcv.utils.viz.plot_bbox(img, bboxes, scores, ids,
                                      class_names=net.classes, ax=ax)

--- a/scripts/detection/faster_rcnn/eval_faster_rcnn.py
+++ b/scripts/detection/faster_rcnn/eval_faster_rcnn.py
@@ -77,7 +77,6 @@ def split_and_load(batch, ctx_list):
 def validate(net, val_data, ctx, eval_metric, size):
     """Test on validation dataset."""
     eval_metric.reset()
-    net.collect_params().reset_ctx(ctx)
     net.hybridize(static_alloc=True)
     with tqdm(total=size) as pbar:
         for ib, batch in enumerate(val_data):
@@ -125,6 +124,7 @@ if __name__ == '__main__':
     else:
         net = gcv.model_zoo.get_model(net_name, pretrained=False)
         net.load_parameters(args.pretrained.strip())
+    net.collect_params().reset_ctx(ctx)
 
     # training data
     val_dataset, eval_metric = get_dataset(args.dataset, args)

--- a/scripts/detection/faster_rcnn/eval_faster_rcnn.py
+++ b/scripts/detection/faster_rcnn/eval_faster_rcnn.py
@@ -33,6 +33,8 @@ def parse_args():
                         help='Load weights from previously saved parameters.')
     parser.add_argument('--save-prefix', type=str, default='',
                         help='Saving parameter prefix')
+    parser.add_argument('--save-json', action='store_true',
+                        help='Save coco output json')
     parser.add_argument('--eval-all', action='store_true',
                         help='Eval all models begins with save prefix. Use with pretrained.')
     args = parser.parse_args()
@@ -45,7 +47,8 @@ def get_dataset(dataset, args):
         val_metric = VOC07MApMetric(iou_thresh=0.5, class_names=val_dataset.classes)
     elif dataset.lower() == 'coco':
         val_dataset = gdata.COCODetection(splits='instances_val2017', skip_empty=False)
-        val_metric = COCODetectionMetric(val_dataset, args.save_prefix + '_eval', cleanup=True)
+        val_metric = COCODetectionMetric(val_dataset, args.save_prefix + '_eval',
+                                         cleanup=not args.save_json)
     else:
         raise NotImplementedError('Dataset: {} not implemented.'.format(dataset))
     return val_dataset, val_metric

--- a/scripts/detection/faster_rcnn/eval_faster_rcnn.py
+++ b/scripts/detection/faster_rcnn/eval_faster_rcnn.py
@@ -78,8 +78,7 @@ def validate(net, val_data, ctx, eval_metric, size):
     """Test on validation dataset."""
     eval_metric.reset()
     net.collect_params().reset_ctx(ctx)
-    net.set_nms(nms_thresh=0.3, nms_topk=400)
-    # net.hybridize()
+    net.hybridize(static_alloc=True)
     with tqdm(total=size) as pbar:
         for ib, batch in enumerate(val_data):
             batch = split_and_load(batch, ctx_list=ctx)

--- a/scripts/detection/faster_rcnn/eval_faster_rcnn.py
+++ b/scripts/detection/faster_rcnn/eval_faster_rcnn.py
@@ -76,6 +76,7 @@ def split_and_load(batch, ctx_list):
 
 def validate(net, val_data, ctx, eval_metric, size):
     """Test on validation dataset."""
+    clipper = gcv.nn.bbox.BBoxClipToImage()
     eval_metric.reset()
     net.hybridize(static_alloc=True)
     with tqdm(total=size) as pbar:
@@ -90,10 +91,10 @@ def validate(net, val_data, ctx, eval_metric, size):
             for x, y, im_scale in zip(*batch):
                 # get prediction results
                 ids, scores, bboxes = net(x)
-                det_ids.append(ids.expand_dims(0))
-                det_scores.append(scores.expand_dims(0))
+                det_ids.append(ids)
+                det_scores.append(scores)
                 # clip to image size
-                det_bboxes.append(mx.nd.Custom(bboxes, x, op_type='bbox_clip_to_image').expand_dims(0))
+                det_bboxes.append(clipper(bboxes, x))
                 # rescale to original resolution
                 im_scale = im_scale.reshape((-1)).asscalar()
                 det_bboxes[-1] *= im_scale

--- a/scripts/detection/faster_rcnn/train_faster_rcnn.py
+++ b/scripts/detection/faster_rcnn/train_faster_rcnn.py
@@ -378,8 +378,8 @@ def train(net, train_data, val_data, eval_metric, args):
                 # msg = ','.join(['{}={:.3f}'.format(*metric.get()) for metric in metrics])
                 msg = ','.join(['{}={:.3f}'.format(*metric.get()) for metric in metrics + metrics2])
                 logger.info('[Epoch {}][Batch {}], Speed: {:.3f} samples/sec, {}'.format(
-                    epoch, i, batch_size/(time.time()-btic), msg))
-            btic = time.time()
+                    epoch, i, args.log_interval * batch_size/(time.time()-btic), msg))
+                btic = time.time()
 
         msg = ','.join(['{}={:.3f}'.format(*metric.get()) for metric in metrics])
         logger.info('[Epoch {}] Training cost: {:.3f}, {}'.format(

--- a/scripts/detection/faster_rcnn/train_faster_rcnn.py
+++ b/scripts/detection/faster_rcnn/train_faster_rcnn.py
@@ -176,7 +176,7 @@ def get_dataset(dataset, args):
             splits=[(2007, 'test')])
         val_metric = VOC07MApMetric(iou_thresh=0.5, class_names=val_dataset.classes)
     elif dataset.lower() == 'coco':
-        train_dataset = gdata.COCODetection(splits='instances_train2017', use_crowd=True)
+        train_dataset = gdata.COCODetection(splits='instances_train2017', use_crowd=False)
         val_dataset = gdata.COCODetection(splits='instances_val2017', skip_empty=False)
         val_metric = COCODetectionMetric(val_dataset, args.save_prefix + '_eval', cleanup=True)
     else:

--- a/scripts/detection/faster_rcnn/train_faster_rcnn.py
+++ b/scripts/detection/faster_rcnn/train_faster_rcnn.py
@@ -150,7 +150,7 @@ class RCNNAccMetric(mx.metric.EvalMetric):
         rcnn_cls = preds[0]
 
         # calculate num_acc
-        pred_label = mx.nd.argmax(rcnn_cls, axis=1)
+        pred_label = mx.nd.argmax(rcnn_cls, axis=-1)
         num_acc = mx.nd.sum(pred_label == rcnn_label)
 
         self.sum_metric += num_acc.asscalar()

--- a/scripts/detection/faster_rcnn/train_faster_rcnn.py
+++ b/scripts/detection/faster_rcnn/train_faster_rcnn.py
@@ -264,7 +264,6 @@ def get_lr_at_iter(alpha):
 
 def train(net, train_data, val_data, eval_metric, args):
     """Training pipeline"""
-    net.collect_params().reset_ctx(ctx)
     net.collect_params().setattr('grad_req', 'null')
     net.collect_train_params().setattr('grad_req', 'write')
     trainer = gluon.Trainer(
@@ -415,6 +414,7 @@ if __name__ == '__main__':
             if param._data is not None:
                 continue
             param.initialize()
+    net.collect_params().reset_ctx(ctx)
 
     # training data
     train_dataset, val_dataset, eval_metric = get_dataset(args.dataset, args)

--- a/scripts/detection/faster_rcnn/train_faster_rcnn.py
+++ b/scripts/detection/faster_rcnn/train_faster_rcnn.py
@@ -329,7 +329,8 @@ def train(net, train_data, val_data, eval_metric, args):
                 # adjust based on real percentage
                 new_lr = base_lr * get_lr_at_iter(i / lr_warmup)
                 if new_lr != trainer.learning_rate:
-                    logger.info('[Epoch 0 Iteration {}] Set learning rate to {}'.format(i, new_lr))
+                    if i % args.log_interval == 0:
+                        logger.info('[Epoch 0 Iteration {}] Set learning rate to {}'.format(i, new_lr))
                     trainer.set_learning_rate(new_lr)
             batch = split_and_load(batch, ctx_list=ctx)
             batch_size = len(batch[0])

--- a/scripts/detection/faster_rcnn/train_faster_rcnn.py
+++ b/scripts/detection/faster_rcnn/train_faster_rcnn.py
@@ -228,6 +228,7 @@ def split_and_load(batch, ctx_list):
 
 def validate(net, val_data, ctx, eval_metric):
     """Test on validation dataset."""
+    clipper = gcv.nn.bbox.BBoxClipToImage()
     eval_metric.reset()
     net.hybridize(static_alloc=True)
     for batch in val_data:
@@ -241,10 +242,10 @@ def validate(net, val_data, ctx, eval_metric):
         for x, y, im_scale in zip(*batch):
             # get prediction results
             ids, scores, bboxes = net(x)
-            det_ids.append(ids.expand_dims(0))
-            det_scores.append(scores.expand_dims(0))
+            det_ids.append(ids)
+            det_scores.append(scores)
             # clip to image size
-            det_bboxes.append(mx.nd.Custom(bboxes, x, op_type='bbox_clip_to_image').expand_dims(0))
+            det_bboxes.append(clipper(bboxes, x))
             # rescale to original resolution
             im_scale = im_scale.reshape((-1)).asscalar()
             det_bboxes[-1] *= im_scale

--- a/scripts/detection/faster_rcnn/train_faster_rcnn.py
+++ b/scripts/detection/faster_rcnn/train_faster_rcnn.py
@@ -184,7 +184,7 @@ def get_dataset(dataset, args):
             splits=[(2007, 'test')])
         val_metric = VOC07MApMetric(iou_thresh=0.5, class_names=val_dataset.classes)
     elif dataset.lower() == 'coco':
-        train_dataset = gdata.COCODetection(splits='instances_train2017')
+        train_dataset = gdata.COCODetection(splits='instances_train2017', use_crowd=True)
         val_dataset = gdata.COCODetection(splits='instances_val2017', skip_empty=False)
         val_metric = COCODetectionMetric(val_dataset, args.save_prefix + '_eval', cleanup=True)
     else:

--- a/scripts/detection/faster_rcnn/train_faster_rcnn.py
+++ b/scripts/detection/faster_rcnn/train_faster_rcnn.py
@@ -229,8 +229,6 @@ def split_and_load(batch, ctx_list):
 def validate(net, val_data, ctx, eval_metric):
     """Test on validation dataset."""
     eval_metric.reset()
-    # set nms threshold and topk constraint
-    net.set_nms(nms_thresh=0.3, nms_topk=400)
     net.hybridize(static_alloc=True)
     for batch in val_data:
         batch = split_and_load(batch, ctx_list=ctx)

--- a/scripts/detection/faster_rcnn/train_faster_rcnn.py
+++ b/scripts/detection/faster_rcnn/train_faster_rcnn.py
@@ -278,7 +278,7 @@ def train(net, train_data, val_data, eval_metric, args):
     # lr decay policy
     lr_decay = float(args.lr_decay)
     lr_steps = sorted([float(ls) for ls in args.lr_decay_epoch.split(',') if ls.strip()])
-    lr_warmup = int(args.lr_warmup)
+    lr_warmup = float(args.lr_warmup)  # avoid int division
 
     # TODO(zhreshold) losses?
     rpn_cls_loss = mx.gluon.loss.SigmoidBinaryCrossEntropyLoss(from_sigmoid=False)
@@ -326,7 +326,8 @@ def train(net, train_data, val_data, eval_metric, args):
         base_lr = trainer.learning_rate
         for i, batch in enumerate(train_data):
             if epoch == 0 and i <= lr_warmup:
-                new_lr = base_lr * get_lr_at_iter((i // 500) / (lr_warmup / 500.))
+                # adjust based on real percentage
+                new_lr = base_lr * get_lr_at_iter(i / lr_warmup)
                 if new_lr != trainer.learning_rate:
                     logger.info('[Epoch 0 Iteration {}] Set learning rate to {}'.format(i, new_lr))
                     trainer.set_learning_rate(new_lr)

--- a/scripts/detection/faster_rcnn/train_faster_rcnn.py
+++ b/scripts/detection/faster_rcnn/train_faster_rcnn.py
@@ -267,6 +267,8 @@ def get_lr_at_iter(alpha):
 def train(net, train_data, val_data, eval_metric, args):
     """Training pipeline"""
     net.collect_params().reset_ctx(ctx)
+    net.collect_params().setattr('grad_req', 'null')
+    net.collect_train_params().setattr('grad_req', 'write')
     trainer = gluon.Trainer(
         net.collect_train_params(),  # fix batchnorm, fix first stage, etc...
         'sgd',

--- a/scripts/detection/ssd/eval_ssd.py
+++ b/scripts/detection/ssd/eval_ssd.py
@@ -56,7 +56,7 @@ def get_dataloader(val_dataset, data_shape, batch_size, num_workers):
     batchify_fn = Tuple(Stack(), Pad(pad_val=-1))
     val_loader = gluon.data.DataLoader(
         val_dataset.transform(SSDDefaultValTransform(width, height)), batchify_fn=batchify_fn,
-        batch_size, False, last_batch='keep', num_workers=num_workers)
+        batch_size=batch_size, shuffle=False, last_batch='keep', num_workers=num_workers)
     return val_loader
 
 def validate(net, val_data, ctx, classes, size, metric):

--- a/tests/py2.yml
+++ b/tests/py2.yml
@@ -11,6 +11,6 @@ dependencies:
   - scipy
   - pip=9.0.3
   - pip:
-    - mxnet-cu80==1.3.0b20180621
+    - mxnet-cu80==1.3.0b20180713
     - coverage-badge
     - awscli

--- a/tests/py3.yml
+++ b/tests/py3.yml
@@ -11,6 +11,6 @@ dependencies:
   - scipy
   - pip=9.0.3
   - pip:
-    - mxnet-cu80==1.3.0b20180621
+    - mxnet-cu80==1.3.0b20180713
     - coverage-badge
     - awscli

--- a/tests/unittests/test_data_dataloader.py
+++ b/tests/unittests/test_data_dataloader.py
@@ -9,7 +9,7 @@ from gluoncv.data.batchify import *
 from gluoncv.data import DetectionDataLoader
 
 
-class DummyDetectionDataset(object):
+class DummyDetectionDataset(mx.gluon.data.Dataset):
     def __init__(self, size=10):
         self.size = size
 


### PR DESCRIPTION
- coco dataset: option to use crowd instances; roi_align sample ratio; nms threshold; bilinear interpolation; box_decode clip
- sampler: replaced with native op
- box_clip: replaced with native op; introduced mxnet 20180713 dependency for shape_array
- multi batch inference: almost correct, except that box_clip need actual image size when padded
- resnetv1b models: new test for use_global_stats in modelzoo require reinstall pip packages