### PR TITLE
Fixed CPU context on segmentation train

### DIFF
--- a/scripts/segmentation/train.py
+++ b/scripts/segmentation/train.py
@@ -91,7 +91,7 @@ def parse_args():
     if args.no_cuda:
         print('Using CPU')
         args.kvstore = 'local'
-        args.ctx = mx.cpu(0)
+        args.ctx = [mx.cpu(0)]
     else:
         print('Number of GPUs:', args.ngpus)
         args.ctx = [mx.gpu(i) for i in range(args.ngpus)]


### PR DESCRIPTION
The CPU context is currently not a list which causes split_and_load to crash