### PR TITLE
add convenient custom models for detection

### DIFF
--- a/gluoncv/data/transforms/image.py
+++ b/gluoncv/data/transforms/image.py
@@ -45,7 +45,9 @@ def imresize(src, w, h, interp=1):
     >>> print(img.shape)
     (200, 200, 3)
     """
-    return mx.image.imresize(src, w, h, interp)
+    from mxnet.image.image import _get_interp_method as get_interp
+    oh, ow, _ = src.shape
+    return mx.image.imresize(src, w, h, interp=get_interp(interp, (oh, ow, h, w)))
 
 def resize_long(src, size, interp=2):
     """Resizes longer edge to size.

--- a/gluoncv/data/transforms/presets/ssd.py
+++ b/gluoncv/data/transforms/presets/ssd.py
@@ -169,7 +169,7 @@ class SSDDefaultValTransform(object):
         """Apply transform to validation image/label."""
         # resize
         h, w, _ = src.shape
-        img = timage.imresize(src, self._width, self._height)
+        img = timage.imresize(src, self._width, self._height, interp=9)
         bbox = tbbox.resize(label, in_size=(w, h), out_size=(self._width, self._height))
 
         img = mx.nd.image.to_tensor(img)

--- a/gluoncv/data/transforms/presets/yolo.py
+++ b/gluoncv/data/transforms/presets/yolo.py
@@ -178,7 +178,7 @@ class YOLO3DefaultValTransform(object):
         """Apply transform to validation image/label."""
         # resize
         h, w, _ = src.shape
-        img = timage.imresize(src, self._width, self._height)
+        img = timage.imresize(src, self._width, self._height, interp=9)
         bbox = tbbox.resize(label, in_size=(w, h), out_size=(self._width, self._height))
 
         img = mx.nd.image.to_tensor(img)

--- a/gluoncv/model_zoo/__init__.py
+++ b/gluoncv/model_zoo/__init__.py
@@ -1,6 +1,6 @@
 """Gluon Vision Model Zoo"""
 # pylint: disable=wildcard-import
-from .model_zoo import get_model
+from .model_zoo import get_model, get_model_list
 from .model_store import pretrained_model_list
 from .faster_rcnn import *
 from .ssd import *

--- a/gluoncv/model_zoo/model_zoo.py
+++ b/gluoncv/model_zoo/model_zoo.py
@@ -17,7 +17,81 @@ from .se_resnet import *
 from .yolo import *
 from .nasnet import *
 
