### PR TITLE
fix the name of train dataset

### DIFF
--- a/gluoncv/data/pascal_voc/segmentation.py
+++ b/gluoncv/data/pascal_voc/segmentation.py
@@ -44,7 +44,7 @@ class VOCSegmentation(SegmentationDataset):
         # train/val/test splits are pre-cut
         _splits_dir = os.path.join(_voc_root, 'ImageSets/Segmentation')
         if split == 'train':
-            _split_f = os.path.join(_splits_dir, 'trainval.txt')
+            _split_f = os.path.join(_splits_dir, 'train.txt')
         elif split == 'val':
             _split_f = os.path.join(_splits_dir, 'val.txt')
         elif split == 'test':


### PR DESCRIPTION
The train dataset of Pascal VOC Segmentation is train.txt, not trainval.txt.