### PR TITLE
Allowing training from scratch on Segmentation

### DIFF
--- a/gluoncv/model_zoo/fcn.py
+++ b/gluoncv/model_zoo/fcn.py
@@ -37,7 +37,7 @@ class FCN(SegBaseModel):
     def __init__(self, nclass, backbone='resnet50', norm_layer=nn.BatchNorm,
                  aux=True, ctx=cpu(), pretrained=True, **kwargs):
         super(FCN, self).__init__(nclass, aux, backbone, ctx=ctx,
-                                  norm_layer=norm_layer, pretrained = pretrained, **kwargs)
+                                  norm_layer=norm_layer, pretrained=pretrained, **kwargs)
         with self.name_scope():
             self.head = _FCNHead(2048, nclass, norm_layer=norm_layer, **kwargs)
             self.head.initialize(ctx=ctx)
@@ -85,7 +85,7 @@ class _FCNHead(HybridBlock):
         return self.block(x)
 
 
-def get_fcn(dataset='pascal_voc', backbone='resnet50', pretrained=True,
+def get_fcn(dataset='pascal_voc', backbone='resnet50', pretrained=False,
             root='~/.mxnet/models', ctx=cpu(0), **kwargs):
     r"""FCN model from the paper `"Fully Convolutional Network for semantic segmentation"
     <https://people.eecs.berkeley.edu/~jonlong/long_shelhamer_fcn.pdf>`_
@@ -107,6 +107,7 @@ def get_fcn(dataset='pascal_voc', backbone='resnet50', pretrained=True,
     >>> print(model)
     """
     from ..data.pascal_voc.segmentation import VOCSegmentation
+    from ..data.pascal_aug.segmentation import VOCAugSegmentation    
     from ..data.ade20k.segmentation import ADE20KSegmentation
     acronyms = {
         'pascal_voc': 'voc',
@@ -117,7 +118,7 @@ def get_fcn(dataset='pascal_voc', backbone='resnet50', pretrained=True,
         'ade20k': ADE20KSegmentation,
     }
     # infer number of classes
-    model = FCN(datasets[dataset].NUM_CLASS, backbone=backbone, pretrained = pretrained, 
+    model = FCN(datasets[dataset].NUM_CLASS, backbone=backbone, pretrained=pretrained, 
                                             ctx=ctx, **kwargs)
     if pretrained:
         from .model_store import get_model_file

--- a/gluoncv/model_zoo/fcn.py
+++ b/gluoncv/model_zoo/fcn.py
@@ -89,7 +89,7 @@ class _FCNHead(HybridBlock):
 
 
 def get_fcn(dataset='pascal_voc', backbone='resnet50', pretrained=False,
-            root='~/.mxnet/models', ctx=cpu(0), backbone_pretrained=True, **kwargs):
+            root='~/.mxnet/models', ctx=cpu(0), pretrained_base=True, **kwargs):
     r"""FCN model from the paper `"Fully Convolutional Network for semantic segmentation"
     <https://people.eecs.berkeley.edu/~jonlong/long_shelhamer_fcn.pdf>`_
 
@@ -103,7 +103,7 @@ def get_fcn(dataset='pascal_voc', backbone='resnet50', pretrained=False,
         The context in which to load the pretrained weights.
     root : str, default '~/.mxnet/models'
         Location for keeping the model parameters.
-    backbone_pretrained : bool, default True
+    pretrained_base : bool, default True
         This will load pretrained backbone network, that was trained on ImageNet.
 
     Examples
@@ -111,9 +111,6 @@ def get_fcn(dataset='pascal_voc', backbone='resnet50', pretrained=False,
     >>> model = get_fcn(dataset='pascal_voc', backbone='resnet50', pretrained=False)
     >>> print(model)
     """
-    if pretrained is True and backbone_pretrained is not True:
-        import warnings
-        warnings.warn('Ignoring backbone_pretrained and setting it to True.')
 
     from ..data.pascal_voc.segmentation import VOCSegmentation
     from ..data.pascal_aug.segmentation import VOCAugSegmentation
@@ -129,7 +126,7 @@ def get_fcn(dataset='pascal_voc', backbone='resnet50', pretrained=False,
         'ade20k': ADE20KSegmentation,
     }
     # infer number of classes
-    model = FCN(datasets[dataset].NUM_CLASS, backbone=backbone, pretrained=backbone_pretrained,
+    model = FCN(datasets[dataset].NUM_CLASS, backbone=backbone, pretrained=pretrained_base,
                 ctx=ctx, **kwargs)
     if pretrained:
         from .model_store import get_model_file

--- a/gluoncv/model_zoo/fcn.py
+++ b/gluoncv/model_zoo/fcn.py
@@ -118,8 +118,7 @@ def get_fcn(dataset='pascal_voc', backbone='resnet50', pretrained=False,
         'ade20k': ADE20KSegmentation,
     }
     # infer number of classes
-    model = FCN(datasets[dataset].NUM_CLASS, backbone=backbone, pretrained=pretrained, 
-                                            ctx=ctx, **kwargs)
+    model = FCN(datasets[dataset].NUM_CLASS, backbone=backbone, pretrained=pretrained, ctx=ctx, **kwargs)
     if pretrained:
         from .model_store import get_model_file
         model.load_params(get_model_file('fcn_%s_%s'%(backbone, acronyms[dataset]),

--- a/gluoncv/model_zoo/fcn.py
+++ b/gluoncv/model_zoo/fcn.py
@@ -42,11 +42,11 @@ class FCN(SegBaseModel):
         super(FCN, self).__init__(nclass, aux, backbone, ctx=ctx,
                                   norm_layer=norm_layer, **kwargs)
         with self.name_scope():
-            self.head = _FCNHead(2048, nclass, norm_layer=norm_layer, **kwargs)
+            self.head = _FCNHead(2048, nclass, norm_layer=norm_layer)
             self.head.initialize(ctx=ctx)
             self.head.collect_params().setattr('lr_mult', 10)
             if self.aux:
-                self.auxlayer = _FCNHead(1024, nclass, norm_layer=norm_layer, **kwargs)
+                self.auxlayer = _FCNHead(1024, nclass, norm_layer=norm_layer)
                 self.auxlayer.initialize(ctx=ctx)
                 self.auxlayer.collect_params().setattr('lr_mult', 10)
 
@@ -69,7 +69,7 @@ class FCN(SegBaseModel):
 
 class _FCNHead(HybridBlock):
     # pylint: disable=redefined-outer-name
-    def __init__(self, in_channels, channels, norm_layer, norm_kwargs={}, **kwargs):
+    def __init__(self, in_channels, channels, norm_layer, norm_kwargs={}):
         super(_FCNHead, self).__init__()
         with self.name_scope():
             self.block = nn.HybridSequential()

--- a/gluoncv/model_zoo/fcn.py
+++ b/gluoncv/model_zoo/fcn.py
@@ -107,7 +107,7 @@ def get_fcn(dataset='pascal_voc', backbone='resnet50', pretrained=False,
     >>> print(model)
     """
     from ..data.pascal_voc.segmentation import VOCSegmentation
-    from ..data.pascal_aug.segmentation import VOCAugSegmentation    
+    from ..data.pascal_aug.segmentation import VOCAugSegmentation
     from ..data.ade20k.segmentation import ADE20KSegmentation
     acronyms = {
         'pascal_voc': 'voc',

--- a/gluoncv/model_zoo/fcn.py
+++ b/gluoncv/model_zoo/fcn.py
@@ -126,7 +126,7 @@ def get_fcn(dataset='pascal_voc', backbone='resnet50', pretrained=False,
         'ade20k': ADE20KSegmentation,
     }
     # infer number of classes
-    model = FCN(datasets[dataset].NUM_CLASS, backbone=backbone, pretrained=pretrained_base,
+    model = FCN(datasets[dataset].NUM_CLASS, backbone=backbone, pretrained_base=pretrained_base,
                 ctx=ctx, **kwargs)
     if pretrained:
         from .model_store import get_model_file

--- a/gluoncv/model_zoo/fcn.py
+++ b/gluoncv/model_zoo/fcn.py
@@ -116,13 +116,16 @@ def get_fcn(dataset='pascal_voc', backbone='resnet50', pretrained=False,
         warnings.warn('Ignoring backbone_pretrained and setting it to True.')
 
     from ..data.pascal_voc.segmentation import VOCSegmentation
+    from ..data.pascal_aug.segmentation import VOCAugSegmentation
     from ..data.ade20k.segmentation import ADE20KSegmentation
     acronyms = {
         'pascal_voc': 'voc',
+        'pascal_aug': 'voc',
         'ade20k': 'ade',
     }
     datasets = {
         'pascal_voc': VOCSegmentation,
+        'pascal_aug': VOCAugSegmentation,
         'ade20k': ADE20KSegmentation,
     }
     # infer number of classes

--- a/gluoncv/model_zoo/fcn.py
+++ b/gluoncv/model_zoo/fcn.py
@@ -35,9 +35,9 @@ class FCN(SegBaseModel):
     """
     # pylint: disable=arguments-differ
     def __init__(self, nclass, backbone='resnet50', norm_layer=nn.BatchNorm,
-                 aux=True, ctx=cpu(), **kwargs):
+                 aux=True, ctx=cpu(), pretrained=True, **kwargs):
         super(FCN, self).__init__(nclass, aux, backbone, ctx=ctx,
-                                  norm_layer=norm_layer, **kwargs)
+                                  norm_layer=norm_layer, pretrained = pretrained, **kwargs)
         with self.name_scope():
             self.head = _FCNHead(2048, nclass, norm_layer=norm_layer, **kwargs)
             self.head.initialize(ctx=ctx)
@@ -85,7 +85,7 @@ class _FCNHead(HybridBlock):
         return self.block(x)
 
 
-def get_fcn(dataset='pascal_voc', backbone='resnet50', pretrained=False,
+def get_fcn(dataset='pascal_voc', backbone='resnet50', pretrained=True,
             root='~/.mxnet/models', ctx=cpu(0), **kwargs):
     r"""FCN model from the paper `"Fully Convolutional Network for semantic segmentation"
     <https://people.eecs.berkeley.edu/~jonlong/long_shelhamer_fcn.pdf>`_
@@ -107,20 +107,18 @@ def get_fcn(dataset='pascal_voc', backbone='resnet50', pretrained=False,
     >>> print(model)
     """
     from ..data.pascal_voc.segmentation import VOCSegmentation
-    from ..data.pascal_aug.segmentation import VOCAugSegmentation
     from ..data.ade20k.segmentation import ADE20KSegmentation
     acronyms = {
         'pascal_voc': 'voc',
-        'pascal_aug': 'voc',
         'ade20k': 'ade',
     }
     datasets = {
         'pascal_voc': VOCSegmentation,
-        'pascal_aug': VOCAugSegmentation,
         'ade20k': ADE20KSegmentation,
     }
     # infer number of classes
-    model = FCN(datasets[dataset].NUM_CLASS, backbone=backbone, ctx=ctx, **kwargs)
+    model = FCN(datasets[dataset].NUM_CLASS, backbone=backbone, pretrained = pretrained, 
+                                            ctx=ctx, **kwargs)
     if pretrained:
         from .model_store import get_model_file
         model.load_params(get_model_file('fcn_%s_%s'%(backbone, acronyms[dataset]),

--- a/gluoncv/model_zoo/fcn.py
+++ b/gluoncv/model_zoo/fcn.py
@@ -21,7 +21,7 @@ class FCN(SegBaseModel):
         'resnet101' or 'resnet152').
     norm_layer : object
         Normalization layer used in backbone network (default: :class:`mxnet.gluon.nn.BatchNorm`;
-    pretrained : bool
+    pretrained_base : bool
         Refers to if the FCN backbone or the encoder is pretrained or not. If `True`,
         model weights of a model that was trained on ImageNet is loaded.
 
@@ -38,9 +38,9 @@ class FCN(SegBaseModel):
     """
     # pylint: disable=arguments-differ
     def __init__(self, nclass, backbone='resnet50', norm_layer=nn.BatchNorm,
-                 aux=True, ctx=cpu(), pretrained=True, **kwargs):
+                 aux=True, ctx=cpu(), **kwargs):
         super(FCN, self).__init__(nclass, aux, backbone, ctx=ctx,
-                                  norm_layer=norm_layer, pretrained=pretrained, **kwargs)
+                                  norm_layer=norm_layer, **kwargs)
         with self.name_scope():
             self.head = _FCNHead(2048, nclass, norm_layer=norm_layer, **kwargs)
             self.head.initialize(ctx=ctx)

--- a/gluoncv/model_zoo/pspnet.py
+++ b/gluoncv/model_zoo/pspnet.py
@@ -31,9 +31,9 @@ class PSPNet(SegBaseModel):
 
     """
     def __init__(self, nclass, backbone='resnet50', norm_layer=nn.BatchNorm,
-                 aux=True, ctx=cpu(), pretrained=True, **kwargs):
+                 aux=True, ctx=cpu(), **kwargs):
         super(PSPNet, self).__init__(nclass, aux, backbone, ctx=ctx,
-                                     norm_layer=norm_layer, pretrained=pretrained, **kwargs)
+                                     norm_layer=norm_layer, **kwargs)
         with self.name_scope():
             self.head = _PSPHead(nclass, norm_layer=norm_layer, **kwargs)
             self.head.initialize(ctx=ctx)

--- a/gluoncv/model_zoo/pspnet.py
+++ b/gluoncv/model_zoo/pspnet.py
@@ -33,7 +33,7 @@ class PSPNet(SegBaseModel):
     def __init__(self, nclass, backbone='resnet50', norm_layer=nn.BatchNorm,
                  aux=True, ctx=cpu(), pretrained=True, **kwargs):
         super(PSPNet, self).__init__(nclass, aux, backbone, ctx=ctx,
-                                     norm_layer=norm_layer, pretrained=pretraind, **kwargs)
+                                     norm_layer=norm_layer, pretrained=pretrained, **kwargs)
         with self.name_scope():
             self.head = _PSPHead(nclass, norm_layer=norm_layer, **kwargs)
             self.head.initialize(ctx=ctx)
@@ -114,7 +114,7 @@ class _PSPHead(HybridBlock):
         return self.block(x)
 
 def get_psp(dataset='pascal_voc', backbone='resnet50', pretrained=False,
-            root='~/.mxnet/models', ctx=cpu(0), **kwargs):
+            root='~/.mxnet/models', ctx=cpu(0), backbone_pretrained=True, **kwargs):
     r"""Pyramid Scene Parsing Network
     Parameters
     ----------
@@ -126,6 +126,8 @@ def get_psp(dataset='pascal_voc', backbone='resnet50', pretrained=False,
         The context in which to load the pretrained weights.
     root : str, default '~/.mxnet/models'
         Location for keeping the model parameters.
+    backbone_pretrained : bool, default True
+        This will load pretrained backbone network, that was trained on ImageNet.
 
     Examples
     --------
@@ -143,7 +145,8 @@ def get_psp(dataset='pascal_voc', backbone='resnet50', pretrained=False,
         'ade20k': ADE20KSegmentation,
     }
     # infer number of classes
-    model = PSPNet(datasets[dataset].NUM_CLASS, backbone=backbone, ctx=ctx, **kwargs)
+    model = PSPNet(datasets[dataset].NUM_CLASS, backbone=backbone,
+                   pretrained=backbone_pretrained, ctx=ctx, **kwargs)
     if pretrained:
         from .model_store import get_model_file
         model.load_params(get_model_file('psp_%s_%s'%(backbone, acronyms[dataset]),

--- a/gluoncv/model_zoo/pspnet.py
+++ b/gluoncv/model_zoo/pspnet.py
@@ -146,7 +146,7 @@ def get_psp(dataset='pascal_voc', backbone='resnet50', pretrained=False,
     }
     # infer number of classes
     model = PSPNet(datasets[dataset].NUM_CLASS, backbone=backbone,
-                   pretrained=pretrained_base, ctx=ctx, **kwargs)
+                   pretrained_base=pretrained_base, ctx=ctx, **kwargs)
     if pretrained:
         from .model_store import get_model_file
         model.load_params(get_model_file('psp_%s_%s'%(backbone, acronyms[dataset]),

--- a/gluoncv/model_zoo/pspnet.py
+++ b/gluoncv/model_zoo/pspnet.py
@@ -31,9 +31,9 @@ class PSPNet(SegBaseModel):
 
     """
     def __init__(self, nclass, backbone='resnet50', norm_layer=nn.BatchNorm,
-                 aux=True, ctx=cpu(), **kwargs):
+                 aux=True, ctx=cpu(), pretrained=True, **kwargs):
         super(PSPNet, self).__init__(nclass, aux, backbone, ctx=ctx,
-                                     norm_layer=norm_layer, **kwargs)
+                                     norm_layer=norm_layer, pretrained=pretraind, **kwargs)
         with self.name_scope():
             self.head = _PSPHead(nclass, norm_layer=norm_layer, **kwargs)
             self.head.initialize(ctx=ctx)

--- a/gluoncv/model_zoo/pspnet.py
+++ b/gluoncv/model_zoo/pspnet.py
@@ -114,7 +114,7 @@ class _PSPHead(HybridBlock):
         return self.block(x)
 
 def get_psp(dataset='pascal_voc', backbone='resnet50', pretrained=False,
-            root='~/.mxnet/models', ctx=cpu(0), backbone_pretrained=True, **kwargs):
+            root='~/.mxnet/models', ctx=cpu(0), pretrained_base=True, **kwargs):
     r"""Pyramid Scene Parsing Network
     Parameters
     ----------
@@ -126,7 +126,7 @@ def get_psp(dataset='pascal_voc', backbone='resnet50', pretrained=False,
         The context in which to load the pretrained weights.
     root : str, default '~/.mxnet/models'
         Location for keeping the model parameters.
-    backbone_pretrained : bool, default True
+    pretrained_base : bool, default True
         This will load pretrained backbone network, that was trained on ImageNet.
 
     Examples
@@ -146,7 +146,7 @@ def get_psp(dataset='pascal_voc', backbone='resnet50', pretrained=False,
     }
     # infer number of classes
     model = PSPNet(datasets[dataset].NUM_CLASS, backbone=backbone,
-                   pretrained=backbone_pretrained, ctx=ctx, **kwargs)
+                   pretrained=pretrained_base, ctx=ctx, **kwargs)
     if pretrained:
         from .model_store import get_model_file
         model.load_params(get_model_file('psp_%s_%s'%(backbone, acronyms[dataset]),

--- a/gluoncv/model_zoo/pspnet.py
+++ b/gluoncv/model_zoo/pspnet.py
@@ -35,11 +35,11 @@ class PSPNet(SegBaseModel):
         super(PSPNet, self).__init__(nclass, aux, backbone, ctx=ctx,
                                      norm_layer=norm_layer, **kwargs)
         with self.name_scope():
-            self.head = _PSPHead(nclass, norm_layer=norm_layer, **kwargs)
+            self.head = _PSPHead(nclass, norm_layer=norm_layer)
             self.head.initialize(ctx=ctx)
             self.head.collect_params().setattr('lr_mult', 10)
             if self.aux:
-                self.auxlayer = _FCNHead(1024, nclass, norm_layer=norm_layer, **kwargs)
+                self.auxlayer = _FCNHead(1024, nclass, norm_layer=norm_layer)
                 self.auxlayer.initialize(ctx=ctx)
                 self.auxlayer.collect_params().setattr('lr_mult', 10)
 
@@ -95,10 +95,10 @@ class _PyramidPooling(HybridBlock):
 
 
 class _PSPHead(HybridBlock):
-    def __init__(self, nclass, norm_layer, norm_kwargs={}, **kwargs):
+    def __init__(self, nclass, norm_layer, norm_kwargs={}):
         super(_PSPHead, self).__init__()
         self.psp = _PyramidPooling(2048, norm_layer=norm_layer,
-                                   norm_kwargs=norm_kwargs, **kwargs)
+                                   norm_kwargs=norm_kwargs)
         with self.name_scope():
             self.block = nn.HybridSequential(prefix='')
             self.block.add(nn.Conv2D(in_channels=4096, channels=512,

--- a/gluoncv/model_zoo/segbase.py
+++ b/gluoncv/model_zoo/segbase.py
@@ -35,7 +35,8 @@ class SegBaseModel(HybridBlock):
         for Synchronized Cross-GPU BachNormalization).
     """
     # pylint : disable=arguments-differ
