### PR TITLE
Ensure that all samples are used when updating the VOC MAp metric (#536)

### DIFF
--- a/gluoncv/utils/metrics/voc_detection.py
+++ b/gluoncv/utils/metrics/voc_detection.py
@@ -103,7 +103,7 @@ class VOCMApMetric(mx.metric.EvalMetric):
             return a
 
         if gt_difficults is None:
-            gt_difficults = [None for _ in gt_labels]
+            gt_difficults = [None for _ in as_numpy(gt_labels)]
 
         for pred_bbox, pred_label, pred_score, gt_bbox, gt_label, gt_difficult in zip(
                 *[as_numpy(x) for x in [pred_bboxes, pred_labels, pred_scores,


### PR DESCRIPTION
Fix for issue #536:

* gluoncv/utils/metrics/voc_detection.py
  (VOCMApMetric.update): Ensure that when gt_difficults is not used, it still has
      as many elements as there are samples in the batch.