-__all__ = ['get_model']
+__all__ = ['get_model', 'get_model_list']
+
+_models = {
+    'ssd_300_vgg16_atrous_voc': ssd_300_vgg16_atrous_voc,
+    'ssd_300_vgg16_atrous_coco': ssd_300_vgg16_atrous_coco,
+    'ssd_300_vgg16_atrous_custom' : ssd_300_vgg16_atrous_custom,
+    'ssd_512_vgg16_atrous_voc': ssd_512_vgg16_atrous_voc,
+    'ssd_512_vgg16_atrous_coco': ssd_512_vgg16_atrous_coco,
+    'ssd_512_vgg16_atrous_custom': ssd_512_vgg16_atrous_custom,
+    'ssd_512_resnet18_v1_voc': ssd_512_resnet18_v1_voc,
+    'ssd_512_resnet18_v1_coco': ssd_512_resnet18_v1_coco,
+    'ssd_512_resnet50_v1_voc': ssd_512_resnet50_v1_voc,
+    'ssd_512_resnet50_v1_coco': ssd_512_resnet50_v1_coco,
+    'ssd_512_resnet50_v1_custom': ssd_512_resnet50_v1_custom,
+    'ssd_512_resnet101_v2_voc': ssd_512_resnet101_v2_voc,
+    'ssd_512_resnet152_v2_voc': ssd_512_resnet152_v2_voc,
+    'ssd_512_mobilenet1_0_voc': ssd_512_mobilenet1_0_voc,
+    'ssd_512_mobilenet1_0_coco': ssd_512_mobilenet1_0_coco,
+    'ssd_512_mobilenet1_0_custom': ssd_512_mobilenet1_0_custom,
+    'faster_rcnn_resnet50_v1b_voc': faster_rcnn_resnet50_v1b_voc,
+    'faster_rcnn_resnet50_v1b_coco': faster_rcnn_resnet50_v1b_coco,
+    'faster_rcnn_resnet50_v2a_voc': faster_rcnn_resnet50_v2a_voc,
+    'faster_rcnn_resnet50_v2a_coco': faster_rcnn_resnet50_v2a_coco,
+    'cifar_resnet20_v1': cifar_resnet20_v1,
+    'cifar_resnet56_v1': cifar_resnet56_v1,
+    'cifar_resnet110_v1': cifar_resnet110_v1,
+    'cifar_resnet20_v2': cifar_resnet20_v2,
+    'cifar_resnet56_v2': cifar_resnet56_v2,
+    'cifar_resnet110_v2': cifar_resnet110_v2,
+    'cifar_wideresnet16_10': cifar_wideresnet16_10,
+    'cifar_wideresnet28_10': cifar_wideresnet28_10,
+    'cifar_wideresnet40_8': cifar_wideresnet40_8,
+    'cifar_resnext29_32x4d': cifar_resnext29_32x4d,
+    'cifar_resnext29_16x64d': cifar_resnext29_16x64d,
+    'fcn_resnet50_voc' : get_fcn_voc_resnet50,
+    'fcn_resnet101_voc' : get_fcn_voc_resnet101,
+    'fcn_resnet50_ade' : get_fcn_ade_resnet50,
+    'psp_resnet50_ade' : get_psp_ade_resnet50,
+    'resnet18_v1b' : resnet18_v1b,
+    'resnet34_v1b' : resnet34_v1b,
+    'resnet50_v1b' : resnet50_v1b,
+    'resnet101_v1b' : resnet101_v1b,
+    'resnet152_v1b' : resnet152_v1b,
+    'resnet50_v1c' : resnet50_v1c,
+    'resnet101_v1c' : resnet101_v1c,
+    'resnet152_v1c' : resnet152_v1c,
+    'resnet50_v2a': resnet50_v2a,
+    'resnext50_32x4d' : resnext50_32x4d,
+    'resnext101_32x4d' : resnext101_32x4d,
+    'resnext101_64x4d' : resnext101_64x4d,
+    'se_resnext50_32x4d' : se_resnext50_32x4d,
+    'se_resnext101_32x4d' : se_resnext101_32x4d,
+    'se_resnext101_64x4d' : se_resnext101_64x4d,
+    'senet_52' : senet_52,
+    'senet_103' : senet_103,
+    'senet_154' : senet_154,
+    'se_resnet18_v1' : se_resnet18_v1,
+    'se_resnet34_v1' : se_resnet34_v1,
+    'se_resnet50_v1' : se_resnet50_v1,
+    'se_resnet101_v1' : se_resnet101_v1,
+    'se_resnet152_v1' : se_resnet152_v1,
+    'se_resnet18_v2' : se_resnet18_v2,
+    'se_resnet34_v2' : se_resnet34_v2,
+    'se_resnet50_v2' : se_resnet50_v2,
+    'se_resnet101_v2' : se_resnet101_v2,
+    'se_resnet152_v2' : se_resnet152_v2,
+    'darknet53': darknet53,
+    'yolo3_darknet53_coco': yolo3_darknet53_coco,
+    'yolo3_darknet53_voc': yolo3_darknet53_voc,
+    'yolo3_darknet53_custom': yolo3_darknet53_custom,
+    'nasnet_4_1056' : nasnet_4_1056,
+    'nasnet_5_1538' : nasnet_5_1538,
+    'nasnet_7_1920' : nasnet_7_1920,
+    'nasnet_6_4032' : nasnet_6_4032,
+    }
 
 def get_model(name, **kwargs):
     """Returns a pre-defined model by name
@@ -40,73 +114,7 @@ def get_model(name, **kwargs):
     HybridBlock
         The model.
     """
