### PR TITLE
if the dimension of the axis is not equeal, the len(out.shape) equal to 1

### DIFF
--- a/gluoncv/utils/metrics/voc_detection.py
+++ b/gluoncv/utils/metrics/voc_detection.py
@@ -82,7 +82,7 @@ class VOCMApMetric(mx.metric.EvalMetric):
             Prediction bounding boxes scores with shape `B, N`.
         gt_bboxes : mxnet.NDArray or numpy.ndarray
             Ground-truth bounding boxes with shape `B, M, 4`.
-            Where B is the size of mini-batch, M is the number of grount-truths.
+            Where B is the size of mini-batch, M is the number of ground-truths.
         gt_labels : mxnet.NDArray or numpy.ndarray
             Ground-truth bounding boxes labels with shape `B, M`.
         gt_difficults : mxnet.NDArray or numpy.ndarray, optional, default is None
@@ -94,9 +94,6 @@ class VOCMApMetric(mx.metric.EvalMetric):
             if isinstance(a, (list, tuple)):
                 out = [x.asnumpy() if isinstance(x, mx.nd.NDArray) else x for x in a]
                 out = np.array(out)
-                # just return out directly for 1-d array
-                if len(out.shape) == 1:
-                    return out
                 return np.concatenate(out, axis=0)
             elif isinstance(a, mx.nd.NDArray):
                 a = a.asnumpy()


### PR DESCRIPTION
#### test case

```
import numpy as np
import mxnet as mx

def as_numpy(a):
    """Convert a (list of) mx.NDArray into numpy.ndarray"""
    if isinstance(a, (list, tuple)):
        out = [x.asnumpy() if isinstance(x, mx.nd.NDArray) else x for x in a]
        out = np.array(out)
        # just return out directly for 1-d array
        if len(out.shape) == 1:
            return out
        return np.concatenate(out, axis=0)
    elif isinstance(a, mx.nd.NDArray):
        a = a.asnumpy()
    return a


shape = 5
data = []
data.append(mx.nd.random.normal(0, 1, shape=(4, 6, 1)))
data.append(mx.nd.random.normal(0, 1, shape=(shape, 6, 1)))

print as_numpy(data).shape
```

if shape = 4, return (8, 6, 1)
if shape = 5, return (2)

