### PR TITLE
Fix as_numpy() error when concat 1-d array in voc map metric

### DIFF
--- a/gluoncv/utils/metrics/voc_detection.py
+++ b/gluoncv/utils/metrics/voc_detection.py
@@ -93,6 +93,10 @@ class VOCMApMetric(mx.metric.EvalMetric):
             """Convert a (list of) mx.NDArray into numpy.ndarray"""
             if isinstance(a, (list, tuple)):
                 out = [x.asnumpy() if isinstance(x, mx.nd.NDArray) else x for x in a]
+                out = np.array(out)
+                # just return out directly for 1-d array
+                if len(out.shape) == 1:
+                    return out
                 return np.concatenate(out, axis=0)
             elif isinstance(a, mx.nd.NDArray):
                 a = a.asnumpy()


### PR DESCRIPTION
When concat 1-d array in:
https://github.com/dmlc/gluon-cv/blob/684355e48101eb3ca035425fbac733a400a70a5f/gluoncv/utils/metrics/voc_detection.py#L96

Especially for `gt_difficults=None`, will raise error like:
```
Traceback (most recent call last):
  File "train_faster_rcnn.py", line 431, in <module>
    train(net, train_data, val_data, eval_metric, ctx, args)
  File "train_faster_rcnn.py", line 392, in train
    map_name, mean_ap = validate(net, val_data, ctx, eval_metric)
  File "train_faster_rcnn.py", line 263, in validate
    eval_metric.update(det_bbox, det_id, det_score, gt_bbox, gt_id, gt_diff)
  File "Python36\site-packages\gluoncv-0.3.0-py3.6.egg\gluoncv\utils\metrics\voc_detection.py", line 106, in update
  File "Python36\site-packages\gluoncv-0.3.0-py3.6.egg\gluoncv\utils\metrics\voc_detection.py", line 105, in <listcomp>
  File "Python36\site-packages\gluoncv-0.3.0-py3.6.egg\gluoncv\utils\metrics\voc_detection.py", line 96, in as_numpy
ValueError: zero-dimensional arrays cannot be concatenated
```

This PR is to fix this.