-    models = {
-        'ssd_300_vgg16_atrous_voc': ssd_300_vgg16_atrous_voc,
-        'ssd_300_vgg16_atrous_coco': ssd_300_vgg16_atrous_coco,
-        'ssd_512_vgg16_atrous_voc': ssd_512_vgg16_atrous_voc,
-        'ssd_512_vgg16_atrous_coco': ssd_512_vgg16_atrous_coco,
-        'ssd_512_resnet18_v1_voc': ssd_512_resnet18_v1_voc,
-        'ssd_512_resnet50_v1_voc': ssd_512_resnet50_v1_voc,
-        'ssd_512_resnet50_v1_coco': ssd_512_resnet50_v1_coco,
-        'ssd_512_resnet101_v2_voc': ssd_512_resnet101_v2_voc,
-        'ssd_512_resnet152_v2_voc': ssd_512_resnet152_v2_voc,
-        'ssd_512_mobilenet1_0_voc': ssd_512_mobilenet1_0_voc,
-        'ssd_512_mobilenet1_0_coco': ssd_512_mobilenet1_0_coco,
-        'faster_rcnn_resnet50_v1b_voc': faster_rcnn_resnet50_v1b_voc,
-        'faster_rcnn_resnet50_v1b_coco': faster_rcnn_resnet50_v1b_coco,
-        'faster_rcnn_resnet50_v2a_voc': faster_rcnn_resnet50_v2a_voc,
-        'faster_rcnn_resnet50_v2a_coco': faster_rcnn_resnet50_v2a_coco,
-        'cifar_resnet20_v1': cifar_resnet20_v1,
-        'cifar_resnet56_v1': cifar_resnet56_v1,
-        'cifar_resnet110_v1': cifar_resnet110_v1,
-        'cifar_resnet20_v2': cifar_resnet20_v2,
-        'cifar_resnet56_v2': cifar_resnet56_v2,
-        'cifar_resnet110_v2': cifar_resnet110_v2,
-        'cifar_wideresnet16_10': cifar_wideresnet16_10,
-        'cifar_wideresnet28_10': cifar_wideresnet28_10,
-        'cifar_wideresnet40_8': cifar_wideresnet40_8,
-        'cifar_resnext29_32x4d': cifar_resnext29_32x4d,
-        'cifar_resnext29_16x64d': cifar_resnext29_16x64d,
-        'fcn_resnet50_voc' : get_fcn_voc_resnet50,
-        'fcn_resnet101_voc' : get_fcn_voc_resnet101,
-        'fcn_resnet50_ade' : get_fcn_ade_resnet50,
-        'psp_resnet50_ade' : get_psp_ade_resnet50,
-        'resnet18_v1b' : resnet18_v1b,
-        'resnet34_v1b' : resnet34_v1b,
-        'resnet50_v1b' : resnet50_v1b,
-        'resnet101_v1b' : resnet101_v1b,
-        'resnet152_v1b' : resnet152_v1b,
-        'resnet50_v1c' : resnet50_v1c,
-        'resnet101_v1c' : resnet101_v1c,
-        'resnet152_v1c' : resnet152_v1c,
-        'resnet50_v2a': resnet50_v2a,
-        'resnext50_32x4d' : resnext50_32x4d,
-        'resnext101_32x4d' : resnext101_32x4d,
-        'resnext101_64x4d' : resnext101_64x4d,
-        'se_resnext50_32x4d' : se_resnext50_32x4d,
-        'se_resnext101_32x4d' : se_resnext101_32x4d,
-        'se_resnext101_64x4d' : se_resnext101_64x4d,
-        'senet_52' : senet_52,
-        'senet_103' : senet_103,
-        'senet_154' : senet_154,
-        'se_resnet18_v1' : se_resnet18_v1,
-        'se_resnet34_v1' : se_resnet34_v1,
-        'se_resnet50_v1' : se_resnet50_v1,
-        'se_resnet101_v1' : se_resnet101_v1,
-        'se_resnet152_v1' : se_resnet152_v1,
-        'se_resnet18_v2' : se_resnet18_v2,
-        'se_resnet34_v2' : se_resnet34_v2,
-        'se_resnet50_v2' : se_resnet50_v2,
-        'se_resnet101_v2' : se_resnet101_v2,
-        'se_resnet152_v2' : se_resnet152_v2,
-        'darknet53': darknet53,
-        'yolo3_darknet53_coco': yolo3_darknet53_coco,
-        'yolo3_darknet53_voc': yolo3_darknet53_voc,
-        'nasnet_4_1056' : nasnet_4_1056,
-        'nasnet_5_1538' : nasnet_5_1538,
-        'nasnet_7_1920' : nasnet_7_1920,
-        'nasnet_6_4032' : nasnet_6_4032,
-        }
+
     try:
         net = gluon.model_zoo.vision.get_model(name, **kwargs)
         return net
@@ -114,7 +122,18 @@ def get_model(name, **kwargs):
         upstream_supported = str(e)
         # avoid raising inside which cause a bit messy error message
     name = name.lower()
-    if name not in models:
-        raise ValueError('%s\n\t%s' % (upstream_supported, '\n\t'.join(sorted(models.keys()))))
-    net = models[name](**kwargs)
+    if name not in _models:
+        raise ValueError('%s\n\t%s' % (upstream_supported, '\n\t'.join(sorted(_models.keys()))))
+    net = _models[name](**kwargs)
     return net
+
+def get_model_list():
+    """Get the entire list of model names in model_zoo.
+
+    Returns
+    -------
+    list of str
+        Entire list of model names in model_zoo.
+
+    """
+    return _models.keys()

--- a/gluoncv/model_zoo/ssd/ssd.py
+++ b/gluoncv/model_zoo/ssd/ssd.py
@@ -11,21 +11,26 @@ from .anchor import SSDAnchorGenerator
 from ...nn.predictor import ConvPredictor
 from ...nn.coder import MultiPerClassDecoder, NormalizedBoxCenterDecoder
 from .vgg_atrous import vgg16_atrous_300, vgg16_atrous_512
