### PR TITLE
Initialization fix for SqueezeNet

### DIFF
--- a/gluoncv/utils/__init__.py
+++ b/gluoncv/utils/__init__.py
@@ -15,3 +15,5 @@ from .metrics.voc_segmentation import batch_pix_accuracy, batch_intersection_uni
 from . import parallel
 
 from .plot_history import TrainingHistory
+
+from .init_mod import init_mod_sqnet

--- a/gluoncv/utils/init_mod.py
+++ b/gluoncv/utils/init_mod.py
@@ -5,7 +5,8 @@ import mxnet as mx
 def init_mod_sqnet(net, ctx):
     '''
     Modified initialization for SqueezeNet.
-    Initialize final conv layer to random normal weights by doing one forward pass through the net and set weights explicitly.
+    Initialize final conv layer to random normal weights by doing one forward pass 
+    through the net and set weights explicitly.
     Parameters
     ----------
     net: SqueezeNet HybridBlock from Gluon model zoo initialized with mx.init.MSRAPrelu()
@@ -13,9 +14,9 @@ def init_mod_sqnet(net, ctx):
     -------
     net: Input net with modified initialization
     '''
-    data = [mx.nd.zeros(shape=(1,3,224,224), ctx=i) for i in ctx]
+    data = [mx.nd.zeros(shape=(1, 3, 224, 224), ctx=i) for i in ctx]
     outputs = [net(X) for X in data]
     new_init_w = mx.nd.random_normal(shape=(1000, 512, 1, 1), scale=0.01)
     final_conv_layer_params = net.output[0].params
     final_conv_layer_params.get('weight').set_data(new_init_w)
-    return net        
+    return net

--- a/gluoncv/utils/init_mod.py
+++ b/gluoncv/utils/init_mod.py
@@ -15,7 +15,7 @@ def init_mod_sqnet(net, ctx):
     net: Input net with modified initialization
     '''
     data = [mx.nd.zeros(shape=(1, 3, 224, 224), ctx=i) for i in ctx]
-    outputs = [net(X) for X in data]
+    _ = [net(X) for X in data]
     new_init_w = mx.nd.random_normal(shape=(1000, 512, 1, 1), scale=0.01)
     final_conv_layer_params = net.output[0].params
     final_conv_layer_params.get('weight').set_data(new_init_w)

--- a/gluoncv/utils/init_mod.py
+++ b/gluoncv/utils/init_mod.py
@@ -5,7 +5,7 @@ import mxnet as mx
 def init_mod_sqnet(net, ctx):
     '''
     Modified initialization for SqueezeNet.
-    Initialize final conv layer to random normal weights by doing one forward pass 
+    Initialize final conv layer to random normal weights by doing one forward pass
     through the net and set weights explicitly.
     Parameters
     ----------

--- a/gluoncv/utils/init_mod.py
+++ b/gluoncv/utils/init_mod.py
@@ -1,0 +1,21 @@
+'''Functions for modified initialization'''
+
+import mxnet as mx
+
+def init_mod_sqnet(net, ctx):
+    '''
+    Modified initialization for SqueezeNet.
+    Initialize final conv layer to random normal weights by doing one forward pass through the net and set weights explicitly.
+    Parameters
+    ----------
+    net: SqueezeNet HybridBlock from Gluon model zoo initialized with mx.init.MSRAPrelu()
+    Returns
+    -------
+    net: Input net with modified initialization
+    '''
+    data = [mx.nd.zeros(shape=(1,3,224,224), ctx=i) for i in ctx]
+    outputs = [net(X) for X in data]
+    new_init_w = mx.nd.random_normal(shape=(1000, 512, 1, 1), scale=0.01)
+    final_conv_layer_params = net.output[0].params
+    final_conv_layer_params.get('weight').set_data(new_init_w)
+    return net        

--- a/scripts/classification/imagenet/train_imagenet.py
+++ b/scripts/classification/imagenet/train_imagenet.py
@@ -8,7 +8,7 @@ from mxnet.gluon.data.vision import transforms
 
 from gluoncv.data import imagenet
 from gluoncv.model_zoo import get_model
-from gluoncv.utils import makedirs, LRScheduler
+from gluoncv.utils import makedirs, LRScheduler, init_mod_sqnet
 
 # CLI
 parser = argparse.ArgumentParser(description='Train a model for image classification.')
@@ -248,7 +248,13 @@ def test(ctx, val_data):
 def train(ctx):
     if isinstance(ctx, mx.Context):
         ctx = [ctx]
+    
+    global net
+    
     net.initialize(mx.init.MSRAPrelu(), ctx=ctx)
+
+    if model_name.startswith('squeezenet'):
+        net = init_mod_sqnet(net, ctx)
 
     trainer = gluon.Trainer(net.collect_params(), optimizer, optimizer_params)
 

--- a/scripts/classification/imagenet/train_imagenet.py
+++ b/scripts/classification/imagenet/train_imagenet.py
@@ -248,7 +248,7 @@ def test(ctx, val_data):
 def train(ctx):
     if isinstance(ctx, mx.Context):
         ctx = [ctx]
-    
+
     global net
     
     net.initialize(mx.init.MSRAPrelu(), ctx=ctx)


### PR DESCRIPTION
Changing initialization of SqueezeNet in which last conv layer is initialized with random normal weights according to original SqueezeNet code [here](https://github.com/DeepScale/SqueezeNet/blob/51147dc0681638c28aad593b9e923f3500117125/SqueezeNet_v1.0/train_val.prototxt#L639). Gives ~5% boost in accuracy for me.

Adding new script `gluoncv/utils/init_mod.py` which houses the function for doing the custom initialization `init_mod_sqnet()`. Custom init functions for other models can be included in the same script.