### PR TITLE
Support inceptionv3 inference using pretrained model

### DIFF
--- a/scripts/classification/imagenet/verify_pretrained.py
+++ b/scripts/classification/imagenet/verify_pretrained.py
@@ -59,9 +59,13 @@ acc_top5 = mx.metric.TopKAccuracy(5)
 
 normalize = transforms.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225])
 
+"""
+Aligning with TF implemenation, the crop-input ratio is 0.875
+Set the crop 342 for input size 299 accordingly. 
+"""
 if 'inceptionv3' in model_name:
     transform_test = transforms.Compose([
-        transforms.Resize(320, keep_ratio=True),
+        transforms.Resize(342, keep_ratio=True),
         transforms.CenterCrop(input_size),
         transforms.ToTensor(),
         normalize
@@ -108,16 +112,22 @@ if not opt.rec_dir:
 else:
     imgrec = os.path.join(opt.rec_dir, 'val.rec')
     imgidx = os.path.join(opt.rec_dir, 'val.idx')
+    resize = 256
     if ('inceptionv3' in model_name) and input_size!=299:
         print('The input shape of inceptionv3 should be 299')
         input_size = 299
+        """
+        Aligning with TF implemenation, the crop-input ratio is 0.875
+        Set the crop 342 for input size 299 accordingly.
+        """
+        resize = 342
     val_data = mx.io.ImageRecordIter(
         path_imgrec         = imgrec,
         path_imgidx         = imgidx,
         preprocess_threads  = 30,
         batch_size          = batch_size,
 
-        resize              = 256,
+        resize              = resize,
         data_shape          = (3, input_size, input_size),
         mean_r              = 123.68,
         mean_g              = 116.779,

--- a/scripts/classification/imagenet/verify_pretrained.py
+++ b/scripts/classification/imagenet/verify_pretrained.py
@@ -64,14 +64,6 @@ acc_top5 = mx.metric.TopKAccuracy(5)
 normalize = transforms.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225])
 
 """
-Especially for inceptionv3, the input size has to be 299
-Set the inputsize to 299 even user set a different value
-"""
-if ('inceptionv3' in model_name) and input_size!=299:
-    input_size = 299
-    print('The input shape of inceptionv3 should be 299.')
-
-"""
 Aligning with TF implemenation, the default crop-input
 ratio set as 0.875; Set the crop as ceil(input-size/ratio)
 """

--- a/scripts/classification/imagenet/verify_pretrained.py
+++ b/scripts/classification/imagenet/verify_pretrained.py
@@ -61,14 +61,14 @@ normalize = transforms.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225])
 
 if 'inceptionv3' in model_name:
     transform_test = transforms.Compose([
-        transforms.CenterCrop(299),
+        transforms.CenterCrop(input_size),
         transforms.ToTensor(),
         normalize
     ])
 else:
     transform_test = transforms.Compose([
         transforms.Resize(256, keep_ratio=True),
-        transforms.CenterCrop(224),
+        transforms.CenterCrop(input_size),
         transforms.ToTensor(),
         normalize
     ])

--- a/scripts/classification/imagenet/verify_pretrained.py
+++ b/scripts/classification/imagenet/verify_pretrained.py
@@ -61,6 +61,7 @@ normalize = transforms.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225])
 
 if 'inceptionv3' in model_name:
     transform_test = transforms.Compose([
+        transforms.Resize(320, keep_ratio=True),
         transforms.CenterCrop(input_size),
         transforms.ToTensor(),
         normalize


### PR DESCRIPTION
The InceptionV3 requires a input shape as 3*299*299, but not 3*224*224.
Per the current implemenation of verify_pretrained.py, if set the --model=inceptionv3, a runtime error as below will happen, and this is because the input shape is always set as 224, I introduce a new parameter to permit user to set the input shape to avoid this issue, and this is also aligning with the implementation of train_imagenet.py. Thanks for view this PR.

Traceback (most recent call last):
  File "verify_pretrained.py", line 122, in <module>
    err_top1_val, err_top5_val = test(ctx, val_data, 'rec')
  File "verify_pretrained.py", line 81, in test
    outputs = [net(X.astype(opt.dtype, copy=False)) for X in data]
  File "verify_pretrained.py", line 81, in <listcomp>
    outputs = [net(X.astype(opt.dtype, copy=False)) for X in data]
  File "/home/shufanwu/pythonenv/py3.6/lib/python3.6/site-packages/mxnet-1.3.0-py3.6.egg/mxnet/gluon/block.py", line 541, in __call__
    out = self.forward(*args)
  File "/home/shufanwu/pythonenv/py3.6/lib/python3.6/site-packages/mxnet-1.3.0-py3.6.egg/mxnet/gluon/block.py", line 908, in forward
    return self._call_cached_op(x, *args)
  File "/home/shufanwu/pythonenv/py3.6/lib/python3.6/site-packages/mxnet-1.3.0-py3.6.egg/mxnet/gluon/block.py", line 814, in _call_cached_op
    out = self._cached_op(*cargs)
  File "/home/shufanwu/pythonenv/py3.6/lib/python3.6/site-packages/mxnet-1.3.0-py3.6.egg/mxnet/_ctypes/ndarray.py", line 150, in __call__
    ctypes.byref(out_stypes)))
  File "/home/shufanwu/pythonenv/py3.6/lib/python3.6/site-packages/mxnet-1.3.0-py3.6.egg/mxnet/base.py", line 252, in check_call
    raise MXNetError(py_str(_LIB.MXGetLastError()))
mxnet.base.MXNetError: Error in operator inception30_pool2_fwd: [18:10:59] src/operator/nn/pooling.cc:144: **Check failed: param.kernel[0] <= dshape[2] + 2 * param.pad[0] kernel size (8) exceeds input (5 padded to 5)**

