### PR TITLE
Add assertions for invalid class names for VOCDetection

### DIFF
--- a/gluoncv/data/pascal_voc/detection.py
+++ b/gluoncv/data/pascal_voc/detection.py
@@ -4,6 +4,7 @@ from __future__ import division
 import os
 import logging
 import numpy as np
+import warnings
 try:
     import xml.etree.cElementTree as ET
 except ImportError:

--- a/gluoncv/data/pascal_voc/detection.py
+++ b/gluoncv/data/pascal_voc/detection.py
@@ -107,7 +107,6 @@ class VOCDetection(VisionDataset):
         label = []
         for obj in root.iter('object'):
             difficult = int(obj.find('difficult').text)
-            print("obj.find('name').text: " + obj.find('name').text)
             cls_name = obj.find('name').text.strip().lower()
             if cls_name not in self.classes:
                 continue

--- a/gluoncv/data/pascal_voc/detection.py
+++ b/gluoncv/data/pascal_voc/detection.py
@@ -65,6 +65,10 @@ class VOCDetection(VisionDataset):
     @property
     def classes(self):
         """Category names."""
+        try:
+            self._validate_class_names(self.CLASSES)
+        except AssertionError as e:
+            raise RuntimeError("Class names must not contain {}".format(e))
         return type(self).CLASSES
 
     def __len__(self):
@@ -103,6 +107,7 @@ class VOCDetection(VisionDataset):
         label = []
         for obj in root.iter('object'):
             difficult = int(obj.find('difficult').text)
+            print("obj.find('name').text: " + obj.find('name').text)
             cls_name = obj.find('name').text.strip().lower()
             if cls_name not in self.classes:
                 continue
@@ -125,6 +130,11 @@ class VOCDetection(VisionDataset):
         assert 0 <= ymin < height, "ymin must in [0, {}), given {}".format(height, ymin)
         assert xmin < xmax <= width, "xmax must in (xmin, {}], given {}".format(width, xmax)
         assert ymin < ymax <= height, "ymax must in (ymin, {}], given {}".format(height, ymax)
+
+    def _validate_class_names(self, class_list):
+        """Validate class names."""
+        assert all(" " not in c for c in class_list), "spaces"
+        assert all(c.islower() for c in class_list), "uppercase characters"
 
     def _preload_labels(self):
         """Preload all labels into memory."""

--- a/gluoncv/data/pascal_voc/detection.py
+++ b/gluoncv/data/pascal_voc/detection.py
@@ -3,8 +3,8 @@ from __future__ import absolute_import
 from __future__ import division
 import os
 import logging
-import numpy as np
 import warnings
+import numpy as np
 try:
     import xml.etree.cElementTree as ET
 except ImportError:

--- a/gluoncv/data/pascal_voc/detection.py
+++ b/gluoncv/data/pascal_voc/detection.py
@@ -132,8 +132,10 @@ class VOCDetection(VisionDataset):
 
     def _validate_class_names(self, class_list):
         """Validate class names."""
-        assert all(" " not in c for c in class_list), "spaces"
         assert all(c.islower() for c in class_list), "uppercase characters"
+        stripped = [c for c in class_list if c.strip() != c]
+        if stripped:
+            warnings.warn('white space removed for {}'.format(stripped))
 
     def _preload_labels(self):
         """Preload all labels into memory."""


### PR DESCRIPTION
* Since `VOCDetection` only processes class names that don't contain spaces or uppercase characters and ignores any class names that deviate from this, adding an assertion to make this less confusing for users