### PR TITLE
Update Jenkinsfile for CI server conda upgrade

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ stage("Sanity Check") {
       sh """#!/bin/bash
       set -e
       conda env update -n gluon_vision_pylint -f tests/pylint.yml
-      source activate gluon_vision_pylint
+      conda activate gluon_vision_pylint
       conda list
       make clean
       make pylint
@@ -24,7 +24,7 @@ stage("Unit Test") {
         # conda env remove -n gluon_cv_py2_test -y
         # conda env create -n gluon_cv_py2_test -f tests/py2.yml
         conda env update -n gluon_cv_py2_test -f tests/py2.yml
-        source activate gluon_cv_py2_test
+        conda activate gluon_cv_py2_test
         conda list
         make clean
         pip install --force-reinstall .
@@ -54,7 +54,7 @@ stage("Unit Test") {
         # conda env remove -n gluon_cv_py3_test -y
         # conda env create -n gluon_cv_py3_test -f tests/py3.yml
         conda env update -n gluon_cv_py3_test -f tests/py3.yml
-        source activate gluon_cv_py3_test
+        conda activate gluon_cv_py3_test
         conda list
         make clean
         pip install --force-reinstall .
@@ -77,7 +77,7 @@ stage("Build Docs") {
       set -e
       set -x
       conda env update -n gluon_vision_docs -f docs/build.yml
-      source activate gluon_vision_docs
+      conda activate gluon_vision_docs
       export PYTHONPATH=\${PWD}
       env
       export LD_LIBRARY_PATH=/usr/local/cuda-8.0/lib64

--- a/tests/py3.yml
+++ b/tests/py3.yml
@@ -1,4 +1,4 @@
-name: gluon_cv_py2
+name: gluon_cv_py3
 channels:
   - conda-forge
   - defaults

--- a/tests/pylint.yml
+++ b/tests/pylint.yml
@@ -1,4 +1,4 @@
 name: gluon_cv_pylint
 dependencies:
-- python
+- python=3.6
 - pylint


### PR DESCRIPTION
Starting with conda v4.4, `source activate` is discouraged. The CI server now runs conda 4.5 so the Jenkinsfile needs to be adapted.