### PR TITLE
[TEST][WIP] add corner ribbon to github

### DIFF
--- a/docs/_static/hidebib.js
+++ b/docs/_static/hidebib.js
@@ -1,0 +1,42 @@
+// adapted from: http://www.robots.ox.ac.uk/~vedaldi/assets/hidebib.js
+function hideallbibs()
+{
+    var el = document.getElementsByTagName("div") ;
+    for (var i = 0 ; i < el.length ; ++i) {
+        if (el[i].className == "paper") {
+            var bib = el[i].getElementsByTagName("pre") ;
+            if (bib.length > 0) {
+                bib [0] .style.display = 'none' ;
+            }
+        }
+    }
+}
+
+function togglebib(paperid)
+{
+    var paper = document.getElementById(paperid) ;
+    var bib = paper.getElementsByTagName('pre') ;
+    if (bib.length > 0) {
+        if (bib [0] .style.display == 'none') {
+            bib [0] .style.display = 'block' ;
+        } else {
+            bib [0] .style.display = 'none' ;
+        }
+    }
+}
+
+function toggleblock(blockId)
+{
+   var block = document.getElementById(blockId);
+   if (block.style.display == 'none') {
+    block.style.display = 'block' ;
+   } else {
+    block.style.display = 'none' ;
+   }
+}
+
+function hideblock(blockId)
+{
+   var block = document.getElementById(blockId);
+   block.style.display = 'none' ;
+}

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -8,4 +8,5 @@
     fill: #2475B0;
   }
   </style>
+
 {% endblock %}

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -3,4 +3,9 @@
 {%- block extrahead %}
 
   <script data-label="Check out the GitHub repository!" data-href="https://github.com/dmlc/gluon-cv" async defer src="https://unpkg.com/github-corners/dist/embed.min.js"></script>
+  <style>
+  .github-corner > svg {
+    fill: #2475B0;
+  }
+  </style>
 {% endblock %}

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,7 +1,6 @@
 {% extends "!layout.html" %}
 
-{%- block extrahead %} 
+{%- block extrahead %}
 
-
-  <script type="text/javascript" src="http://zhanghang1989.github.io/files/hidebib.js"></script>    
+  <script data-label="Check out the GitHub repository!" data-href="https://github.com/dmlc/gluon-cv" async defer src="https://unpkg.com/github-corners/dist/embed.min.js"></script>
 {% endblock %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -241,6 +241,7 @@ todo_include_todos = True
 
 def setup(app):
     app.add_javascript('google_analytics.js')
+    app.add_javascript('hidebib.js')
     app.add_stylesheet('css/custom.css')
      #app.add_transform(AutoStructify)
     #app.add_config_value('recommonmark_config', {


### PR DESCRIPTION
- Add corner ribbon link to GitHub repo. Currently it's hard to find a link to GitHub on website everywhere.
- Added custom js to _static to utilize cloud front cache instead of relying on GitHub. 