-    def __init__(self, nclass, aux, backbone='resnet50', height=480, width=480, pretrained=True, **kwargs):
+    def __init__(self, nclass, aux, backbone='resnet50', height=480, width=480,
+                 pretrained=True, **kwargs):
         super(SegBaseModel, self).__init__()
         self.aux = aux
         self.nclass = nclass

--- a/gluoncv/model_zoo/segbase.py
+++ b/gluoncv/model_zoo/segbase.py
@@ -35,8 +35,7 @@ class SegBaseModel(HybridBlock):
         for Synchronized Cross-GPU BachNormalization).
     """
     # pylint : disable=arguments-differ
-    def __init__(self, nclass, aux, backbone='resnet50', height=480, width=480, pretrained = True,
-                                                             **kwargs):
+    def __init__(self, nclass, aux, backbone='resnet50', height=480, width=480, pretrained=True, **kwargs):
         super(SegBaseModel, self).__init__()
         self.aux = aux
         self.nclass = nclass

--- a/gluoncv/model_zoo/segbase.py
+++ b/gluoncv/model_zoo/segbase.py
@@ -35,17 +35,18 @@ class SegBaseModel(HybridBlock):
         for Synchronized Cross-GPU BachNormalization).
     """
     # pylint : disable=arguments-differ
