### PR TITLE
Improve custo coco compatible detection dataset

### DIFF
--- a/gluoncv/data/mscoco/detection.py
+++ b/gluoncv/data/mscoco/detection.py
@@ -36,7 +36,6 @@ class COCODetection(VisionDataset):
     use_crowd : bool, default is True
         Whether use boxes labeled as crowd instance.
 
-
     """
     CLASSES = ['person', 'bicycle', 'car', 'motorcycle', 'airplane', 'bus', 'train',
                'truck', 'boat', 'traffic light', 'fire hydrant', 'stop sign',
@@ -54,14 +53,13 @@ class COCODetection(VisionDataset):
 
     def __init__(self, root=os.path.join('~', '.mxnet', 'datasets', 'coco'),
                  splits=('instances_val2017',), transform=None, min_object_area=0,
-                 skip_empty=True, use_crowd=True, annotation_dir='annotations'):
+                 skip_empty=True, use_crowd=True):
         super(COCODetection, self).__init__(root)
         self._root = os.path.expanduser(root)
         self._transform = transform
         self._min_object_area = min_object_area
         self._skip_empty = skip_empty
         self._use_crowd = use_crowd
-        self._annotation_dir = annotation_dir
         if isinstance(splits, mx.base.string_types):
             splits = [splits]
         self._splits = splits

--- a/gluoncv/data/mscoco/detection.py
+++ b/gluoncv/data/mscoco/detection.py
@@ -35,6 +35,9 @@ class COCODetection(VisionDataset):
         it will cause undefined behavior.
     use_crowd : bool, default is True
         Whether use boxes labeled as crowd instance.
+    annotation_dir : str, default is 'annotations'(coco default)
+        The subdir for annotations. For example, a coco format json file will be searched as
+        'root/annotation_dir/xxx.json'
 
     """
     CLASSES = ['person', 'bicycle', 'car', 'motorcycle', 'airplane', 'bus', 'train',
@@ -53,13 +56,14 @@ class COCODetection(VisionDataset):
 
     def __init__(self, root=os.path.join('~', '.mxnet', 'datasets', 'coco'),
                  splits=('instances_val2017',), transform=None, min_object_area=0,
-                 skip_empty=True, use_crowd=True):
+                 skip_empty=True, use_crowd=True, annotation_dir='annotations'):
         super(COCODetection, self).__init__(root)
         self._root = os.path.expanduser(root)
         self._transform = transform
         self._min_object_area = min_object_area
         self._skip_empty = skip_empty
         self._use_crowd = use_crowd
+        self._annotation_dir = annotation_dir
         if isinstance(splits, mx.base.string_types):
             splits = [splits]
         self._splits = splits
@@ -108,7 +112,7 @@ class COCODetection(VisionDataset):
         try_import_pycocotools()
         from pycocotools.coco import COCO
         for split in self._splits:
-            anno = os.path.join(self._root, 'annotations', split) + '.json'
+            anno = os.path.join(self._root, self._annotation_dir, split) + '.json'
             _coco = COCO(anno)
             self._coco.append(_coco)
             classes = [c['name'] for c in _coco.loadCats(_coco.getCatIds())]

--- a/gluoncv/data/mscoco/detection.py
+++ b/gluoncv/data/mscoco/detection.py
@@ -83,7 +83,8 @@ class COCODetection(VisionDataset):
             raise ValueError("No coco objects found, dataset not initialized.")
         elif len(self._coco) > 1:
             raise NotImplementedError(
-                "Currently we don't support evaluating {} JSON files".format(len(self._coco)))
+                "Currently we don't support evaluating {} JSON files. \
+                Please use single JSON dataset and evaluate one by one".format(len(self._coco)))
         return self._coco[0]
 
     @property

--- a/gluoncv/data/mscoco/detection.py
+++ b/gluoncv/data/mscoco/detection.py
@@ -169,7 +169,10 @@ class COCODetection(VisionDataset):
 
     def _check_load_bbox(self, coco, entry):
         """Check and load ground-truth labels"""
-        ann_ids = coco.getAnnIds(imgIds=entry['id'], iscrowd=None)
+        entry_id = entry['id']
+        # fix pycocotools _isArrayLike which don't work for str in python3
+        entry_id = [entry_id] if not isinstance(entry_id, (list, tuple)) else entry_id
+        ann_ids = coco.getAnnIds(imgIds=entry_id, iscrowd=None)
         objs = coco.loadAnns(ann_ids)
         # check valid bboxes
         valid_objs = []


### PR DESCRIPTION
Make custom coco compatible detection dataset easier to use.

One can sub-class a COCODetection dataset just like this:

```python
import os
import gluoncv as gcv
print("Using gluoncv: ", gcv)

class CustomCOCODataset(gcv.data.COCODetection):
    CLASSES = ['class_a', 'class_b']

    def __init__(self, root, splits, transform=None, min_object_area=0, skip_empty=True, use_crowd=True, suffix='_foo'):
        splits = [x + suffix for x in splits]
        super(CustomCOCODataset, self).__init__(root, splits, transform, min_object_area, skip_empty, use_crowd)

    @property
    def annotation_dir(self):
        return 'not_default_annotations_dir'

    def _parse_image_path(self, entry):
        path = entry['id'] # or entry['file_name']
        abs_path = os.path.join(self._root, 'the_real_datasets_dir', path)
        return abs_path

```

And usage:

```python
# suppose jsons are stored as 'root/not_default_annotations_dir/foo_2019.json' and 'root/not_default_annotations_dir/bar_2019.json'
dataset = CustomCOCODataset(root='/my_data', splits=['foo', 'bar'], suffix='_2019')
print(len(dataset))
```