-# from ...utils import set_lr_mult
 from ...data import VOCDetection
 
 __all__ = ['SSD', 'get_ssd',
            'ssd_300_vgg16_atrous_voc',
            'ssd_300_vgg16_atrous_coco',
+           'ssd_300_vgg16_atrous_custom',
            'ssd_512_vgg16_atrous_voc',
            'ssd_512_vgg16_atrous_coco',
+           'ssd_512_vgg16_atrous_custom',
            'ssd_512_resnet18_v1_voc',
+           'ssd_512_resnet18_v1_coco',
+           'ssd_512_resnet18_v1_custom',
            'ssd_512_resnet50_v1_voc',
            'ssd_512_resnet50_v1_coco',
+           'ssd_512_resnet50_v1_custom',
            'ssd_512_resnet101_v2_voc',
            'ssd_512_resnet152_v2_voc',
            'ssd_512_mobilenet1_0_voc',
-           'ssd_512_mobilenet1_0_coco',]
+           'ssd_512_mobilenet1_0_coco',
+           'ssd_512_mobilenet1_0_custom',]
 
 
 class SSD(HybridBlock):
@@ -110,7 +115,6 @@ class SSD(HybridBlock):
         assert num_layers > 0, "SSD require at least one layer, suggest multiple."
         self._num_layers = num_layers
         self.classes = classes
-        self.num_classes = len(classes) + 1
         self.nms_thresh = nms_thresh
         self.nms_topk = nms_topk
         self.post_nms = post_nms
