### PR TITLE
fix ssd matcher behavior

### DIFF
--- a/gluoncv/model_zoo/ssd/target.py
+++ b/gluoncv/model_zoo/ssd/target.py
@@ -26,7 +26,8 @@ class SSDTargetGenerator(Block):
     def __init__(self, iou_thresh=0.5, neg_thresh=0.5, negative_mining_ratio=3,
                  stds=(0.1, 0.1, 0.2, 0.2), **kwargs):
         super(SSDTargetGenerator, self).__init__(**kwargs)
-        self._matcher = CompositeMatcher([BipartiteMatcher(), MaximumMatcher(iou_thresh)])
+        self._matcher = CompositeMatcher(
+            [BipartiteMatcher(share_max=False), MaximumMatcher(iou_thresh)])
         if negative_mining_ratio > 0:
             self._sampler = OHEMSampler(negative_mining_ratio, thresh=neg_thresh)
             self._use_negative_sampling = True

--- a/gluoncv/nn/matcher.py
+++ b/gluoncv/nn/matcher.py
@@ -61,12 +61,17 @@ class BipartiteMatcher(gluon.HybridBlock):
         Whether sort matching order in ascending order. Default is False.
     eps : float
         Epsilon for floating number comparison
+    share_max : bool, default is True
+        The maximum overlap between anchor/gt is shared by multiple ground truths.
+        We recommend Fast(er)-RCNN series to use ``True``, while for SSD, it should
+        defaults to ``False`` for better result.
     """
-    def __init__(self, threshold=1e-12, is_ascend=False, eps=1e-12):
+    def __init__(self, threshold=1e-12, is_ascend=False, eps=1e-12, share_max=True):
         super(BipartiteMatcher, self).__init__()
         self._threshold = threshold
         self._is_ascend = is_ascend
         self._eps = eps
+        self._share_max = share_max
 
     def hybrid_forward(self, F, x):
         """BipartiteMatching
@@ -84,10 +89,13 @@ class BipartiteMatcher(gluon.HybridBlock):
         # potential argmax and max
         pargmax = x.argmax(axis=-1, keepdims=True)  # (B, num_anchor, 1)
         maxs = x.max(axis=-2, keepdims=True)  # (B, 1, num_gt)
-        # pmax = F.pick(x, pargmax, axis=-1, keepdims=True)   # (B, num_anchor, 1)
-        mask = F.broadcast_greater_equal(x + self._eps, maxs)  # (B, num_anchor, num_gt)
-        mask = F.sum(mask, axis=-1, keepdims=True)  # (B, num_anchor, 1)
-        # mask = F.pick(mask, pargmax, axis=-1, keepdims=True)  # (B, num_anchor, 1)
+        if self._share_max:
+            mask = F.broadcast_greater_equal(x + self._eps, maxs)  # (B, num_anchor, num_gt)
+            mask = F.sum(mask, axis=-1, keepdims=True)  # (B, num_anchor, 1)
+        else:
+            pmax = F.pick(x, pargmax, axis=-1, keepdims=True)   # (B, num_anchor, 1)
+            mask = F.broadcast_greater_equal(pmax + self._eps, maxs)  # (B, num_anchor, num_gt)
+            mask = F.pick(mask, pargmax, axis=-1, keepdims=True)  # (B, num_anchor, 1)
         new_match = F.where(mask > 0, pargmax, F.ones_like(pargmax) * -1)
         result = F.where(match[0] < 0, new_match.squeeze(axis=-1), match[0])
         return result


### PR DESCRIPTION
Fix degraded SSD training performance(up to 1%, as reported by @eric-haibin-lin, @hetong007 ) due to matcher behavior change introduced by Faster-RCNN (#234)

After this fix, the training performance should match the one in training log https://raw.githubusercontent.com/dmlc/web-data/master/gluoncv/logs/detection/ssd_512_resnet50_v1_coco_train.log

