### PR TITLE
correct a typo

### DIFF
--- a/gluoncv/loss.py
+++ b/gluoncv/loss.py
@@ -11,7 +11,7 @@ __all__ = ['FocalLoss', 'SSDMultiBoxLoss', 'YOLOV3Loss',
            'MixSoftmaxCrossEntropyLoss', 'MixSoftmaxCrossEntropyOHEMLoss']
 
 class FocalLoss(gluon.loss.Loss):
-    """Focal Loss for inbalanced classification.
+    """Focal Loss for imbalanced classification.
     Focal loss was described in https://arxiv.org/abs/1708.02002
 
     Parameters


### PR DESCRIPTION
A very very  small spelling mistake: "Focal Loss for inbalanced _[sic]_ classification."
i**n**balanced -> i**m**balanced