### PR TITLE
Reuse detection weights when `reset_class` is called

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ stage("Unit Test") {
         # remove and create new env instead
         set -ex
         # conda env create -n gluon_cv_py2_test --force tests/py2.yml
-        # conda env update -n gluon_cv_py2_test -f tests/py2.yml --prune
+        conda env update -n gluon_cv_py2_test -f tests/py2.yml --prune
         conda activate gluon_cv_py2_test
         conda list
         export CUDA_VISIBLE_DEVICES=${VISIBLE_GPU}
@@ -81,11 +81,11 @@ stage("Build Docs") {
       checkout scm
       VISIBLE_GPU=env.EXECUTOR_NUMBER.toInteger() % 4
       sh """#!/bin/bash
-      conda env remove -n gluon_vision_docs -y
+      # conda env remove -n gluon_vision_docs -y
       set -ex
       export CUDA_VISIBLE_DEVICES=${VISIBLE_GPU}
-      conda env create -n gluon_vision_docs -f docs/build.yml
-      # conda env update -n gluon_vision_docs -f docs/build.yml --prune
+      # conda env create -n gluon_vision_docs -f docs/build.yml
+      conda env update -n gluon_vision_docs -f docs/build.yml --prune
       conda activate gluon_vision_docs
       export PYTHONPATH=\${PWD}
       env

--- a/gluoncv/model_zoo/yolo/yolo3.py
+++ b/gluoncv/model_zoo/yolo/yolo3.py
@@ -625,7 +625,7 @@ def yolo3_darknet53_coco(pretrained_base=True, pretrained=False,
         'darknet53', stages, [512, 256, 128], anchors, strides, classes, 'coco',
         pretrained=pretrained, norm_layer=norm_layer, norm_kwargs=norm_kwargs, **kwargs)
 
-def yolo3_darknet53_custom(classes, transfer=None, pretrained_base=True, pretrained=False,
+def yolo3_darknet53_custom(classes, transfer=None, pretrained_base=True,
                            norm_layer=BatchNorm, norm_kwargs=None, **kwargs):
     """YOLO3 multi-scale with darknet53 base network on custom dataset.
     Parameters
@@ -667,11 +667,8 @@ def yolo3_darknet53_custom(classes, transfer=None, pretrained_base=True, pretrai
         net.reset_class(classes, reuse_weights=reuse_classes)
     return net
 
-def yolo3_mobilenet1_0_voc(
-        pretrained_base=True,
-        pretrained=False,
-        norm_layer=BatchNorm, norm_kwargs=None,
-        **kwargs):
+def yolo3_mobilenet1_0_voc(pretrained_base=True, pretrained=False,
+                           norm_layer=BatchNorm, norm_kwargs=None, **kwargs):
     """YOLO3 multi-scale with mobilenet base network on VOC dataset.
     Parameters
     ----------
@@ -712,13 +709,8 @@ def yolo3_mobilenet1_0_voc(
         'mobilenet1.0', stages, [512, 256, 128], anchors, strides, classes, 'voc',
         pretrained=pretrained, norm_layer=norm_layer, norm_kwargs=norm_kwargs, **kwargs)
 
-def yolo3_mobilenet1_0_custom(
-        classes,
-        transfer=None,
-        pretrained_base=True,
-        pretrained=False,
-        norm_layer=BatchNorm, norm_kwargs=None,
-        **kwargs):
+def yolo3_mobilenet1_0_custom(classes, transfer=None, pretrained_base=True,
+                              norm_layer=BatchNorm, norm_kwargs=None, **kwargs):
     """YOLO3 multi-scale with mobilenet base network on custom dataset.
     Parameters
     ----------
@@ -767,11 +759,8 @@ def yolo3_mobilenet1_0_custom(
         net.reset_class(classes, reuse_weights=reuse_classes)
     return net
 
-def yolo3_mobilenet1_0_coco(
-        pretrained_base=True,
-        pretrained=False,
-        norm_layer=BatchNorm, norm_kwargs=None,
-        **kwargs):
+def yolo3_mobilenet1_0_coco(pretrained_base=True, pretrained=False, norm_layer=BatchNorm,
+                            norm_kwargs=None, **kwargs):
     """YOLO3 multi-scale with mobilenet base network on COCO dataset.
     Parameters
     ----------

--- a/gluoncv/model_zoo/yolo/yolo3.py
+++ b/gluoncv/model_zoo/yolo/yolo3.py
@@ -625,7 +625,7 @@ def yolo3_darknet53_coco(pretrained_base=True, pretrained=False,
         'darknet53', stages, [512, 256, 128], anchors, strides, classes, 'coco',
         pretrained=pretrained, norm_layer=norm_layer, norm_kwargs=norm_kwargs, **kwargs)
 
-def yolo3_darknet53_custom(classes, transfer=None, pretrained_base=True,
+def yolo3_darknet53_custom(classes, transfer=None, pretrained_base=True, pretrained=False,
                            norm_layer=BatchNorm, norm_kwargs=None, **kwargs):
     """YOLO3 multi-scale with darknet53 base network on custom dataset.
     Parameters
@@ -648,6 +648,8 @@ def yolo3_darknet53_custom(classes, transfer=None, pretrained_base=True,
     mxnet.gluon.HybridBlock
         Fully hybrid yolo3 network.
     """
+    if pretrained:
+        warnings.warn("Custom models don't provide `pretrained` weights, ignored.")
     if transfer is None:
         base_net = darknet53(
             pretrained=pretrained_base, norm_layer=norm_layer, norm_kwargs=norm_kwargs, **kwargs)
@@ -709,7 +711,7 @@ def yolo3_mobilenet1_0_voc(pretrained_base=True, pretrained=False,
         'mobilenet1.0', stages, [512, 256, 128], anchors, strides, classes, 'voc',
         pretrained=pretrained, norm_layer=norm_layer, norm_kwargs=norm_kwargs, **kwargs)
 
-def yolo3_mobilenet1_0_custom(classes, transfer=None, pretrained_base=True,
+def yolo3_mobilenet1_0_custom(classes, transfer=None, pretrained_base=True, pretrained=False,
                               norm_layer=BatchNorm, norm_kwargs=None, **kwargs):
     """YOLO3 multi-scale with mobilenet base network on custom dataset.
     Parameters
@@ -732,6 +734,8 @@ def yolo3_mobilenet1_0_custom(classes, transfer=None, pretrained_base=True,
     mxnet.gluon.HybridBlock
         Fully hybrid yolo3 network.
     """
+    if pretrained:
+        warnings.warn("Custom models don't provide `pretrained` weights, ignored.")
     if transfer is None:
         base_net = get_mobilenet(multiplier=1,
                                  pretrained=pretrained_base,

--- a/tests/unittests/test_model_zoo.py
+++ b/tests/unittests/test_model_zoo.py
@@ -157,6 +157,24 @@ def test_ssd_reset_class_on_gpu():
     net.reset_class(["bus", "car", "bird"])
     net(x)
 
+def test_yolo3_reset_class():
+    ctx = mx.context.current_context()
+    x = mx.random.uniform(shape=(1, 3, 512, 544), ctx=ctx)  # allow non-squre and larger inputs
+    model_name = 'yolo3_darnet53_voc'
+    net = gcv.model_zoo.get_model(model_name, pretrained=True, ctx=ctx)
+    net.reset_class(["bus", "car", "bird"])
+    net(x)
+
+    # for GPU
+    ctx = mx.gpu(0)
+    try:
+        x = mx.random.uniform(shape=(1, 3, 512, 544), ctx=ctx)
+    except Exception:
+        return
+    net = gcv.model_zoo.get_model(model_name, pretrained=True, ctx=ctx)
+    net.reset_class(["bus", "car", "bird"])
+    net(x)
+
 @try_gpu(0)
 def test_faster_rcnn_models():
     ctx = mx.context.current_context()

--- a/tests/unittests/test_model_zoo.py
+++ b/tests/unittests/test_model_zoo.py
@@ -160,7 +160,7 @@ def test_ssd_reset_class_on_gpu():
 def test_yolo3_reset_class():
     ctx = mx.context.current_context()
     x = mx.random.uniform(shape=(1, 3, 512, 544), ctx=ctx)  # allow non-squre and larger inputs
-    model_name = 'yolo3_darnet53_voc'
+    model_name = 'yolo3_darknet53_voc'
     net = gcv.model_zoo.get_model(model_name, pretrained=True, ctx=ctx)
     net.reset_class(["bus", "car", "bird"])
     net(x)


### PR DESCRIPTION
For pre-trained yolo3 models, it now allows user to reset class while reuse weights for specific classes.

```python
net = gluoncv.model_zoo.get_model('yolo3_mobilenet1.0_voc', pretrained=True)
# use direct name to name mapping to reuse weights
net.reset_class(classes=['person'], reuse_weights={'person':'person'})
# or use interger mapping, person is the 14th category in VOC
net.reset_class(classes=['person'], reuse_weights={0:14})
# you can even mix them
net.reset_class(classes=['person'], reuse_weights={'person':14})
# or use a list of string if class name don't change
net.reset_class(classes=['person'], reuse_weights=['person'])


# for coco models, it's still the same
net = gluoncv.model_zoo.get_model('yolo3_mobilenet1.0_coco', pretrained=True)
net.reset_class(classes=['person'], reuse_weights=['person'])
```

This is especially good for pose estimation where only person is required for detection. You can grab any pre-trained models and `reset_class` to person only, and enjoy the results with out finetuning again. 

@hetong007 