@@ -135,10 +139,22 @@ class SSD(HybridBlock):
                 self.anchor_generators.add(anchor_generator)
                 asz = max(asz // 2, 16)  # pre-compute larger than 16x16 anchor map
                 num_anchors = anchor_generator.num_depth
-                self.class_predictors.add(ConvPredictor(num_anchors * self.num_classes))
+                self.class_predictors.add(ConvPredictor(num_anchors * (len(self.classes) + 1)))
                 self.box_predictors.add(ConvPredictor(num_anchors * 4))
             self.bbox_decoder = NormalizedBoxCenterDecoder(stds)
-            self.cls_decoder = MultiPerClassDecoder(self.num_classes, thresh=0.01)
+            self.cls_decoder = MultiPerClassDecoder(len(self.classes) + 1, thresh=0.01)
+
+    @property
+    def num_classes(self):
+        """Return number of foreground classes.
+
+        Returns
+        -------
+        int
+            Number of foreground classes
+
+        """
+        return len(self.classes)
 
     def set_nms(self, nms_thresh=0.45, nms_topk=400, post_nms=100):
         """Set non-maximum suppression parameters.
@@ -175,7 +191,7 @@ class SSD(HybridBlock):
                      for feat, bp in zip(features, self.box_predictors)]
         anchors = [F.reshape(ag(feat), shape=(1, -1))
                    for feat, ag in zip(features, self.anchor_generators)]
-        cls_preds = F.concat(*cls_preds, dim=1).reshape((0, -1, self.num_classes))
+        cls_preds = F.concat(*cls_preds, dim=1).reshape((0, -1, self.num_classes + 1))
         box_preds = F.concat(*box_preds, dim=1).reshape((0, -1, 4))
         anchors = F.concat(*anchors, dim=1).reshape((1, -1, 4))
         if autograd.is_training():
@@ -183,7 +199,7 @@ class SSD(HybridBlock):
         bboxes = self.bbox_decoder(box_preds, anchors)
         cls_ids, scores = self.cls_decoder(F.softmax(cls_preds, axis=-1))
         results = []
-        for i in range(self.num_classes - 1):
+        for i in range(self.num_classes):
             cls_id = cls_ids.slice_axis(axis=-1, begin=i, end=i+1)
             score = scores.slice_axis(axis=-1, begin=i, end=i+1)
             # per class results
@@ -200,6 +216,26 @@ class SSD(HybridBlock):
         scores = F.slice_axis(result, axis=2, begin=1, end=2)
         bboxes = F.slice_axis(result, axis=2, begin=2, end=6)
         return ids, scores, bboxes
+
+    def reset_class(self, classes):
+        """Reset class categories and class predictors.
+
+        Parameters
+        ----------
+        classes : iterable of str
+            The new categories. ['apple', 'orange'] for example.
+
+        """
+        self.classes = classes
+        # replace class predictors
+        with self.name_scope():
+            class_predictors = nn.HybridSequential(prefix=self.class_predictors.prefix)
+            for i, ag in zip(range(len(self.class_predictors)), self.anchor_generators):
+                prefix = self.class_predictors[i].prefix
+                new_cp = ConvPredictor(ag.num_depth * (self.num_classes + 1), prefix=prefix)
+                new_cp.collect_params().initialize()
+                class_predictors.add(new_cp)
+            self.class_predictors = class_predictors
 
 def get_ssd(name, base_size, features, filters, sizes, ratios, steps, classes,
             dataset, pretrained=False, pretrained_base=True, ctx=mx.cpu(),
@@ -260,7 +296,6 @@ def get_ssd(name, base_size, features, filters, sizes, ratios, steps, classes,
         from ..model_store import get_model_file
         full_name = '_'.join(('ssd', str(base_size), name, dataset))
         net.load_params(get_model_file(full_name, root=root), ctx=ctx)
-    # set_lr_mult(net, ".*_bias", 2.0)
     return net
 
 def ssd_300_vgg16_atrous_voc(pretrained=False, pretrained_base=True, **kwargs):
@@ -312,6 +347,44 @@ def ssd_300_vgg16_atrous_coco(pretrained=False, pretrained_base=True, **kwargs):
                   pretrained_base=pretrained_base, **kwargs)
     return net
 
+def ssd_300_vgg16_atrous_custom(classes, pretrained_base=True, transfer=None, **kwargs):
+    """SSD architecture with VGG16 atrous 300x300 base network for COCO.
+
+    Parameters
+    ----------
+    classes : iterable of str
+        Names of custom foreground classes. `len(classes)` is the number of foreground classes.
+    pretrained_base : bool, optional, default is True
+        Load pretrained base network, the extra layers are randomized.
+    transfer : str or None
+        If not `None`, will try to reuse pre-trained weights from SSD networks trained on other
+        datasets.
+
+    Returns
+    -------
+    HybridBlock
+        A SSD detection network.
+
+    Example
+    -------
+    >>> net = ssd_300_vgg16_atrous_custom(classes=['a', 'b', 'c'], pretrained_base=True)
+    >>> net = ssd_300_vgg16_atrous_custom(classes=['foo', 'bar'], transfer='coco')
+
+    """
+    if transfer is None:
+        kwargs['pretrained'] = False
+        net = get_ssd('vgg16_atrous', 300, features=vgg16_atrous_300, filters=None,
+                      sizes=[21, 45, 99, 153, 207, 261, 315],
+                      ratios=[[1, 2, 0.5]] + [[1, 2, 0.5, 3, 1.0/3]] * 3 + [[1, 2, 0.5]] * 2,
+                      steps=[8, 16, 32, 64, 100, 300],
+                      classes=classes, dataset='',
+                      pretrained_base=pretrained_base, **kwargs)
+    else:
+        from ...model_zoo import get_model
+        net = get_model('ssd_300_vgg16_atrous_' + str(transfer), pretrained=True, **kwargs)
+        net.reset_class(classes)
+    return net
+
 def ssd_512_vgg16_atrous_voc(pretrained=False, pretrained_base=True, **kwargs):
     """SSD architecture with VGG16 atrous 512x512 base network.
 
@@ -334,6 +407,68 @@ def ssd_512_vgg16_atrous_voc(pretrained=False, pretrained_base=True, **kwargs):
                   steps=[8, 16, 32, 64, 128, 256, 512],
                   classes=classes, dataset='voc', pretrained=pretrained,
                   pretrained_base=pretrained_base, **kwargs)