-    def __init__(self, nclass, aux, backbone='resnet50', height=480, width=480, **kwargs):
+    def __init__(self, nclass, aux, backbone='resnet50', height=480, width=480, pretrained = True,
+                                                             **kwargs):
         super(SegBaseModel, self).__init__()
         self.aux = aux
         self.nclass = nclass
         with self.name_scope():
             if backbone == 'resnet50':
-                pretrained = resnet50_v1b(pretrained=True, dilated=True, **kwargs)
+                pretrained = resnet50_v1b(pretrained=pretrained, dilated=True, **kwargs)
             elif backbone == 'resnet101':
-                pretrained = resnet101_v1b(pretrained=True, dilated=True, **kwargs)
+                pretrained = resnet101_v1b(pretrained=pretrained, dilated=True, **kwargs)
             elif backbone == 'resnet152':
-                pretrained = resnet152_v1b(pretrained=True, dilated=True, **kwargs)
+                pretrained = resnet152_v1b(pretrained=pretrained, dilated=True, **kwargs)
             else:
                 raise RuntimeError('unknown backbone: {}'.format(backbone))
             self.conv1 = pretrained.conv1

--- a/gluoncv/model_zoo/segbase.py
+++ b/gluoncv/model_zoo/segbase.py
@@ -36,17 +36,17 @@ class SegBaseModel(HybridBlock):
     """
     # pylint : disable=arguments-differ
     def __init__(self, nclass, aux, backbone='resnet50', height=480, width=480,
-                 pretrained=True, **kwargs):
+                 pretrained_base=True, **kwargs):
         super(SegBaseModel, self).__init__()
         self.aux = aux
         self.nclass = nclass
         with self.name_scope():
             if backbone == 'resnet50':
-                pretrained = resnet50_v1b(pretrained=pretrained, dilated=True, **kwargs)
+                pretrained = resnet50_v1b(pretrained=pretrained_base, dilated=True, **kwargs)
             elif backbone == 'resnet101':
-                pretrained = resnet101_v1b(pretrained=pretrained, dilated=True, **kwargs)
+                pretrained = resnet101_v1b(pretrained=pretrained_base, dilated=True, **kwargs)
             elif backbone == 'resnet152':
-                pretrained = resnet152_v1b(pretrained=pretrained, dilated=True, **kwargs)
+                pretrained = resnet152_v1b(pretrained=pretrained_base, dilated=True, **kwargs)
             else:
                 raise RuntimeError('unknown backbone: {}'.format(backbone))
             self.conv1 = pretrained.conv1

--- a/tests/unittests/test_model_zoo.py
+++ b/tests/unittests/test_model_zoo.py
@@ -153,9 +153,9 @@ def test_segmentation_models():
     ctx = mx.context.current_context()
     x = mx.random.uniform(shape=(2, 3, 480, 480), ctx=ctx)
     models = ['fcn_resnet50_voc', 'fcn_resnet101_voc', 'fcn_resnet50_ade']
-    _test_model_list(models, ctx, x, pretrained=True, backbone_pretrained=True)
-    _test_model_list(models, ctx, x, pretrained=False, backbone_pretrained=False)
-    _test_model_list(models, ctx, x, pretrained=False, backbone_pretrained=True)
+    _test_model_list(models, ctx, x, pretrained=True, pretrained_base=True)
+    _test_model_list(models, ctx, x, pretrained=False, pretrained_base=False)
+    _test_model_list(models, ctx, x, pretrained=False, pretrained_base=True)
 
 if __name__ == '__main__':
     import nose

--- a/tests/unittests/test_model_zoo.py
+++ b/tests/unittests/test_model_zoo.py
@@ -36,7 +36,7 @@ def test_get_all_models():
         assert isinstance(net, mx.gluon.Block), '{}'.format(name)
 
 @with_cpu(0)
-def _test_model_list(model_list, ctx, x, pretrained = True, **kwargs):
+def _test_model_list(model_list, ctx, x, pretrained=True, **kwargs):
     for model in model_list:
         net = gcv.model_zoo.get_model(model, **kwargs)
         with warnings.catch_warnings():
@@ -153,8 +153,8 @@ def test_segmentation_models():
     ctx = mx.context.current_context()
     x = mx.random.uniform(shape=(2, 3, 480, 480), ctx=ctx)
     models = ['fcn_resnet50_voc', 'fcn_resnet101_voc', 'fcn_resnet50_ade']
-    _test_model_list(models, ctx, x, pretrained = True)
-    _test_model_list(models, ctx, x, pretrained = False)
+    _test_model_list(models, ctx, x, pretrained=True)
+    _test_model_list(models, ctx, x, pretrained=False)
 
 if __name__ == '__main__':
     import nose

--- a/tests/unittests/test_model_zoo.py
+++ b/tests/unittests/test_model_zoo.py
@@ -153,8 +153,9 @@ def test_segmentation_models():
     ctx = mx.context.current_context()
     x = mx.random.uniform(shape=(2, 3, 480, 480), ctx=ctx)
     models = ['fcn_resnet50_voc', 'fcn_resnet101_voc', 'fcn_resnet50_ade']
-    _test_model_list(models, ctx, x, pretrained=True)
-    _test_model_list(models, ctx, x, pretrained=False)
+    _test_model_list(models, ctx, x, pretrained=True, backbone_pretrained=True)
+    _test_model_list(models, ctx, x, pretrained=False, backbone_pretrained=False)
+    _test_model_list(models, ctx, x, pretrained=False, backbone_pretrained=True)
 
 if __name__ == '__main__':
     import nose

--- a/tests/unittests/test_model_zoo.py
+++ b/tests/unittests/test_model_zoo.py
@@ -36,7 +36,7 @@ def test_get_all_models():
         assert isinstance(net, mx.gluon.Block), '{}'.format(name)
 
 @with_cpu(0)
-def _test_model_list(model_list, ctx, x, **kwargs):
+def _test_model_list(model_list, ctx, x, pretrained = True, **kwargs):
     for model in model_list:
         net = gcv.model_zoo.get_model(model, **kwargs)
         with warnings.catch_warnings():
@@ -49,7 +49,7 @@ def _test_model_list(model_list, ctx, x, **kwargs):
     pretrained_models = gcv.model_zoo.pretrained_model_list()
     for model in model_list:
         if model in pretrained_models:
-            net = gcv.model_zoo.get_model(model, pretrained=True, **kwargs)
+            net = gcv.model_zoo.get_model(model, pretrained=pretrained, **kwargs)
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore")
                 net.initialize()
@@ -153,7 +153,8 @@ def test_segmentation_models():
     ctx = mx.context.current_context()
     x = mx.random.uniform(shape=(2, 3, 480, 480), ctx=ctx)
     models = ['fcn_resnet50_voc', 'fcn_resnet101_voc', 'fcn_resnet50_ade']
-    _test_model_list(models, ctx, x)
+    _test_model_list(models, ctx, x, pretrained = True)
+    _test_model_list(models, ctx, x, pretrained = False)
 
 if __name__ == '__main__':
     import nose

--- a/tests/unittests/test_model_zoo.py
+++ b/tests/unittests/test_model_zoo.py
@@ -49,7 +49,7 @@ def _test_model_list(model_list, ctx, x, pretrained=True, **kwargs):
     pretrained_models = gcv.model_zoo.pretrained_model_list()
     for model in model_list:
         if model in pretrained_models:
-            net = gcv.model_zoo.get_model(model, pretrained=pretrained, **kwargs)
+            net = gcv.model_zoo.get_model(model, pretrained=True, **kwargs)
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore")
                 net.initialize()


### PR DESCRIPTION
## Notes

This PR will allow ``pretrained=False`` mode for semantic segmentation, which at the moment is hardcoded to ``pretrained=True``.  Apart from simple code changes to ``segbase.py`` to the base class arguments, I have also changed the ``FCN`` and the ``PSPNet`` classes to reflect these changes appropriately. 

## Testing

I tested this by adding a unittest to the ``get_model`` method that now runs tests for both ``pretrained=True`` and ``pretrained=False``. I also tested by running both those modes for both the algorithms in use.