### PR TITLE
Enable exporting a model with a preprocessing layer and its parameters

### DIFF
--- a/gluoncv/utils/export_helper.py
+++ b/gluoncv/utils/export_helper.py
@@ -88,7 +88,7 @@ def export_block(path, block, data_shape=None, epoch=0, preprocess=True, layout=
             if not isinstance(preprocess, HybridBlock):
                 raise TypeError("preprocess must be HybridBlock, given {}".format(type(preprocess)))
         wrapper_block = nn.HybridSequential()
-        preprocess.initialize()
+        preprocess.initialize(ctx=ctx)
         wrapper_block.add(preprocess)
         wrapper_block.add(block)
     else:


### PR DESCRIPTION
during training on a GPU.

* gluoncv/utils/export_helper.py
  (export_block): Initialize the preprocessing wrapper layers in the
      defined context, not on the default CPU context.