+    return net
+
+def ssd_512_vgg16_atrous_coco(pretrained=False, pretrained_base=True, **kwargs):
+    """SSD architecture with VGG16 atrous layers for COCO.
+
+    Parameters
+    ----------
+    pretrained : bool, optional, default is False
+        Load pretrained weights.
+    pretrained_base : bool, optional, default is True
+        Load pretrained base network, the extra layers are randomized.
+
+    Returns
+    -------
+    HybridBlock
+        A SSD detection network.
+    """
+    from ...data import COCODetection
+    classes = COCODetection.CLASSES
+    return get_ssd('vgg16_atrous', 512, features=vgg16_atrous_512, filters=None,
+                   sizes=[51.2, 76.8, 153.6, 230.4, 307.2, 384.0, 460.8, 537.6],
+                   ratios=[[1, 2, 0.5]] + [[1, 2, 0.5, 3, 1.0/3]] * 4 + [[1, 2, 0.5]] * 2,
+                   steps=[8, 16, 32, 64, 128, 256, 512],
+                   classes=classes, dataset='coco', pretrained=pretrained,
+                   pretrained_base=pretrained_base, **kwargs)
+
+def ssd_512_vgg16_atrous_custom(classes, pretrained_base=True, transfer=None, **kwargs):
+    """SSD architecture with VGG16 atrous 300x300 base network for COCO.
+
+    Parameters
+    ----------
+    classes : iterable of str
+        Names of custom foreground classes. `len(classes)` is the number of foreground classes.
+    pretrained_base : bool, optional, default is True
+        Load pretrained base network, the extra layers are randomized.
+    transfer : str or None
+        If not `None`, will try to reuse pre-trained weights from SSD networks trained on other
+        datasets.
+
+    Returns
+    -------
+    HybridBlock
+        A SSD detection network.
+
+    Example
+    -------
+    >>> net = ssd_512_vgg16_atrous_custom(classes=['a', 'b', 'c'], pretrained_base=True)
+    >>> net = ssd_512_vgg16_atrous_custom(classes=['foo', 'bar'], transfer='coco')
+
+    """
+    if transfer is None:
+        kwargs['pretrained'] = False
+        net = get_ssd('vgg16_atrous', 512, features=vgg16_atrous_512, filters=None,
+                      sizes=[51.2, 76.8, 153.6, 230.4, 307.2, 384.0, 460.8, 537.6],
+                      ratios=[[1, 2, 0.5]] + [[1, 2, 0.5, 3, 1.0/3]] * 4 + [[1, 2, 0.5]] * 2,
+                      steps=[8, 16, 32, 64, 128, 256, 512],
+                      classes=classes, dataset='',
+                      pretrained_base=pretrained_base, **kwargs)
+    else:
+        from ...model_zoo import get_model
+        net = get_model('ssd_512_vgg16_atrous_' + str(transfer), pretrained=True, **kwargs)
+        net.reset_class(classes)
     return net
 
 def ssd_512_resnet18_v1_voc(pretrained=False, pretrained_base=True, **kwargs):
@@ -361,6 +496,72 @@ def ssd_512_resnet18_v1_voc(pretrained=False, pretrained_base=True, **kwargs):
                    classes=classes, dataset='voc', pretrained=pretrained,
                    pretrained_base=pretrained_base, **kwargs)
 
