### PR TITLE
fix senet, resnext and verification script

### DIFF
--- a/gluoncv/model_zoo/resnext.py
+++ b/gluoncv/model_zoo/resnext.py
@@ -72,9 +72,9 @@ class Block(HybridBlock):
 
         if use_se:
             self.se = nn.HybridSequential(prefix='')
-            self.se.add(nn.Dense(channels // 4, use_bias=False))
+            self.se.add(nn.Conv2D(channels // 4, kernel_size=1, padding=0))
             self.se.add(nn.Activation('relu'))
-            self.se.add(nn.Dense(channels * 4, use_bias=False))
+            self.se.add(nn.Conv2D(channels * 4, kernel_size=1, padding=0))
             self.se.add(nn.Activation('sigmoid'))
         else:
             self.se = None
@@ -95,7 +95,7 @@ class Block(HybridBlock):
         if self.se:
             w = F.contrib.AdaptiveAvgPooling2D(x, output_size=1)
             w = self.se(w)
-            x = F.broadcast_mul(x, w.expand_dims(axis=2).expand_dims(axis=2))
+            x = F.broadcast_mul(x, w)
 
         if self.downsample:
             residual = self.downsample(residual)

--- a/scripts/classification/imagenet/verify_pretrained.py
+++ b/scripts/classification/imagenet/verify_pretrained.py
@@ -57,7 +57,7 @@ acc_top5 = mx.metric.TopKAccuracy(5)
 normalize = transforms.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225])
 
 transform_test = transforms.Compose([
-    transforms.Resize(256),
+    transforms.Resize(256, keep_ratio=True),
     transforms.CenterCrop(224),
     transforms.ToTensor(),
     normalize


### PR DESCRIPTION
Fix SE-Net downsampling kernel size and MaxPooling with `ceil_mode`, so that it is able to convert weights from caffe.
Fix verification with `keep_ratio=True`.