+def ssd_512_resnet18_v1_coco(pretrained=False, pretrained_base=True, **kwargs):
+    """SSD architecture with ResNet v1 18 layers.
+
+    Parameters
+    ----------
+    pretrained : bool, optional, default is False
+        Load pretrained weights.
+    pretrained_base : bool, optional, default is True
+        Load pretrained base network, the extra layers are randomized.
+
+    Returns
+    -------
+    HybridBlock
+        A SSD detection network.
+    """
+    from ...data import COCODetection
+    classes = COCODetection.CLASSES
+    return get_ssd('resnet18_v1', 512,
+                   features=['stage3_activation1', 'stage4_activation1'],
+                   filters=[512, 512, 256, 256],
+                   sizes=[51.2, 102.4, 189.4, 276.4, 363.52, 450.6, 492],
+                   ratios=[[1, 2, 0.5]] + [[1, 2, 0.5, 3, 1.0/3]] * 3 + [[1, 2, 0.5]] * 2,
+                   steps=[8, 16, 32, 64, 128, 256, 512],
+                   classes=classes, dataset='coco', pretrained=pretrained,
+                   pretrained_base=pretrained_base, **kwargs)
+
+def ssd_512_resnet18_v1_custom(classes, pretrained_base=True, transfer=None, **kwargs):
+    """SSD architecture with ResNet18 v1 512 base network for COCO.
+
+    Parameters
+    ----------
+    classes : iterable of str
+        Names of custom foreground classes. `len(classes)` is the number of foreground classes.
+    pretrained_base : bool, optional, default is True
+        Load pretrained base network, the extra layers are randomized.
+    transfer : str or None
+        If not `None`, will try to reuse pre-trained weights from SSD networks trained on other
+        datasets.
+
+    Returns
+    -------
+    HybridBlock
+        A SSD detection network.
+
+    Example
+    -------
+    >>> net = ssd_512_resnet18_v1_custom(classes=['a', 'b', 'c'], pretrained_base=True)
+    >>> net = ssd_512_resnet18_v1_custom(classes=['foo', 'bar'], transfer='voc')
+
+    """
+    if transfer is None:
+        kwargs['pretrained'] = False
+        net = get_ssd('resnet18_v1', 512,
+                      features=['stage3_activation1', 'stage4_activation1'],
+                      filters=[512, 512, 256, 256],
+                      sizes=[51.2, 102.4, 189.4, 276.4, 363.52, 450.6, 492],
+                      ratios=[[1, 2, 0.5]] + [[1, 2, 0.5, 3, 1.0/3]] * 3 + [[1, 2, 0.5]] * 2,
+                      steps=[8, 16, 32, 64, 128, 256, 512],
+                      classes=classes, dataset='',
+                      pretrained_base=pretrained_base, **kwargs)
+    else:
+        from ...model_zoo import get_model
+        net = get_model('ssd_512_resnet18_v1_' + str(transfer), pretrained=True, **kwargs)
+        net.reset_class(classes)
+    return net
+
 def ssd_512_resnet50_v1_voc(pretrained=False, pretrained_base=True, **kwargs):
     """SSD architecture with ResNet v1 50 layers.
 
@@ -385,6 +586,72 @@ def ssd_512_resnet50_v1_voc(pretrained=False, pretrained_base=True, **kwargs):
                    steps=[16, 32, 64, 128, 256, 512],
                    classes=classes, dataset='voc', pretrained=pretrained,
                    pretrained_base=pretrained_base, **kwargs)
+
+def ssd_512_resnet50_v1_coco(pretrained=False, pretrained_base=True, **kwargs):
+    """SSD architecture with ResNet v1 50 layers for COCO.
+
+    Parameters
+    ----------
+    pretrained : bool, optional, default is False
+        Load pretrained weights.
+    pretrained_base : bool, optional, default is True
+        Load pretrained base network, the extra layers are randomized.
+
+    Returns
+    -------
+    HybridBlock
+        A SSD detection network.
+    """
+    from ...data import COCODetection
+    classes = COCODetection.CLASSES
+    return get_ssd('resnet50_v1', 512,
+                   features=['stage3_activation5', 'stage4_activation2'],
+                   filters=[512, 512, 256, 256],
+                   sizes=[51.2, 133.12, 215.04, 296.96, 378.88, 460.8, 542.72],
+                   ratios=[[1, 2, 0.5]] + [[1, 2, 0.5, 3, 1.0/3]] * 3 + [[1, 2, 0.5]] * 2,
+                   steps=[16, 32, 64, 128, 256, 512],
+                   classes=classes, dataset='coco', pretrained=pretrained,
+                   pretrained_base=pretrained_base, **kwargs)
+
+def ssd_512_resnet50_v1_custom(classes, pretrained_base=True, transfer=None, **kwargs):
+    """SSD architecture with ResNet50 v1 512 base network for custom dataset.
+
+    Parameters
+    ----------
+    classes : iterable of str
+        Names of custom foreground classes. `len(classes)` is the number of foreground classes.
+    pretrained_base : bool, optional, default is True
+        Load pretrained base network, the extra layers are randomized.
+    transfer : str or None
+        If not `None`, will try to reuse pre-trained weights from SSD networks trained on other
+        datasets.
+
+    Returns
+    -------
+    HybridBlock
+        A SSD detection network.
+
+    Example
+    -------
+    >>> net = ssd_512_resnet50_v1_custom(classes=['a', 'b', 'c'], pretrained_base=True)
+    >>> net = ssd_512_resnet50_v1_custom(classes=['foo', 'bar'], transfer='voc')
+
+    """
+    if transfer is None:
+        kwargs['pretrained'] = False
+        net = get_ssd('resnet50_v1', 512,
+                      features=['stage3_activation5', 'stage4_activation2'],
+                      filters=[512, 512, 256, 256],
+                      sizes=[51.2, 133.12, 215.04, 296.96, 378.88, 460.8, 542.72],
+                      ratios=[[1, 2, 0.5]] + [[1, 2, 0.5, 3, 1.0/3]] * 3 + [[1, 2, 0.5]] * 2,
+                      steps=[16, 32, 64, 128, 256, 512],
+                      classes=classes, dataset='',
+                      pretrained_base=pretrained_base, **kwargs)
+    else:
+        from ...model_zoo import get_model
+        net = get_model('ssd_512_resnet50_v1_' + str(transfer), pretrained=True, **kwargs)
+        net.reset_class(classes)
+    return net
 
 def ssd_512_resnet101_v2_voc(pretrained=False, pretrained_base=True, **kwargs):
     """SSD architecture with ResNet v2 101 layers.
@@ -487,53 +754,42 @@ def ssd_512_mobilenet1_0_coco(pretrained=False, pretrained_base=True, **kwargs):
                    classes=classes, dataset='coco', pretrained=pretrained,
                    pretrained_base=pretrained_base, **kwargs)
 
-def ssd_512_vgg16_atrous_coco(pretrained=False, pretrained_base=True, **kwargs):
-    """SSD architecture with VGG16 atrous layers for COCO.
+def ssd_512_mobilenet1_0_custom(classes, pretrained_base=True, transfer=None, **kwargs):
+    """SSD architecture with mobilenet1.0 512 base network for custom dataset.
 
     Parameters
     ----------
-    pretrained : bool, optional, default is False
-        Load pretrained weights.
+    classes : iterable of str
+        Names of custom foreground classes. `len(classes)` is the number of foreground classes.
     pretrained_base : bool, optional, default is True
         Load pretrained base network, the extra layers are randomized.
+    transfer : str or None
+        If not `None`, will try to reuse pre-trained weights from SSD networks trained on other
+        datasets.
 
     Returns
     -------
     HybridBlock
         A SSD detection network.
-    """
-    from ...data import COCODetection
-    classes = COCODetection.CLASSES
-    return get_ssd('vgg16_atrous', 512, features=vgg16_atrous_512, filters=None,
-                   sizes=[51.2, 76.8, 153.6, 230.4, 307.2, 384.0, 460.8, 537.6],
-                   ratios=[[1, 2, 0.5]] + [[1, 2, 0.5, 3, 1.0/3]] * 4 + [[1, 2, 0.5]] * 2,
-                   steps=[8, 16, 32, 64, 128, 256, 512],
-                   classes=classes, dataset='coco', pretrained=pretrained,
-                   pretrained_base=pretrained_base, **kwargs)
 
-
-def ssd_512_resnet50_v1_coco(pretrained=False, pretrained_base=True, **kwargs):
-    """SSD architecture with ResNet v1 50 layers for COCO.
-
-    Parameters
-    ----------
-    pretrained : bool, optional, default is False
-        Load pretrained weights.
-    pretrained_base : bool, optional, default is True
-        Load pretrained base network, the extra layers are randomized.
-
-    Returns
+    Example
     -------
-    HybridBlock
-        A SSD detection network.
+    >>> net = ssd_512_mobilenet1_0_custom(classes=['a', 'b', 'c'], pretrained_base=True)
+    >>> net = ssd_512_mobilenet1_0_custom(classes=['foo', 'bar'], transfer='voc')
+
     """
-    from ...data import COCODetection
-    classes = COCODetection.CLASSES
-    return get_ssd('resnet50_v1', 512,
-                   features=['stage3_activation5', 'stage4_activation2'],
-                   filters=[512, 512, 256, 256],
-                   sizes=[51.2, 133.12, 215.04, 296.96, 378.88, 460.8, 542.72],
-                   ratios=[[1, 2, 0.5]] + [[1, 2, 0.5, 3, 1.0/3]] * 3 + [[1, 2, 0.5]] * 2,
-                   steps=[16, 32, 64, 128, 256, 512],
-                   classes=classes, dataset='coco', pretrained=pretrained,
-                   pretrained_base=pretrained_base, **kwargs)
+    if transfer is None:
+        kwargs['pretrained'] = False
+        net = get_ssd('mobilenet1.0', 512,
+                      features=['relu22_fwd', 'relu26_fwd'],
+                      filters=[512, 512, 256, 256],
+                      sizes=[51.2, 102.4, 189.4, 276.4, 363.52, 450.6, 492],
+                      ratios=[[1, 2, 0.5]] + [[1, 2, 0.5, 3, 1.0/3]] * 3 + [[1, 2, 0.5]] * 2,
+                      steps=[16, 32, 64, 128, 256, 512],
+                      classes=classes, dataset='',
+                      pretrained_base=pretrained_base, **kwargs)
+    else:
+        from ...model_zoo import get_model
+        net = get_model('ssd_512_mobilenet1_0_' + str(transfer), pretrained=True, **kwargs)
+        net.reset_class(classes)
+    return net

--- a/tests/unittests/test_model_zoo.py
+++ b/tests/unittests/test_model_zoo.py
@@ -26,6 +26,15 @@ import numpy as np
 import gluoncv as gcv
 from common import try_gpu, with_cpu
 
+def test_get_all_models():
+    names = gcv.model_zoo.get_model_list()
+    for name in names:
+        kwargs = {}
+        if 'custom' in name:
+            kwargs['classes'] = ['a', 'b']
+        net = gcv.model_zoo.get_model(name, pretrained=False, **kwargs)
+        assert isinstance(net, mx.gluon.Block), '{}'.format(name)
+
 @with_cpu(0)
 def _test_model_list(model_list, ctx, x, **kwargs):
     for model in model_list:


### PR DESCRIPTION
- Change SSD/YOLO validation transform resize function to use interp=9(automatic)
- provide convenient functions, e.g.

```python

net = gcv.model_zoo.get_model('yolo3_darknet53_custom', classes=['foo', 'bar'], transfer='voc')
```