### PR TITLE
Quantized Model for Classification and Detection

### DIFF
--- a/docs/build.yml
+++ b/docs/build.yml
@@ -9,7 +9,7 @@ dependencies:
 - pip:
   - https://github.com/mli/mx-theme/tarball/master
   - sphinx-gallery
-  - mxnet-cu92mkl==1.5.0b20190115
+  - mxnet-cu92mkl==1.5.0b20190314
   # - guzzle_sphinx_theme
   - recommonmark
   - Image

--- a/gluoncv/model_zoo/model_zoo.py
+++ b/gluoncv/model_zoo/model_zoo.py
@@ -27,6 +27,7 @@ from .vgg import *
 from .mobilenet import *
 from .residual_attentionnet import *
 from .pruned_resnet.resnetv1b_pruned import *
+from .quantized import *
 
 
 __all__ = ['get_model', 'get_model_list']
@@ -186,7 +187,13 @@ _models = {
     'resnet50_v1d_0.37': resnet50_v1d_37,
     'resnet50_v1d_0.11': resnet50_v1d_11,
     'resnet101_v1d_0.76': resnet101_v1d_76,
-    'resnet101_v1d_0.73': resnet101_v1d_73
+    'resnet101_v1d_0.73': resnet101_v1d_73,
+    'mobilenet1.0_int8': mobilenet1_0_int8,
+    'resnet50_v1_int8': resnet50_v1_int8,
+    'ssd_300_vgg16_atrous_voc_int8': ssd_300_vgg16_atrous_voc_int8,
+    'ssd_512_mobilenet1.0_voc_int8': ssd_512_mobilenet1_0_voc_int8,
+    'ssd_512_resnet50_v1_voc_int8': ssd_512_resnet50_v1_voc_int8,
+    'ssd_512_vgg16_atrous_voc_int8': ssd_512_vgg16_atrous_voc_int8,
     }
 
 def get_model(name, **kwargs):

--- a/gluoncv/model_zoo/quantized/__init__.py
+++ b/gluoncv/model_zoo/quantized/__init__.py
@@ -1,0 +1,2 @@
+"""Quantized versions of GluonCV models."""
+from .quantized import *

--- a/gluoncv/model_zoo/quantized/mobilenet1.0_int8-symbol.json
+++ b/gluoncv/model_zoo/quantized/mobilenet1.0_int8-symbol.json
@@ -1,0 +1,4385 @@
+{
+  "nodes": [
+    {
+      "op": "null", 
+      "name": "data", 
+      "inputs": []
+    }, 
+    {
+      "op": "_contrib_quantize_v2", 
+      "name": "data_quantize", 
+      "attrs": {"out_type": "auto"}, 
+      "inputs": [[0, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(32, 3, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm0_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(32,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm0_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(32,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm0_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(32,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm0_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(32,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_0", 
+      "attrs": {
+        "max_calib_range": "23.429403", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[1, 0, 0], [2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 1], [6, 0, 1], [1, 1, 0], [1, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "data0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "mobilenet0_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "32", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(2, 2)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm0_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm0_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm0_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm0_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "mobilenet0_batchnorm0_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "mobilenet0_relu0_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_conv1_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(32, 1, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm1_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(32,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm1_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(32,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm1_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(32,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm1_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(32,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_1", 
+      "attrs": {
+        "max_calib_range": "53.783321", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[7, 0, 0], [8, 0, 0], [9, 0, 0], [10, 0, 0], [11, 0, 1], [12, 0, 1], [7, 1, 0], [7, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_0_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_conv1_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "mobilenet0_conv1_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "32", 
+                "num_group": "32", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm1_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm1_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm1_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm1_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "mobilenet0_batchnorm1_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "mobilenet0_relu1_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_conv2_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64, 32, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm2_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm2_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm2_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm2_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_2", 
+      "attrs": {
+        "max_calib_range": "48.818260", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[13, 0, 0], [14, 0, 0], [15, 0, 0], [16, 0, 0], [17, 0, 1], [18, 0, 1], [13, 1, 0], [13, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_1_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_conv2_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "mobilenet0_conv2_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "64", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm2_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm2_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm2_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm2_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "mobilenet0_batchnorm2_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "mobilenet0_relu2_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_conv3_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64, 1, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm3_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm3_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm3_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm3_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_3", 
+      "attrs": {
+        "max_calib_range": "40.278053", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[19, 0, 0], [20, 0, 0], [21, 0, 0], [22, 0, 0], [23, 0, 1], [24, 0, 1], [19, 1, 0], [19, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_2_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_conv3_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "mobilenet0_conv3_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "64", 
+                "num_group": "64", 
+                "pad": "(1, 1)", 
+                "stride": "(2, 2)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm3_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm3_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm3_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm3_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "mobilenet0_batchnorm3_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "mobilenet0_relu3_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_conv4_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128, 64, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm4_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm4_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm4_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm4_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_4", 
+      "attrs": {
+        "max_calib_range": "24.593645", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[25, 0, 0], [26, 0, 0], [27, 0, 0], [28, 0, 0], [29, 0, 1], [30, 0, 1], [25, 1, 0], [25, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_3_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_conv4_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "mobilenet0_conv4_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "128", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm4_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm4_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm4_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm4_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "mobilenet0_batchnorm4_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "mobilenet0_relu4_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_conv5_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128, 1, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm5_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm5_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm5_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm5_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_5", 
+      "attrs": {
+        "max_calib_range": "25.675819", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[31, 0, 0], [32, 0, 0], [33, 0, 0], [34, 0, 0], [35, 0, 1], [36, 0, 1], [31, 1, 0], [31, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_4_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_conv5_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "mobilenet0_conv5_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "128", 
+                "num_group": "128", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm5_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm5_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm5_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm5_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "mobilenet0_batchnorm5_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "mobilenet0_relu5_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_conv6_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128, 128, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm6_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm6_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm6_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm6_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_6", 
+      "attrs": {
+        "max_calib_range": "18.093466", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[37, 0, 0], [38, 0, 0], [39, 0, 0], [40, 0, 0], [41, 0, 1], [42, 0, 1], [37, 1, 0], [37, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_5_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_conv6_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "mobilenet0_conv6_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "128", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm6_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm6_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm6_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm6_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "mobilenet0_batchnorm6_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "mobilenet0_relu6_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_conv7_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128, 1, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm7_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm7_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm7_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm7_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_7", 
+      "attrs": {
+        "max_calib_range": "18.568243", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[43, 0, 0], [44, 0, 0], [45, 0, 0], [46, 0, 0], [47, 0, 1], [48, 0, 1], [43, 1, 0], [43, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_6_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_conv7_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "mobilenet0_conv7_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "128", 
+                "num_group": "128", 
+                "pad": "(1, 1)", 
+                "stride": "(2, 2)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm7_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm7_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm7_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm7_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "mobilenet0_batchnorm7_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "mobilenet0_relu7_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_conv8_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256, 128, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm8_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm8_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm8_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm8_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_8", 
+      "attrs": {
+        "max_calib_range": "15.476743", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[49, 0, 0], [50, 0, 0], [51, 0, 0], [52, 0, 0], [53, 0, 1], [54, 0, 1], [49, 1, 0], [49, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_7_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_conv8_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "mobilenet0_conv8_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "256", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm8_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm8_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm8_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm8_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "mobilenet0_batchnorm8_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "mobilenet0_relu8_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_conv9_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256, 1, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm9_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm9_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm9_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm9_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_9", 
+      "attrs": {
+        "max_calib_range": "24.638727", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[55, 0, 0], [56, 0, 0], [57, 0, 0], [58, 0, 0], [59, 0, 1], [60, 0, 1], [55, 1, 0], [55, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_8_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_conv9_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "mobilenet0_conv9_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "256", 
+                "num_group": "256", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm9_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm9_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm9_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm9_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "mobilenet0_batchnorm9_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "mobilenet0_relu9_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_conv10_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256, 256, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm10_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm10_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm10_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm10_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_10", 
+      "attrs": {
+        "max_calib_range": "18.475277", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[61, 0, 0], [62, 0, 0], [63, 0, 0], [64, 0, 0], [65, 0, 1], [66, 0, 1], [61, 1, 0], [61, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_9_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_conv10_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "mobilenet0_conv10_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "256", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm10_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm10_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm10_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm10_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "mobilenet0_batchnorm10_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "mobilenet0_relu10_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_conv11_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256, 1, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm11_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm11_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm11_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm11_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_11", 
+      "attrs": {
+        "max_calib_range": "20.770248", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[67, 0, 0], [68, 0, 0], [69, 0, 0], [70, 0, 0], [71, 0, 1], [72, 0, 1], [67, 1, 0], [67, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_10_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_conv11_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "mobilenet0_conv11_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "256", 
+                "num_group": "256", 
+                "pad": "(1, 1)", 
+                "stride": "(2, 2)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm11_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm11_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm11_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm11_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "mobilenet0_batchnorm11_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "mobilenet0_relu11_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_conv12_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 256, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm12_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm12_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm12_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm12_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_12", 
+      "attrs": {
+        "max_calib_range": "15.783651", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[73, 0, 0], [74, 0, 0], [75, 0, 0], [76, 0, 0], [77, 0, 1], [78, 0, 1], [73, 1, 0], [73, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_11_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_conv12_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "mobilenet0_conv12_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "512", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm12_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm12_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm12_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm12_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "mobilenet0_batchnorm12_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "mobilenet0_relu12_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_conv13_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 1, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm13_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm13_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm13_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm13_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_13", 
+      "attrs": {
+        "max_calib_range": "14.455085", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[79, 0, 0], [80, 0, 0], [81, 0, 0], [82, 0, 0], [83, 0, 1], [84, 0, 1], [79, 1, 0], [79, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_12_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_conv13_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "mobilenet0_conv13_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "512", 
+                "num_group": "512", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm13_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm13_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm13_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm13_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "mobilenet0_batchnorm13_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "mobilenet0_relu13_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_conv14_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 512, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm14_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm14_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm14_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm14_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_14", 
+      "attrs": {
+        "max_calib_range": "12.018683", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[85, 0, 0], [86, 0, 0], [87, 0, 0], [88, 0, 0], [89, 0, 1], [90, 0, 1], [85, 1, 0], [85, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_13_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_conv14_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "mobilenet0_conv14_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "512", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm14_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm14_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm14_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm14_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "mobilenet0_batchnorm14_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "mobilenet0_relu14_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_conv15_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 1, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm15_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm15_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm15_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm15_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_15", 
+      "attrs": {
+        "max_calib_range": "23.984909", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[91, 0, 0], [92, 0, 0], [93, 0, 0], [94, 0, 0], [95, 0, 1], [96, 0, 1], [91, 1, 0], [91, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_14_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_conv15_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "mobilenet0_conv15_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "512", 
+                "num_group": "512", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm15_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm15_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm15_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm15_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "mobilenet0_batchnorm15_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "mobilenet0_relu15_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_conv16_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 512, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm16_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm16_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm16_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm16_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_16", 
+      "attrs": {
+        "max_calib_range": "13.874047", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[97, 0, 0], [98, 0, 0], [99, 0, 0], [100, 0, 0], [101, 0, 1], [102, 0, 1], [97, 1, 0], [97, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_15_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_conv16_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "mobilenet0_conv16_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "512", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm16_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm16_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm16_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm16_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "mobilenet0_batchnorm16_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "mobilenet0_relu16_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_conv17_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 1, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm17_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm17_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm17_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm17_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_17", 
+      "attrs": {
+        "max_calib_range": "33.278786", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[103, 0, 0], [104, 0, 0], [105, 0, 0], [106, 0, 0], [107, 0, 1], [108, 0, 1], [103, 1, 0], [103, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_16_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_conv17_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "mobilenet0_conv17_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "512", 
+                "num_group": "512", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm17_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm17_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm17_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm17_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "mobilenet0_batchnorm17_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "mobilenet0_relu17_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_conv18_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 512, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm18_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm18_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm18_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm18_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_18", 
+      "attrs": {
+        "max_calib_range": "12.887977", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[109, 0, 0], [110, 0, 0], [111, 0, 0], [112, 0, 0], [113, 0, 1], [114, 0, 1], [109, 1, 0], [109, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_17_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_conv18_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "mobilenet0_conv18_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "512", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm18_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm18_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm18_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm18_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "mobilenet0_batchnorm18_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "mobilenet0_relu18_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_conv19_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 1, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm19_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm19_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm19_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm19_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_19", 
+      "attrs": {
+        "max_calib_range": "28.710047", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[115, 0, 0], [116, 0, 0], [117, 0, 0], [118, 0, 0], [119, 0, 1], [120, 0, 1], [115, 1, 0], [115, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_18_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_conv19_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "mobilenet0_conv19_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "512", 
+                "num_group": "512", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm19_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm19_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm19_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm19_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "mobilenet0_batchnorm19_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "mobilenet0_relu19_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_conv20_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 512, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm20_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm20_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm20_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm20_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_20", 
+      "attrs": {
+        "max_calib_range": "18.683052", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[121, 0, 0], [122, 0, 0], [123, 0, 0], [124, 0, 0], [125, 0, 1], [126, 0, 1], [121, 1, 0], [121, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_19_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_conv20_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "mobilenet0_conv20_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "512", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm20_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm20_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm20_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm20_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "mobilenet0_batchnorm20_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "mobilenet0_relu20_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_conv21_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 1, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm21_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm21_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm21_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm21_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_21", 
+      "attrs": {
+        "max_calib_range": "26.440147", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[127, 0, 0], [128, 0, 0], [129, 0, 0], [130, 0, 0], [131, 0, 1], [132, 0, 1], [127, 1, 0], [127, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_20_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_conv21_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "mobilenet0_conv21_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "512", 
+                "num_group": "512", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm21_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm21_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm21_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm21_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "mobilenet0_batchnorm21_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "mobilenet0_relu21_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_conv22_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 512, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm22_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm22_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm22_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm22_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_22", 
+      "attrs": {
+        "max_calib_range": "16.255720", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[133, 0, 0], [134, 0, 0], [135, 0, 0], [136, 0, 0], [137, 0, 1], [138, 0, 1], [133, 1, 0], [133, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_21_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_conv22_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "mobilenet0_conv22_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "512", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm22_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm22_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm22_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm22_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "mobilenet0_batchnorm22_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "mobilenet0_relu22_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_conv23_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 1, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm23_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm23_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm23_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm23_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_23", 
+      "attrs": {
+        "max_calib_range": "33.441959", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[139, 0, 0], [140, 0, 0], [141, 0, 0], [142, 0, 0], [143, 0, 1], [144, 0, 1], [139, 1, 0], [139, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_22_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_conv23_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "mobilenet0_conv23_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "512", 
+                "num_group": "512", 
+                "pad": "(1, 1)", 
+                "stride": "(2, 2)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm23_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm23_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm23_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm23_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "mobilenet0_batchnorm23_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "mobilenet0_relu23_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_conv24_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024, 512, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm24_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm24_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm24_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm24_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_24", 
+      "attrs": {
+        "max_calib_range": "15.809774", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[145, 0, 0], [146, 0, 0], [147, 0, 0], [148, 0, 0], [149, 0, 1], [150, 0, 1], [145, 1, 0], [145, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_23_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_conv24_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "mobilenet0_conv24_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "1024", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm24_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm24_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm24_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm24_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "mobilenet0_batchnorm24_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "mobilenet0_relu24_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_conv25_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024, 1, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm25_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm25_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm25_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm25_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_25", 
+      "attrs": {
+        "max_calib_range": "17.511763", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[151, 0, 0], [152, 0, 0], [153, 0, 0], [154, 0, 0], [155, 0, 1], [156, 0, 1], [151, 1, 0], [151, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_24_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_conv25_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "mobilenet0_conv25_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "1024", 
+                "num_group": "1024", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm25_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm25_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm25_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm25_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "mobilenet0_batchnorm25_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "mobilenet0_relu25_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_conv26_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024, 1024, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm26_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm26_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm26_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_batchnorm26_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_26", 
+      "attrs": {
+        "max_calib_range": "57.908100", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[157, 0, 0], [158, 0, 0], [159, 0, 0], [160, 0, 0], [161, 0, 1], [162, 0, 1], [157, 1, 0], [157, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_25_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_conv26_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "mobilenet0_conv26_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "1024", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm26_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm26_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm26_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "mobilenet0_batchnorm26_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "mobilenet0_batchnorm26_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "mobilenet0_relu26_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_bn_relu_26_dequantize", 
+      "inputs": [[163, 0, 0], [163, 1, 0], [163, 2, 0]]
+    }, 
+    {
+      "op": "Pooling", 
+      "name": "mobilenet0_pool0_fwd", 
+      "attrs": {
+        "global_pool": "True", 
+        "kernel": "(1, 1)", 
+        "layout": "NCHW", 
+        "pad": "(0, 0)", 
+        "pool_type": "avg", 
+        "pooling_convention": "full", 
+        "stride": "(1, 1)"
+      }, 
+      "inputs": [[164, 0, 0]]
+    }, 
+    {
+      "op": "Flatten", 
+      "name": "mobilenet0_flatten0_flatten0", 
+      "inputs": [[165, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_dense0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1000, 1024)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "mobilenet0_dense0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1000,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "FullyConnected", 
+      "name": "mobilenet0_dense0_fwd", 
+      "attrs": {
+        "flatten": "True", 
+        "no_bias": "False", 
+        "num_hidden": "1000"
+      }, 
+      "inputs": [[166, 0, 0], [167, 0, 0], [168, 0, 0]]
+    }
+  ], 
+  "arg_nodes": [
+    0, 
+    2, 
+    3, 
+    4, 
+    5, 
+    6, 
+    8, 
+    9, 
+    10, 
+    11, 
+    12, 
+    14, 
+    15, 
+    16, 
+    17, 
+    18, 
+    20, 
+    21, 
+    22, 
+    23, 
+    24, 
+    26, 
+    27, 
+    28, 
+    29, 
+    30, 
+    32, 
+    33, 
+    34, 
+    35, 
+    36, 
+    38, 
+    39, 
+    40, 
+    41, 
+    42, 
+    44, 
+    45, 
+    46, 
+    47, 
+    48, 
+    50, 
+    51, 
+    52, 
+    53, 
+    54, 
+    56, 
+    57, 
+    58, 
+    59, 
+    60, 
+    62, 
+    63, 
+    64, 
+    65, 
+    66, 
+    68, 
+    69, 
+    70, 
+    71, 
+    72, 
+    74, 
+    75, 
+    76, 
+    77, 
+    78, 
+    80, 
+    81, 
+    82, 
+    83, 
+    84, 
+    86, 
+    87, 
+    88, 
+    89, 
+    90, 
+    92, 
+    93, 
+    94, 
+    95, 
+    96, 
+    98, 
+    99, 
+    100, 
+    101, 
+    102, 
+    104, 
+    105, 
+    106, 
+    107, 
+    108, 
+    110, 
+    111, 
+    112, 
+    113, 
+    114, 
+    116, 
+    117, 
+    118, 
+    119, 
+    120, 
+    122, 
+    123, 
+    124, 
+    125, 
+    126, 
+    128, 
+    129, 
+    130, 
+    131, 
+    132, 
+    134, 
+    135, 
+    136, 
+    137, 
+    138, 
+    140, 
+    141, 
+    142, 
+    143, 
+    144, 
+    146, 
+    147, 
+    148, 
+    149, 
+    150, 
+    152, 
+    153, 
+    154, 
+    155, 
+    156, 
+    158, 
+    159, 
+    160, 
+    161, 
+    162, 
+    167, 
+    168
+  ], 
+  "node_row_ptr": [
+    0, 
+    1, 
+    4, 
+    5, 
+    6, 
+    7, 
+    8, 
+    9, 
+    12, 
+    13, 
+    14, 
+    15, 
+    16, 
+    17, 
+    20, 
+    21, 
+    22, 
+    23, 
+    24, 
+    25, 
+    28, 
+    29, 
+    30, 
+    31, 
+    32, 
+    33, 
+    36, 
+    37, 
+    38, 
+    39, 
+    40, 
+    41, 
+    44, 
+    45, 
+    46, 
+    47, 
+    48, 
+    49, 
+    52, 
+    53, 
+    54, 
+    55, 
+    56, 
+    57, 
+    60, 
+    61, 
+    62, 
+    63, 
+    64, 
+    65, 
+    68, 
+    69, 
+    70, 
+    71, 
+    72, 
+    73, 
+    76, 
+    77, 
+    78, 
+    79, 
+    80, 
+    81, 
+    84, 
+    85, 
+    86, 
+    87, 
+    88, 
+    89, 
+    92, 
+    93, 
+    94, 
+    95, 
+    96, 
+    97, 
+    100, 
+    101, 
+    102, 
+    103, 
+    104, 
+    105, 
+    108, 
+    109, 
+    110, 
+    111, 
+    112, 
+    113, 
+    116, 
+    117, 
+    118, 
+    119, 
+    120, 
+    121, 
+    124, 
+    125, 
+    126, 
+    127, 
+    128, 
+    129, 
+    132, 
+    133, 
+    134, 
+    135, 
+    136, 
+    137, 
+    140, 
+    141, 
+    142, 
+    143, 
+    144, 
+    145, 
+    148, 
+    149, 
+    150, 
+    151, 
+    152, 
+    153, 
+    156, 
+    157, 
+    158, 
+    159, 
+    160, 
+    161, 
+    164, 
+    165, 
+    166, 
+    167, 
+    168, 
+    169, 
+    172, 
+    173, 
+    174, 
+    175, 
+    176, 
+    177, 
+    180, 
+    181, 
+    182, 
+    183, 
+    184, 
+    185, 
+    188, 
+    189, 
+    190, 
+    191, 
+    192, 
+    193, 
+    196, 
+    197, 
+    198, 
+    199, 
+    200, 
+    201, 
+    204, 
+    205, 
+    206, 
+    207, 
+    208, 
+    209, 
+    212, 
+    213, 
+    214, 
+    215, 
+    216, 
+    217, 
+    220, 
+    221, 
+    222, 
+    223, 
+    224, 
+    225, 
+    226
+  ], 
+  "heads": [[169, 0, 0]], 
+  "attrs": {"mxnet_version": ["int", 10500]}
+}

--- a/gluoncv/model_zoo/quantized/quantized.py
+++ b/gluoncv/model_zoo/quantized/quantized.py
@@ -48,7 +48,12 @@ def _create_quantized_models(name, sym_prefix):
                 import tempfile
                 net.load_params(param_file)
                 net.hybridize()
-                net(mx.nd.zeros((1, 3, 224, 224)))
+                if '512' in base_name:
+                    net(mx.nd.zeros((1, 3, 512, 512)))
+                elif '300' in base_name:
+                    net(mx.nd.zeros((1, 3, 300, 300)))
+                else:
+                    net(mx.nd.zeros((1, 3, 224, 224)))
                 with tempfile.TemporaryDirectory() as tmpdirname:
                     prefix = os.path.join(tmpdirname, 'tmp')
                     net.export(prefix, epoch=0)

--- a/gluoncv/model_zoo/quantized/quantized.py
+++ b/gluoncv/model_zoo/quantized/quantized.py
@@ -1,0 +1,69 @@
+"""Create quantized model from JSON files..."""
+import os
+import warnings
+import mxnet as mx
+from mxnet.context import cpu
+from mxnet.gluon import SymbolBlock
+
+__all__ = ['mobilenet1_0_int8', 'resnet50_v1_int8',
+           'ssd_300_vgg16_atrous_voc_int8', 'ssd_512_mobilenet1_0_voc_int8',
+           'ssd_512_resnet50_v1_voc_int8', 'ssd_512_vgg16_atrous_voc_int8']
+
+def _not_impl(*args, **kwargs):
+    raise NotImplementedError("Not yet implemented for quantized models")
+
+def _create_quantized_models(name, sym_prefix):
+    def func(pretrained=False, tag=None, root='~/.mxnet/models', ctx=cpu(0), **kwargs):
+        r"""Quantized model.
+
+        Parameters
+        ----------
+        pretrained : bool or str
+            Boolean value controls whether to load the default pretrained weights for model.
+            String value represents the hashtag for a certain version of pretrained weights.
+        tag : str, default is None
+            Optional length-8 sha1sum of parameter file. If `None`, best parameter file
+            will be used.
+        ctx : Context, default CPU
+            The context in which to load the pretrained weights.
+        root : str, default $MXNET_HOME/models
+            Location for keeping the model parameters.
+        """
+        from ..model_zoo import get_model
+        from ..model_store import get_model_file
+        curr_dir = os.path.abspath(os.path.dirname(__file__))
+        model_name = name.replace('mobilenet1_', 'mobilenet1.')
+        model_name = model_name.replace('mobilenet0_', 'mobilenet0.')
+        json_file = os.path.join(curr_dir, '{}-symbol.json'.format(model_name))
+        base_name = '_'.join(model_name.split('_')[:-1])
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            param_file = get_model_file(base_name, tag=tag, root=root) if pretrained else None
+            net = get_model('_'.join(model_name.split('_')[:-1]), prefix=sym_prefix)
+            classes = getattr(net, 'classes', [])
+            sym_net = SymbolBlock.imports(json_file, ['data'], None, ctx=ctx)
+            if param_file:
+                # directly imports weights saved by save_parameters is not applicable
+                # so we hack it by load and export once to a temporary params file
+                import tempfile
+                net.load_params(param_file)
+                net.hybridize()
+                net(mx.nd.zeros((1, 3, 224, 224)))
+                with tempfile.TemporaryDirectory() as tmpdirname:
+                    prefix = os.path.join(tmpdirname, 'tmp')
+                    net.export(prefix, epoch=0)
+                    param_prefix = prefix + '-0000.params'
+                    sym_net.collect_params().load(param_prefix)
+        net.classes = classes
+        net.reset_class = _not_impl
+        net.set_nms = _not_impl
+        return net
+    func.__name__ = name
+    globals()[name] = func
+
+_create_quantized_models('mobilenet1_0_int8', 'mobilenet0_')
+_create_quantized_models('resnet50_v1_int8', 'resnetv10_')
+_create_quantized_models('ssd_300_vgg16_atrous_voc_int8', 'ssd0_')
+_create_quantized_models('ssd_512_mobilenet1_0_voc_int8', 'ssd0_')
+_create_quantized_models('ssd_512_resnet50_v1_voc_int8', 'ssd0_')
+_create_quantized_models('ssd_512_vgg16_atrous_voc_int8', 'ssd0_')

--- a/gluoncv/model_zoo/quantized/quantized.py
+++ b/gluoncv/model_zoo/quantized/quantized.py
@@ -1,3 +1,4 @@
+# pylint: skip-file
 """Create quantized model from JSON files..."""
 import os
 import warnings

--- a/gluoncv/model_zoo/quantized/resnet50_v1_int8-symbol.json
+++ b/gluoncv/model_zoo/quantized/resnet50_v1_int8-symbol.json
@@ -1,0 +1,9940 @@
+{
+  "nodes": [
+    {
+      "op": "null", 
+      "name": "data", 
+      "inputs": []
+    }, 
+    {
+      "op": "_contrib_quantize_v2", 
+      "name": "data_quantize", 
+      "attrs": {"out_type": "auto"}, 
+      "inputs": [[0, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64, 3, 7, 7)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_batchnorm0_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_batchnorm0_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_batchnorm0_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_batchnorm0_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_0", 
+      "attrs": {
+        "max_calib_range": "28.366196", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[1, 0, 0], [2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 1], [6, 0, 1], [1, 1, 0], [1, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "data0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "resnetv10_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(7, 7)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "64", 
+                "num_group": "1", 
+                "pad": "(3, 3)", 
+                "stride": "(2, 2)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_batchnorm0_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_batchnorm0_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_batchnorm0_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_batchnorm0_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "resnetv10_batchnorm0_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "resnetv10_relu0_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_quantized_pooling", 
+      "name": "quantized_resnetv10_pool0_fwd", 
+      "attrs": {
+        "global_pool": "False", 
+        "kernel": "(3, 3)", 
+        "layout": "NCHW", 
+        "pad": "(1, 1)", 
+        "pool_type": "max", 
+        "pooling_convention": "valid", 
+        "stride": "(2, 2)"
+      }, 
+      "inputs": [[7, 0, 0], [7, 1, 0], [7, 2, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64, 64, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_batchnorm0_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_batchnorm0_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_batchnorm0_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_batchnorm0_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_1", 
+      "attrs": {
+        "max_calib_range": "17.692879", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[8, 0, 0], [9, 0, 0], [10, 0, 0], [11, 0, 0], [12, 0, 0], [13, 0, 1], [14, 0, 1], [8, 1, 0], [8, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "resnetv10_pool0_fwd_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "resnetv10_stage1_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "64", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_batchnorm0_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_batchnorm0_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_batchnorm0_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_batchnorm0_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "resnetv10_stage1_batchnorm0_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "resnetv10_stage1_relu0_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[8, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12
+          ], 
+          "heads": [[9, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_conv1_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64, 64, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_batchnorm1_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_batchnorm1_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_batchnorm1_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_batchnorm1_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_2", 
+      "attrs": {
+        "max_calib_range": "15.738866", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[15, 0, 0], [16, 0, 0], [17, 0, 0], [18, 0, 0], [19, 0, 1], [20, 0, 1], [15, 1, 0], [15, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_1_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_conv1_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "resnetv10_stage1_conv1_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "64", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_batchnorm1_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_batchnorm1_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_batchnorm1_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_batchnorm1_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "resnetv10_stage1_batchnorm1_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "resnetv10_stage1_relu1_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_conv2_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256, 64, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_conv2_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_batchnorm2_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_batchnorm2_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_batchnorm2_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_batchnorm2_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_conv3_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256, 64, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_batchnorm3_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_batchnorm3_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_batchnorm3_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_batchnorm3_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_4", 
+      "attrs": {
+        "max_calib_range": "14.089601", 
+        "min_calib_range": "-36.878681", 
+        "quantized": "true", 
+        "with_bn": "true"
+      }, 
+      "inputs": [[8, 0, 0], [28, 0, 0], [29, 0, 0], [30, 0, 0], [31, 0, 1], [32, 0, 1], [8, 1, 0], [8, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "resnetv10_pool0_fwd_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_conv3_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "resnetv10_stage1_conv3_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "256", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_batchnorm3_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_batchnorm3_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_batchnorm3_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_batchnorm3_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "resnetv10_stage1_batchnorm3_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10], 
+          "heads": [[7, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_add_relu_3", 
+      "attrs": {
+        "max_calib_range": "14.925311", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_postsum_relu": "true", 
+        "with_sum": "true"
+      }, 
+      "inputs": [
+        [21, 0, 0], 
+        [22, 0, 0], 
+        [23, 0, 0], 
+        [24, 0, 0], 
+        [25, 0, 0], 
+        [26, 0, 1], 
+        [27, 0, 1], 
+        [33, 0, 0], 
+        [21, 1, 0], 
+        [21, 2, 0], 
+        [33, 1, 0], 
+        [33, 2, 0]
+      ], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_2_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_conv2_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_conv2_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "resnetv10_stage1_conv2_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "256", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_batchnorm2_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_batchnorm2_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_batchnorm2_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_batchnorm2_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "resnetv10_stage1_batchnorm2_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_batchnorm3_fwd_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "elemwise_add", 
+              "name": "resnetv10_stage1__plus0", 
+              "inputs": [[8, 0, 0], [9, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "resnetv10_stage1_activation0", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[10, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7, 9], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12, 
+            13, 
+            14
+          ], 
+          "heads": [[11, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_conv4_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64, 256, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_conv4_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_batchnorm4_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_batchnorm4_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_batchnorm4_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_batchnorm4_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_5", 
+      "attrs": {
+        "max_calib_range": "10.324755", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[34, 0, 0], [35, 0, 0], [36, 0, 0], [37, 0, 0], [38, 0, 0], [39, 0, 1], [40, 0, 1], [34, 1, 0], [34, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_3_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_conv4_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_conv4_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "resnetv10_stage1_conv4_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "64", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_batchnorm4_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_batchnorm4_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_batchnorm4_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_batchnorm4_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "resnetv10_stage1_batchnorm4_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "resnetv10_stage1_relu2_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[8, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12
+          ], 
+          "heads": [[9, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_conv5_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64, 64, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_batchnorm5_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_batchnorm5_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_batchnorm5_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_batchnorm5_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_6", 
+      "attrs": {
+        "max_calib_range": "12.012566", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[41, 0, 0], [42, 0, 0], [43, 0, 0], [44, 0, 0], [45, 0, 1], [46, 0, 1], [41, 1, 0], [41, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_5_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_conv5_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "resnetv10_stage1_conv5_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "64", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_batchnorm5_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_batchnorm5_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_batchnorm5_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_batchnorm5_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "resnetv10_stage1_batchnorm5_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "resnetv10_stage1_relu3_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_conv6_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256, 64, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_conv6_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_batchnorm6_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_batchnorm6_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_batchnorm6_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_batchnorm6_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_add_relu_7", 
+      "attrs": {
+        "max_calib_range": "20.961098", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_postsum_relu": "true", 
+        "with_sum": "true"
+      }, 
+      "inputs": [
+        [47, 0, 0], 
+        [48, 0, 0], 
+        [49, 0, 0], 
+        [50, 0, 0], 
+        [51, 0, 0], 
+        [52, 0, 1], 
+        [53, 0, 1], 
+        [34, 0, 0], 
+        [47, 1, 0], 
+        [47, 2, 0], 
+        [34, 1, 0], 
+        [34, 2, 0]
+      ], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_6_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_conv6_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_conv6_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "resnetv10_stage1_conv6_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "256", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_batchnorm6_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_batchnorm6_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_batchnorm6_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_batchnorm6_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "resnetv10_stage1_batchnorm6_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_3_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "elemwise_add", 
+              "name": "resnetv10_stage1__plus1", 
+              "inputs": [[8, 0, 0], [9, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "resnetv10_stage1_activation1", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[10, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7, 9], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12, 
+            13, 
+            14
+          ], 
+          "heads": [[11, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_conv7_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64, 256, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_conv7_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_batchnorm7_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_batchnorm7_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_batchnorm7_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_batchnorm7_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_8", 
+      "attrs": {
+        "max_calib_range": "14.017304", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[54, 0, 0], [55, 0, 0], [56, 0, 0], [57, 0, 0], [58, 0, 0], [59, 0, 1], [60, 0, 1], [54, 1, 0], [54, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_7_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_conv7_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_conv7_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "resnetv10_stage1_conv7_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "64", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_batchnorm7_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_batchnorm7_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_batchnorm7_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_batchnorm7_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "resnetv10_stage1_batchnorm7_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "resnetv10_stage1_relu4_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[8, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12
+          ], 
+          "heads": [[9, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_conv8_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64, 64, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_batchnorm8_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_batchnorm8_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_batchnorm8_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_batchnorm8_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_9", 
+      "attrs": {
+        "max_calib_range": "24.763096", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[61, 0, 0], [62, 0, 0], [63, 0, 0], [64, 0, 0], [65, 0, 1], [66, 0, 1], [61, 1, 0], [61, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_8_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_conv8_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "resnetv10_stage1_conv8_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "64", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_batchnorm8_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_batchnorm8_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_batchnorm8_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_batchnorm8_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "resnetv10_stage1_batchnorm8_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "resnetv10_stage1_relu5_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_conv9_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256, 64, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_conv9_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_batchnorm9_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_batchnorm9_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_batchnorm9_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage1_batchnorm9_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_add_relu_10", 
+      "attrs": {
+        "max_calib_range": "20.881592", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_postsum_relu": "true", 
+        "with_sum": "true"
+      }, 
+      "inputs": [
+        [67, 0, 0], 
+        [68, 0, 0], 
+        [69, 0, 0], 
+        [70, 0, 0], 
+        [71, 0, 0], 
+        [72, 0, 1], 
+        [73, 0, 1], 
+        [54, 0, 0], 
+        [67, 1, 0], 
+        [67, 2, 0], 
+        [54, 1, 0], 
+        [54, 2, 0]
+      ], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_9_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_conv9_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_conv9_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "resnetv10_stage1_conv9_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "256", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_batchnorm9_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_batchnorm9_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_batchnorm9_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage1_batchnorm9_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "resnetv10_stage1_batchnorm9_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_7_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "elemwise_add", 
+              "name": "resnetv10_stage1__plus2", 
+              "inputs": [[8, 0, 0], [9, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "resnetv10_stage1_activation2", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[10, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7, 9], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12, 
+            13, 
+            14
+          ], 
+          "heads": [[11, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128, 256, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_batchnorm0_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_batchnorm0_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_batchnorm0_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_batchnorm0_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_11", 
+      "attrs": {
+        "max_calib_range": "12.303838", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[74, 0, 0], [75, 0, 0], [76, 0, 0], [77, 0, 0], [78, 0, 0], [79, 0, 1], [80, 0, 1], [74, 1, 0], [74, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_10_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "resnetv10_stage2_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "128", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(2, 2)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_batchnorm0_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_batchnorm0_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_batchnorm0_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_batchnorm0_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "resnetv10_stage2_batchnorm0_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "resnetv10_stage2_relu0_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[8, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12
+          ], 
+          "heads": [[9, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_conv1_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128, 128, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_batchnorm1_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_batchnorm1_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_batchnorm1_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_batchnorm1_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_12", 
+      "attrs": {
+        "max_calib_range": "11.038647", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[81, 0, 0], [82, 0, 0], [83, 0, 0], [84, 0, 0], [85, 0, 1], [86, 0, 1], [81, 1, 0], [81, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_11_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_conv1_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "resnetv10_stage2_conv1_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "128", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_batchnorm1_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_batchnorm1_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_batchnorm1_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_batchnorm1_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "resnetv10_stage2_batchnorm1_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "resnetv10_stage2_relu1_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_conv2_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 128, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_conv2_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_batchnorm2_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_batchnorm2_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_batchnorm2_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_batchnorm2_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_conv3_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 256, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_batchnorm3_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_batchnorm3_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_batchnorm3_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_batchnorm3_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_14", 
+      "attrs": {
+        "max_calib_range": "24.462372", 
+        "min_calib_range": "-16.531317", 
+        "quantized": "true", 
+        "with_bn": "true"
+      }, 
+      "inputs": [[74, 0, 0], [94, 0, 0], [95, 0, 0], [96, 0, 0], [97, 0, 1], [98, 0, 1], [74, 1, 0], [74, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_10_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_conv3_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "resnetv10_stage2_conv3_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "512", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(2, 2)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_batchnorm3_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_batchnorm3_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_batchnorm3_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_batchnorm3_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "resnetv10_stage2_batchnorm3_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10], 
+          "heads": [[7, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_add_relu_13", 
+      "attrs": {
+        "max_calib_range": "23.952017", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_postsum_relu": "true", 
+        "with_sum": "true"
+      }, 
+      "inputs": [
+        [87, 0, 0], 
+        [88, 0, 0], 
+        [89, 0, 0], 
+        [90, 0, 0], 
+        [91, 0, 0], 
+        [92, 0, 1], 
+        [93, 0, 1], 
+        [99, 0, 0], 
+        [87, 1, 0], 
+        [87, 2, 0], 
+        [99, 1, 0], 
+        [99, 2, 0]
+      ], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_12_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_conv2_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_conv2_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "resnetv10_stage2_conv2_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "512", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_batchnorm2_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_batchnorm2_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_batchnorm2_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_batchnorm2_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "resnetv10_stage2_batchnorm2_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_batchnorm3_fwd_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "elemwise_add", 
+              "name": "resnetv10_stage2__plus0", 
+              "inputs": [[8, 0, 0], [9, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "resnetv10_stage2_activation0", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[10, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7, 9], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12, 
+            13, 
+            14
+          ], 
+          "heads": [[11, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_conv4_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128, 512, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_conv4_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_batchnorm4_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_batchnorm4_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_batchnorm4_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_batchnorm4_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_15", 
+      "attrs": {
+        "max_calib_range": "15.537408", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[100, 0, 0], [101, 0, 0], [102, 0, 0], [103, 0, 0], [104, 0, 0], [105, 0, 1], [106, 0, 1], [100, 1, 0], [100, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_13_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_conv4_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_conv4_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "resnetv10_stage2_conv4_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "128", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_batchnorm4_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_batchnorm4_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_batchnorm4_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_batchnorm4_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "resnetv10_stage2_batchnorm4_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "resnetv10_stage2_relu2_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[8, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12
+          ], 
+          "heads": [[9, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_conv5_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128, 128, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_batchnorm5_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_batchnorm5_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_batchnorm5_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_batchnorm5_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_16", 
+      "attrs": {
+        "max_calib_range": "15.847849", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[107, 0, 0], [108, 0, 0], [109, 0, 0], [110, 0, 0], [111, 0, 1], [112, 0, 1], [107, 1, 0], [107, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_15_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_conv5_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "resnetv10_stage2_conv5_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "128", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_batchnorm5_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_batchnorm5_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_batchnorm5_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_batchnorm5_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "resnetv10_stage2_batchnorm5_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "resnetv10_stage2_relu3_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_conv6_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 128, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_conv6_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_batchnorm6_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_batchnorm6_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_batchnorm6_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_batchnorm6_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_add_relu_17", 
+      "attrs": {
+        "max_calib_range": "18.434828", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_postsum_relu": "true", 
+        "with_sum": "true"
+      }, 
+      "inputs": [
+        [113, 0, 0], 
+        [114, 0, 0], 
+        [115, 0, 0], 
+        [116, 0, 0], 
+        [117, 0, 0], 
+        [118, 0, 1], 
+        [119, 0, 1], 
+        [100, 0, 0], 
+        [113, 1, 0], 
+        [113, 2, 0], 
+        [100, 1, 0], 
+        [100, 2, 0]
+      ], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_16_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_conv6_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_conv6_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "resnetv10_stage2_conv6_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "512", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_batchnorm6_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_batchnorm6_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_batchnorm6_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_batchnorm6_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "resnetv10_stage2_batchnorm6_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_13_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "elemwise_add", 
+              "name": "resnetv10_stage2__plus1", 
+              "inputs": [[8, 0, 0], [9, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "resnetv10_stage2_activation1", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[10, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7, 9], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12, 
+            13, 
+            14
+          ], 
+          "heads": [[11, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_conv7_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128, 512, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_conv7_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_batchnorm7_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_batchnorm7_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_batchnorm7_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_batchnorm7_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_18", 
+      "attrs": {
+        "max_calib_range": "13.915319", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[120, 0, 0], [121, 0, 0], [122, 0, 0], [123, 0, 0], [124, 0, 0], [125, 0, 1], [126, 0, 1], [120, 1, 0], [120, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_17_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_conv7_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_conv7_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "resnetv10_stage2_conv7_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "128", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_batchnorm7_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_batchnorm7_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_batchnorm7_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_batchnorm7_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "resnetv10_stage2_batchnorm7_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "resnetv10_stage2_relu4_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[8, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12
+          ], 
+          "heads": [[9, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_conv8_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128, 128, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_batchnorm8_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_batchnorm8_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_batchnorm8_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_batchnorm8_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_19", 
+      "attrs": {
+        "max_calib_range": "19.091326", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[127, 0, 0], [128, 0, 0], [129, 0, 0], [130, 0, 0], [131, 0, 1], [132, 0, 1], [127, 1, 0], [127, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_18_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_conv8_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "resnetv10_stage2_conv8_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "128", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_batchnorm8_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_batchnorm8_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_batchnorm8_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_batchnorm8_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "resnetv10_stage2_batchnorm8_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "resnetv10_stage2_relu5_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_conv9_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 128, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_conv9_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_batchnorm9_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_batchnorm9_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_batchnorm9_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_batchnorm9_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_add_relu_20", 
+      "attrs": {
+        "max_calib_range": "20.155378", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_postsum_relu": "true", 
+        "with_sum": "true"
+      }, 
+      "inputs": [
+        [133, 0, 0], 
+        [134, 0, 0], 
+        [135, 0, 0], 
+        [136, 0, 0], 
+        [137, 0, 0], 
+        [138, 0, 1], 
+        [139, 0, 1], 
+        [120, 0, 0], 
+        [133, 1, 0], 
+        [133, 2, 0], 
+        [120, 1, 0], 
+        [120, 2, 0]
+      ], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_19_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_conv9_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_conv9_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "resnetv10_stage2_conv9_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "512", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_batchnorm9_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_batchnorm9_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_batchnorm9_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_batchnorm9_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "resnetv10_stage2_batchnorm9_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_17_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "elemwise_add", 
+              "name": "resnetv10_stage2__plus2", 
+              "inputs": [[8, 0, 0], [9, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "resnetv10_stage2_activation2", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[10, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7, 9], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12, 
+            13, 
+            14
+          ], 
+          "heads": [[11, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_conv10_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128, 512, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_conv10_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_batchnorm10_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_batchnorm10_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_batchnorm10_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_batchnorm10_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_21", 
+      "attrs": {
+        "max_calib_range": "20.129475", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[140, 0, 0], [141, 0, 0], [142, 0, 0], [143, 0, 0], [144, 0, 0], [145, 0, 1], [146, 0, 1], [140, 1, 0], [140, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_20_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_conv10_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_conv10_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "resnetv10_stage2_conv10_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "128", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_batchnorm10_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_batchnorm10_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_batchnorm10_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_batchnorm10_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "resnetv10_stage2_batchnorm10_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "resnetv10_stage2_relu6_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[8, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12
+          ], 
+          "heads": [[9, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_conv11_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128, 128, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_batchnorm11_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_batchnorm11_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_batchnorm11_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_batchnorm11_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_22", 
+      "attrs": {
+        "max_calib_range": "15.679976", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[147, 0, 0], [148, 0, 0], [149, 0, 0], [150, 0, 0], [151, 0, 1], [152, 0, 1], [147, 1, 0], [147, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_21_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_conv11_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "resnetv10_stage2_conv11_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "128", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_batchnorm11_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_batchnorm11_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_batchnorm11_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_batchnorm11_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "resnetv10_stage2_batchnorm11_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "resnetv10_stage2_relu7_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_conv12_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 128, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_conv12_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_batchnorm12_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_batchnorm12_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_batchnorm12_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage2_batchnorm12_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_add_relu_23", 
+      "attrs": {
+        "max_calib_range": "23.930492", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_postsum_relu": "true", 
+        "with_sum": "true"
+      }, 
+      "inputs": [
+        [153, 0, 0], 
+        [154, 0, 0], 
+        [155, 0, 0], 
+        [156, 0, 0], 
+        [157, 0, 0], 
+        [158, 0, 1], 
+        [159, 0, 1], 
+        [140, 0, 0], 
+        [153, 1, 0], 
+        [153, 2, 0], 
+        [140, 1, 0], 
+        [140, 2, 0]
+      ], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_22_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_conv12_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_conv12_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "resnetv10_stage2_conv12_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "512", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_batchnorm12_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_batchnorm12_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_batchnorm12_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage2_batchnorm12_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "resnetv10_stage2_batchnorm12_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_20_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "elemwise_add", 
+              "name": "resnetv10_stage2__plus3", 
+              "inputs": [[8, 0, 0], [9, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "resnetv10_stage2_activation3", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[10, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7, 9], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12, 
+            13, 
+            14
+          ], 
+          "heads": [[11, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256, 512, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm0_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm0_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm0_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm0_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_24", 
+      "attrs": {
+        "max_calib_range": "10.704535", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[160, 0, 0], [161, 0, 0], [162, 0, 0], [163, 0, 0], [164, 0, 0], [165, 0, 1], [166, 0, 1], [160, 1, 0], [160, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_23_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "resnetv10_stage3_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "256", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(2, 2)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm0_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm0_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm0_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm0_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "resnetv10_stage3_batchnorm0_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "resnetv10_stage3_relu0_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[8, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12
+          ], 
+          "heads": [[9, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_conv1_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256, 256, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm1_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm1_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm1_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm1_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_25", 
+      "attrs": {
+        "max_calib_range": "8.525423", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[167, 0, 0], [168, 0, 0], [169, 0, 0], [170, 0, 0], [171, 0, 1], [172, 0, 1], [167, 1, 0], [167, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_24_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_conv1_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "resnetv10_stage3_conv1_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "256", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm1_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm1_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm1_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm1_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "resnetv10_stage3_batchnorm1_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "resnetv10_stage3_relu1_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_conv2_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024, 256, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_conv2_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm2_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm2_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm2_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm2_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_conv3_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024, 512, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm3_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm3_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm3_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm3_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_27", 
+      "attrs": {
+        "max_calib_range": "17.089722", 
+        "min_calib_range": "-12.146319", 
+        "quantized": "true", 
+        "with_bn": "true"
+      }, 
+      "inputs": [[160, 0, 0], [180, 0, 0], [181, 0, 0], [182, 0, 0], [183, 0, 1], [184, 0, 1], [160, 1, 0], [160, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_23_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_conv3_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "resnetv10_stage3_conv3_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "1024", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(2, 2)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm3_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm3_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm3_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm3_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "resnetv10_stage3_batchnorm3_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10], 
+          "heads": [[7, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_add_relu_26", 
+      "attrs": {
+        "max_calib_range": "18.613106", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_postsum_relu": "true", 
+        "with_sum": "true"
+      }, 
+      "inputs": [
+        [173, 0, 0], 
+        [174, 0, 0], 
+        [175, 0, 0], 
+        [176, 0, 0], 
+        [177, 0, 0], 
+        [178, 0, 1], 
+        [179, 0, 1], 
+        [185, 0, 0], 
+        [173, 1, 0], 
+        [173, 2, 0], 
+        [185, 1, 0], 
+        [185, 2, 0]
+      ], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_25_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_conv2_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_conv2_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "resnetv10_stage3_conv2_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "1024", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm2_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm2_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm2_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm2_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "resnetv10_stage3_batchnorm2_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm3_fwd_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "elemwise_add", 
+              "name": "resnetv10_stage3__plus0", 
+              "inputs": [[8, 0, 0], [9, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "resnetv10_stage3_activation0", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[10, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7, 9], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12, 
+            13, 
+            14
+          ], 
+          "heads": [[11, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_conv4_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256, 1024, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_conv4_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm4_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm4_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm4_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm4_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_28", 
+      "attrs": {
+        "max_calib_range": "11.316041", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[186, 0, 0], [187, 0, 0], [188, 0, 0], [189, 0, 0], [190, 0, 0], [191, 0, 1], [192, 0, 1], [186, 1, 0], [186, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_26_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_conv4_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_conv4_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "resnetv10_stage3_conv4_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "256", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm4_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm4_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm4_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm4_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "resnetv10_stage3_batchnorm4_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "resnetv10_stage3_relu2_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[8, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12
+          ], 
+          "heads": [[9, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_conv5_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256, 256, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm5_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm5_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm5_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm5_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_29", 
+      "attrs": {
+        "max_calib_range": "8.063420", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[193, 0, 0], [194, 0, 0], [195, 0, 0], [196, 0, 0], [197, 0, 1], [198, 0, 1], [193, 1, 0], [193, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_28_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_conv5_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "resnetv10_stage3_conv5_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "256", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm5_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm5_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm5_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm5_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "resnetv10_stage3_batchnorm5_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "resnetv10_stage3_relu3_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_conv6_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024, 256, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_conv6_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm6_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm6_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm6_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm6_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_add_relu_30", 
+      "attrs": {
+        "max_calib_range": "14.595169", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_postsum_relu": "true", 
+        "with_sum": "true"
+      }, 
+      "inputs": [
+        [199, 0, 0], 
+        [200, 0, 0], 
+        [201, 0, 0], 
+        [202, 0, 0], 
+        [203, 0, 0], 
+        [204, 0, 1], 
+        [205, 0, 1], 
+        [186, 0, 0], 
+        [199, 1, 0], 
+        [199, 2, 0], 
+        [186, 1, 0], 
+        [186, 2, 0]
+      ], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_29_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_conv6_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_conv6_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "resnetv10_stage3_conv6_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "1024", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm6_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm6_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm6_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm6_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "resnetv10_stage3_batchnorm6_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_26_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "elemwise_add", 
+              "name": "resnetv10_stage3__plus1", 
+              "inputs": [[8, 0, 0], [9, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "resnetv10_stage3_activation1", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[10, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7, 9], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12, 
+            13, 
+            14
+          ], 
+          "heads": [[11, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_conv7_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256, 1024, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_conv7_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm7_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm7_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm7_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm7_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_31", 
+      "attrs": {
+        "max_calib_range": "8.072557", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[206, 0, 0], [207, 0, 0], [208, 0, 0], [209, 0, 0], [210, 0, 0], [211, 0, 1], [212, 0, 1], [206, 1, 0], [206, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_30_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_conv7_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_conv7_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "resnetv10_stage3_conv7_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "256", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm7_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm7_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm7_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm7_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "resnetv10_stage3_batchnorm7_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "resnetv10_stage3_relu4_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[8, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12
+          ], 
+          "heads": [[9, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_conv8_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256, 256, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm8_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm8_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm8_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm8_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_32", 
+      "attrs": {
+        "max_calib_range": "9.256506", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[213, 0, 0], [214, 0, 0], [215, 0, 0], [216, 0, 0], [217, 0, 1], [218, 0, 1], [213, 1, 0], [213, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_31_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_conv8_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "resnetv10_stage3_conv8_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "256", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm8_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm8_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm8_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm8_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "resnetv10_stage3_batchnorm8_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "resnetv10_stage3_relu5_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_conv9_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024, 256, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_conv9_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm9_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm9_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm9_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm9_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_add_relu_33", 
+      "attrs": {
+        "max_calib_range": "13.494219", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_postsum_relu": "true", 
+        "with_sum": "true"
+      }, 
+      "inputs": [
+        [219, 0, 0], 
+        [220, 0, 0], 
+        [221, 0, 0], 
+        [222, 0, 0], 
+        [223, 0, 0], 
+        [224, 0, 1], 
+        [225, 0, 1], 
+        [206, 0, 0], 
+        [219, 1, 0], 
+        [219, 2, 0], 
+        [206, 1, 0], 
+        [206, 2, 0]
+      ], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_32_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_conv9_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_conv9_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "resnetv10_stage3_conv9_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "1024", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm9_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm9_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm9_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm9_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "resnetv10_stage3_batchnorm9_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_30_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "elemwise_add", 
+              "name": "resnetv10_stage3__plus2", 
+              "inputs": [[8, 0, 0], [9, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "resnetv10_stage3_activation2", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[10, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7, 9], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12, 
+            13, 
+            14
+          ], 
+          "heads": [[11, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_conv10_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256, 1024, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_conv10_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm10_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm10_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm10_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm10_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_34", 
+      "attrs": {
+        "max_calib_range": "11.622367", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[226, 0, 0], [227, 0, 0], [228, 0, 0], [229, 0, 0], [230, 0, 0], [231, 0, 1], [232, 0, 1], [226, 1, 0], [226, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_33_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_conv10_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_conv10_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "resnetv10_stage3_conv10_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "256", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm10_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm10_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm10_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm10_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "resnetv10_stage3_batchnorm10_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "resnetv10_stage3_relu6_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[8, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12
+          ], 
+          "heads": [[9, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_conv11_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256, 256, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm11_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm11_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm11_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm11_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_35", 
+      "attrs": {
+        "max_calib_range": "9.712450", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[233, 0, 0], [234, 0, 0], [235, 0, 0], [236, 0, 0], [237, 0, 1], [238, 0, 1], [233, 1, 0], [233, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_34_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_conv11_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "resnetv10_stage3_conv11_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "256", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm11_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm11_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm11_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm11_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "resnetv10_stage3_batchnorm11_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "resnetv10_stage3_relu7_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_conv12_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024, 256, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_conv12_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm12_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm12_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm12_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm12_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_add_relu_36", 
+      "attrs": {
+        "max_calib_range": "14.864284", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_postsum_relu": "true", 
+        "with_sum": "true"
+      }, 
+      "inputs": [
+        [239, 0, 0], 
+        [240, 0, 0], 
+        [241, 0, 0], 
+        [242, 0, 0], 
+        [243, 0, 0], 
+        [244, 0, 1], 
+        [245, 0, 1], 
+        [226, 0, 0], 
+        [239, 1, 0], 
+        [239, 2, 0], 
+        [226, 1, 0], 
+        [226, 2, 0]
+      ], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_35_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_conv12_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_conv12_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "resnetv10_stage3_conv12_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "1024", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm12_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm12_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm12_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm12_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "resnetv10_stage3_batchnorm12_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_33_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "elemwise_add", 
+              "name": "resnetv10_stage3__plus3", 
+              "inputs": [[8, 0, 0], [9, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "resnetv10_stage3_activation3", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[10, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7, 9], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12, 
+            13, 
+            14
+          ], 
+          "heads": [[11, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_conv13_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256, 1024, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_conv13_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm13_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm13_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm13_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm13_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_37", 
+      "attrs": {
+        "max_calib_range": "14.608517", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[246, 0, 0], [247, 0, 0], [248, 0, 0], [249, 0, 0], [250, 0, 0], [251, 0, 1], [252, 0, 1], [246, 1, 0], [246, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_36_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_conv13_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_conv13_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "resnetv10_stage3_conv13_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "256", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm13_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm13_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm13_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm13_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "resnetv10_stage3_batchnorm13_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "resnetv10_stage3_relu8_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[8, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12
+          ], 
+          "heads": [[9, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_conv14_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256, 256, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm14_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm14_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm14_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm14_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_38", 
+      "attrs": {
+        "max_calib_range": "14.155235", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[253, 0, 0], [254, 0, 0], [255, 0, 0], [256, 0, 0], [257, 0, 1], [258, 0, 1], [253, 1, 0], [253, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_37_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_conv14_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "resnetv10_stage3_conv14_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "256", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm14_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm14_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm14_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm14_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "resnetv10_stage3_batchnorm14_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "resnetv10_stage3_relu9_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_conv15_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024, 256, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_conv15_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm15_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm15_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm15_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm15_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_add_relu_39", 
+      "attrs": {
+        "max_calib_range": "20.607891", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_postsum_relu": "true", 
+        "with_sum": "true"
+      }, 
+      "inputs": [
+        [259, 0, 0], 
+        [260, 0, 0], 
+        [261, 0, 0], 
+        [262, 0, 0], 
+        [263, 0, 0], 
+        [264, 0, 1], 
+        [265, 0, 1], 
+        [246, 0, 0], 
+        [259, 1, 0], 
+        [259, 2, 0], 
+        [246, 1, 0], 
+        [246, 2, 0]
+      ], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_38_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_conv15_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_conv15_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "resnetv10_stage3_conv15_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "1024", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm15_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm15_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm15_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm15_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "resnetv10_stage3_batchnorm15_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_36_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "elemwise_add", 
+              "name": "resnetv10_stage3__plus4", 
+              "inputs": [[8, 0, 0], [9, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "resnetv10_stage3_activation4", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[10, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7, 9], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12, 
+            13, 
+            14
+          ], 
+          "heads": [[11, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_conv16_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256, 1024, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_conv16_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm16_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm16_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm16_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm16_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_40", 
+      "attrs": {
+        "max_calib_range": "13.343627", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[266, 0, 0], [267, 0, 0], [268, 0, 0], [269, 0, 0], [270, 0, 0], [271, 0, 1], [272, 0, 1], [266, 1, 0], [266, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_39_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_conv16_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_conv16_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "resnetv10_stage3_conv16_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "256", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm16_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm16_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm16_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm16_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "resnetv10_stage3_batchnorm16_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "resnetv10_stage3_relu10_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[8, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12
+          ], 
+          "heads": [[9, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_conv17_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256, 256, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm17_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm17_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm17_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm17_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_41", 
+      "attrs": {
+        "max_calib_range": "14.610030", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[273, 0, 0], [274, 0, 0], [275, 0, 0], [276, 0, 0], [277, 0, 1], [278, 0, 1], [273, 1, 0], [273, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_40_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_conv17_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "resnetv10_stage3_conv17_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "256", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm17_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm17_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm17_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm17_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "resnetv10_stage3_batchnorm17_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "resnetv10_stage3_relu11_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_conv18_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024, 256, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_conv18_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm18_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm18_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm18_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage3_batchnorm18_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_add_relu_42", 
+      "attrs": {
+        "max_calib_range": "20.540854", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_postsum_relu": "true", 
+        "with_sum": "true"
+      }, 
+      "inputs": [
+        [279, 0, 0], 
+        [280, 0, 0], 
+        [281, 0, 0], 
+        [282, 0, 0], 
+        [283, 0, 0], 
+        [284, 0, 1], 
+        [285, 0, 1], 
+        [266, 0, 0], 
+        [279, 1, 0], 
+        [279, 2, 0], 
+        [266, 1, 0], 
+        [266, 2, 0]
+      ], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_41_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_conv18_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_conv18_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "resnetv10_stage3_conv18_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "1024", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm18_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm18_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm18_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage3_batchnorm18_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "resnetv10_stage3_batchnorm18_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_39_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "elemwise_add", 
+              "name": "resnetv10_stage3__plus5", 
+              "inputs": [[8, 0, 0], [9, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "resnetv10_stage3_activation5", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[10, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7, 9], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12, 
+            13, 
+            14
+          ], 
+          "heads": [[11, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 1024, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_batchnorm0_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_batchnorm0_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_batchnorm0_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_batchnorm0_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_43", 
+      "attrs": {
+        "max_calib_range": "10.681038", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[286, 0, 0], [287, 0, 0], [288, 0, 0], [289, 0, 0], [290, 0, 0], [291, 0, 1], [292, 0, 1], [286, 1, 0], [286, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_42_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "resnetv10_stage4_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "512", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(2, 2)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_batchnorm0_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_batchnorm0_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_batchnorm0_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_batchnorm0_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "resnetv10_stage4_batchnorm0_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "resnetv10_stage4_relu0_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[8, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12
+          ], 
+          "heads": [[9, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_conv1_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 512, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_batchnorm1_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_batchnorm1_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_batchnorm1_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_batchnorm1_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_44", 
+      "attrs": {
+        "max_calib_range": "8.364565", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[293, 0, 0], [294, 0, 0], [295, 0, 0], [296, 0, 0], [297, 0, 1], [298, 0, 1], [293, 1, 0], [293, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_43_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_conv1_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "resnetv10_stage4_conv1_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "512", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_batchnorm1_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_batchnorm1_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_batchnorm1_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_batchnorm1_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "resnetv10_stage4_batchnorm1_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "resnetv10_stage4_relu1_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_conv2_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(2048, 512, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_conv2_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(2048,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_batchnorm2_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(2048,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_batchnorm2_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(2048,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_batchnorm2_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(2048,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_batchnorm2_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(2048,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_conv3_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(2048, 1024, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_batchnorm3_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(2048,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_batchnorm3_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(2048,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_batchnorm3_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(2048,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_batchnorm3_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(2048,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_46", 
+      "attrs": {
+        "max_calib_range": "53.855495", 
+        "min_calib_range": "-25.451092", 
+        "quantized": "true", 
+        "with_bn": "true"
+      }, 
+      "inputs": [[286, 0, 0], [306, 0, 0], [307, 0, 0], [308, 0, 0], [309, 0, 1], [310, 0, 1], [286, 1, 0], [286, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_42_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_conv3_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "resnetv10_stage4_conv3_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "2048", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(2, 2)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_batchnorm3_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_batchnorm3_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_batchnorm3_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_batchnorm3_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "resnetv10_stage4_batchnorm3_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10], 
+          "heads": [[7, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_add_relu_45", 
+      "attrs": {
+        "max_calib_range": "54.005638", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_postsum_relu": "true", 
+        "with_sum": "true"
+      }, 
+      "inputs": [
+        [299, 0, 0], 
+        [300, 0, 0], 
+        [301, 0, 0], 
+        [302, 0, 0], 
+        [303, 0, 0], 
+        [304, 0, 1], 
+        [305, 0, 1], 
+        [311, 0, 0], 
+        [299, 1, 0], 
+        [299, 2, 0], 
+        [311, 1, 0], 
+        [311, 2, 0]
+      ], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_44_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_conv2_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_conv2_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "resnetv10_stage4_conv2_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "2048", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_batchnorm2_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_batchnorm2_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_batchnorm2_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_batchnorm2_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "resnetv10_stage4_batchnorm2_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_batchnorm3_fwd_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "elemwise_add", 
+              "name": "resnetv10_stage4__plus0", 
+              "inputs": [[8, 0, 0], [9, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "resnetv10_stage4_activation0", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[10, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7, 9], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12, 
+            13, 
+            14
+          ], 
+          "heads": [[11, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_conv4_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 2048, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_conv4_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_batchnorm4_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_batchnorm4_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_batchnorm4_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_batchnorm4_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_47", 
+      "attrs": {
+        "max_calib_range": "10.894166", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[312, 0, 0], [313, 0, 0], [314, 0, 0], [315, 0, 0], [316, 0, 0], [317, 0, 1], [318, 0, 1], [312, 1, 0], [312, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_45_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_conv4_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_conv4_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "resnetv10_stage4_conv4_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "512", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_batchnorm4_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_batchnorm4_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_batchnorm4_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_batchnorm4_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "resnetv10_stage4_batchnorm4_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "resnetv10_stage4_relu2_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[8, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12
+          ], 
+          "heads": [[9, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_conv5_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 512, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_batchnorm5_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_batchnorm5_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_batchnorm5_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_batchnorm5_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_48", 
+      "attrs": {
+        "max_calib_range": "6.628451", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[319, 0, 0], [320, 0, 0], [321, 0, 0], [322, 0, 0], [323, 0, 1], [324, 0, 1], [319, 1, 0], [319, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_47_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_conv5_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "resnetv10_stage4_conv5_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "512", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_batchnorm5_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_batchnorm5_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_batchnorm5_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_batchnorm5_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "resnetv10_stage4_batchnorm5_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "resnetv10_stage4_relu3_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_conv6_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(2048, 512, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_conv6_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(2048,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_batchnorm6_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(2048,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_batchnorm6_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(2048,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_batchnorm6_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(2048,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_batchnorm6_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(2048,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_add_relu_49", 
+      "attrs": {
+        "max_calib_range": "70.722534", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_postsum_relu": "true", 
+        "with_sum": "true"
+      }, 
+      "inputs": [
+        [325, 0, 0], 
+        [326, 0, 0], 
+        [327, 0, 0], 
+        [328, 0, 0], 
+        [329, 0, 0], 
+        [330, 0, 1], 
+        [331, 0, 1], 
+        [312, 0, 0], 
+        [325, 1, 0], 
+        [325, 2, 0], 
+        [312, 1, 0], 
+        [312, 2, 0]
+      ], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_48_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_conv6_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_conv6_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "resnetv10_stage4_conv6_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "2048", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_batchnorm6_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_batchnorm6_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_batchnorm6_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_batchnorm6_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "resnetv10_stage4_batchnorm6_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_45_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "elemwise_add", 
+              "name": "resnetv10_stage4__plus1", 
+              "inputs": [[8, 0, 0], [9, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "resnetv10_stage4_activation1", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[10, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7, 9], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12, 
+            13, 
+            14
+          ], 
+          "heads": [[11, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_conv7_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 2048, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_conv7_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_batchnorm7_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_batchnorm7_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_batchnorm7_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_batchnorm7_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_50", 
+      "attrs": {
+        "max_calib_range": "8.861896", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[332, 0, 0], [333, 0, 0], [334, 0, 0], [335, 0, 0], [336, 0, 0], [337, 0, 1], [338, 0, 1], [332, 1, 0], [332, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_49_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_conv7_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_conv7_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "resnetv10_stage4_conv7_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "512", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_batchnorm7_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_batchnorm7_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_batchnorm7_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_batchnorm7_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "resnetv10_stage4_batchnorm7_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "resnetv10_stage4_relu4_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[8, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12
+          ], 
+          "heads": [[9, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_conv8_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 512, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_batchnorm8_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_batchnorm8_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_batchnorm8_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_batchnorm8_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_51", 
+      "attrs": {
+        "max_calib_range": "8.543266", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[339, 0, 0], [340, 0, 0], [341, 0, 0], [342, 0, 0], [343, 0, 1], [344, 0, 1], [339, 1, 0], [339, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_50_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_conv8_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "resnetv10_stage4_conv8_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "512", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_batchnorm8_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_batchnorm8_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_batchnorm8_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_batchnorm8_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "resnetv10_stage4_batchnorm8_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "resnetv10_stage4_relu5_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_conv9_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(2048, 512, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_conv9_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(2048,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_batchnorm9_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(2048,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_batchnorm9_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(2048,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_batchnorm9_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(2048,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_stage4_batchnorm9_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(2048,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_add_relu_52", 
+      "attrs": {
+        "max_calib_range": "80.659859", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_postsum_relu": "true", 
+        "with_sum": "true"
+      }, 
+      "inputs": [
+        [345, 0, 0], 
+        [346, 0, 0], 
+        [347, 0, 0], 
+        [348, 0, 0], 
+        [349, 0, 0], 
+        [350, 0, 1], 
+        [351, 0, 1], 
+        [332, 0, 0], 
+        [345, 1, 0], 
+        [345, 2, 0], 
+        [332, 1, 0], 
+        [332, 2, 0]
+      ], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_51_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_conv9_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_conv9_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "resnetv10_stage4_conv9_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "2048", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_batchnorm9_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_batchnorm9_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_batchnorm9_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "resnetv10_stage4_batchnorm9_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "resnetv10_stage4_batchnorm9_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_49_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "elemwise_add", 
+              "name": "resnetv10_stage4__plus2", 
+              "inputs": [[8, 0, 0], [9, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "resnetv10_stage4_activation2", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[10, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7, 9], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12, 
+            13, 
+            14
+          ], 
+          "heads": [[11, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_quantized_pooling", 
+      "name": "quantized_resnetv10_pool1_fwd", 
+      "attrs": {
+        "global_pool": "True", 
+        "kernel": "(1, 1)", 
+        "layout": "NCHW", 
+        "pad": "(0, 0)", 
+        "pool_type": "avg", 
+        "pooling_convention": "full", 
+        "stride": "(1, 1)"
+      }, 
+      "inputs": [[352, 0, 0], [352, 1, 0], [352, 2, 0]]
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "resnetv10_pool1_fwd_dequantize", 
+      "inputs": [[353, 0, 0], [353, 1, 0], [353, 2, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_dense0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1000, 2048)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "resnetv10_dense0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1000,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "FullyConnected", 
+      "name": "resnetv10_dense0_fwd", 
+      "attrs": {
+        "flatten": "True", 
+        "no_bias": "False", 
+        "num_hidden": "1000"
+      }, 
+      "inputs": [[354, 0, 0], [355, 0, 0], [356, 0, 0]]
+    }
+  ], 
+  "arg_nodes": [
+    0, 
+    2, 
+    3, 
+    4, 
+    5, 
+    6, 
+    9, 
+    10, 
+    11, 
+    12, 
+    13, 
+    14, 
+    16, 
+    17, 
+    18, 
+    19, 
+    20, 
+    22, 
+    23, 
+    24, 
+    25, 
+    26, 
+    27, 
+    28, 
+    29, 
+    30, 
+    31, 
+    32, 
+    35, 
+    36, 
+    37, 
+    38, 
+    39, 
+    40, 
+    42, 
+    43, 
+    44, 
+    45, 
+    46, 
+    48, 
+    49, 
+    50, 
+    51, 
+    52, 
+    53, 
+    55, 
+    56, 
+    57, 
+    58, 
+    59, 
+    60, 
+    62, 
+    63, 
+    64, 
+    65, 
+    66, 
+    68, 
+    69, 
+    70, 
+    71, 
+    72, 
+    73, 
+    75, 
+    76, 
+    77, 
+    78, 
+    79, 
+    80, 
+    82, 
+    83, 
+    84, 
+    85, 
+    86, 
+    88, 
+    89, 
+    90, 
+    91, 
+    92, 
+    93, 
+    94, 
+    95, 
+    96, 
+    97, 
+    98, 
+    101, 
+    102, 
+    103, 
+    104, 
+    105, 
+    106, 
+    108, 
+    109, 
+    110, 
+    111, 
+    112, 
+    114, 
+    115, 
+    116, 
+    117, 
+    118, 
+    119, 
+    121, 
+    122, 
+    123, 
+    124, 
+    125, 
+    126, 
+    128, 
+    129, 
+    130, 
+    131, 
+    132, 
+    134, 
+    135, 
+    136, 
+    137, 
+    138, 
+    139, 
+    141, 
+    142, 
+    143, 
+    144, 
+    145, 
+    146, 
+    148, 
+    149, 
+    150, 
+    151, 
+    152, 
+    154, 
+    155, 
+    156, 
+    157, 
+    158, 
+    159, 
+    161, 
+    162, 
+    163, 
+    164, 
+    165, 
+    166, 
+    168, 
+    169, 
+    170, 
+    171, 
+    172, 
+    174, 
+    175, 
+    176, 
+    177, 
+    178, 
+    179, 
+    180, 
+    181, 
+    182, 
+    183, 
+    184, 
+    187, 
+    188, 
+    189, 
+    190, 
+    191, 
+    192, 
+    194, 
+    195, 
+    196, 
+    197, 
+    198, 
+    200, 
+    201, 
+    202, 
+    203, 
+    204, 
+    205, 
+    207, 
+    208, 
+    209, 
+    210, 
+    211, 
+    212, 
+    214, 
+    215, 
+    216, 
+    217, 
+    218, 
+    220, 
+    221, 
+    222, 
+    223, 
+    224, 
+    225, 
+    227, 
+    228, 
+    229, 
+    230, 
+    231, 
+    232, 
+    234, 
+    235, 
+    236, 
+    237, 
+    238, 
+    240, 
+    241, 
+    242, 
+    243, 
+    244, 
+    245, 
+    247, 
+    248, 
+    249, 
+    250, 
+    251, 
+    252, 
+    254, 
+    255, 
+    256, 
+    257, 
+    258, 
+    260, 
+    261, 
+    262, 
+    263, 
+    264, 
+    265, 
+    267, 
+    268, 
+    269, 
+    270, 
+    271, 
+    272, 
+    274, 
+    275, 
+    276, 
+    277, 
+    278, 
+    280, 
+    281, 
+    282, 
+    283, 
+    284, 
+    285, 
+    287, 
+    288, 
+    289, 
+    290, 
+    291, 
+    292, 
+    294, 
+    295, 
+    296, 
+    297, 
+    298, 
+    300, 
+    301, 
+    302, 
+    303, 
+    304, 
+    305, 
+    306, 
+    307, 
+    308, 
+    309, 
+    310, 
+    313, 
+    314, 
+    315, 
+    316, 
+    317, 
+    318, 
+    320, 
+    321, 
+    322, 
+    323, 
+    324, 
+    326, 
+    327, 
+    328, 
+    329, 
+    330, 
+    331, 
+    333, 
+    334, 
+    335, 
+    336, 
+    337, 
+    338, 
+    340, 
+    341, 
+    342, 
+    343, 
+    344, 
+    346, 
+    347, 
+    348, 
+    349, 
+    350, 
+    351, 
+    355, 
+    356
+  ], 
+  "node_row_ptr": [
+    0, 
+    1, 
+    4, 
+    5, 
+    6, 
+    7, 
+    8, 
+    9, 
+    12, 
+    15, 
+    16, 
+    17, 
+    18, 
+    19, 
+    20, 
+    21, 
+    24, 
+    25, 
+    26, 
+    27, 
+    28, 
+    29, 
+    32, 
+    33, 
+    34, 
+    35, 
+    36, 
+    37, 
+    38, 
+    39, 
+    40, 
+    41, 
+    42, 
+    43, 
+    46, 
+    49, 
+    50, 
+    51, 
+    52, 
+    53, 
+    54, 
+    55, 
+    58, 
+    59, 
+    60, 
+    61, 
+    62, 
+    63, 
+    66, 
+    67, 
+    68, 
+    69, 
+    70, 
+    71, 
+    72, 
+    75, 
+    76, 
+    77, 
+    78, 
+    79, 
+    80, 
+    81, 
+    84, 
+    85, 
+    86, 
+    87, 
+    88, 
+    89, 
+    92, 
+    93, 
+    94, 
+    95, 
+    96, 
+    97, 
+    98, 
+    101, 
+    102, 
+    103, 
+    104, 
+    105, 
+    106, 
+    107, 
+    110, 
+    111, 
+    112, 
+    113, 
+    114, 
+    115, 
+    118, 
+    119, 
+    120, 
+    121, 
+    122, 
+    123, 
+    124, 
+    125, 
+    126, 
+    127, 
+    128, 
+    129, 
+    132, 
+    135, 
+    136, 
+    137, 
+    138, 
+    139, 
+    140, 
+    141, 
+    144, 
+    145, 
+    146, 
+    147, 
+    148, 
+    149, 
+    152, 
+    153, 
+    154, 
+    155, 
+    156, 
+    157, 
+    158, 
+    161, 
+    162, 
+    163, 
+    164, 
+    165, 
+    166, 
+    167, 
+    170, 
+    171, 
+    172, 
+    173, 
+    174, 
+    175, 
+    178, 
+    179, 
+    180, 
+    181, 
+    182, 
+    183, 
+    184, 
+    187, 
+    188, 
+    189, 
+    190, 
+    191, 
+    192, 
+    193, 
+    196, 
+    197, 
+    198, 
+    199, 
+    200, 
+    201, 
+    204, 
+    205, 
+    206, 
+    207, 
+    208, 
+    209, 
+    210, 
+    213, 
+    214, 
+    215, 
+    216, 
+    217, 
+    218, 
+    219, 
+    222, 
+    223, 
+    224, 
+    225, 
+    226, 
+    227, 
+    230, 
+    231, 
+    232, 
+    233, 
+    234, 
+    235, 
+    236, 
+    237, 
+    238, 
+    239, 
+    240, 
+    241, 
+    244, 
+    247, 
+    248, 
+    249, 
+    250, 
+    251, 
+    252, 
+    253, 
+    256, 
+    257, 
+    258, 
+    259, 
+    260, 
+    261, 
+    264, 
+    265, 
+    266, 
+    267, 
+    268, 
+    269, 
+    270, 
+    273, 
+    274, 
+    275, 
+    276, 
+    277, 
+    278, 
+    279, 
+    282, 
+    283, 
+    284, 
+    285, 
+    286, 
+    287, 
+    290, 
+    291, 
+    292, 
+    293, 
+    294, 
+    295, 
+    296, 
+    299, 
+    300, 
+    301, 
+    302, 
+    303, 
+    304, 
+    305, 
+    308, 
+    309, 
+    310, 
+    311, 
+    312, 
+    313, 
+    316, 
+    317, 
+    318, 
+    319, 
+    320, 
+    321, 
+    322, 
+    325, 
+    326, 
+    327, 
+    328, 
+    329, 
+    330, 
+    331, 
+    334, 
+    335, 
+    336, 
+    337, 
+    338, 
+    339, 
+    342, 
+    343, 
+    344, 
+    345, 
+    346, 
+    347, 
+    348, 
+    351, 
+    352, 
+    353, 
+    354, 
+    355, 
+    356, 
+    357, 
+    360, 
+    361, 
+    362, 
+    363, 
+    364, 
+    365, 
+    368, 
+    369, 
+    370, 
+    371, 
+    372, 
+    373, 
+    374, 
+    377, 
+    378, 
+    379, 
+    380, 
+    381, 
+    382, 
+    383, 
+    386, 
+    387, 
+    388, 
+    389, 
+    390, 
+    391, 
+    394, 
+    395, 
+    396, 
+    397, 
+    398, 
+    399, 
+    400, 
+    401, 
+    402, 
+    403, 
+    404, 
+    405, 
+    408, 
+    411, 
+    412, 
+    413, 
+    414, 
+    415, 
+    416, 
+    417, 
+    420, 
+    421, 
+    422, 
+    423, 
+    424, 
+    425, 
+    428, 
+    429, 
+    430, 
+    431, 
+    432, 
+    433, 
+    434, 
+    437, 
+    438, 
+    439, 
+    440, 
+    441, 
+    442, 
+    443, 
+    446, 
+    447, 
+    448, 
+    449, 
+    450, 
+    451, 
+    454, 
+    455, 
+    456, 
+    457, 
+    458, 
+    459, 
+    460, 
+    463, 
+    466, 
+    467, 
+    468, 
+    469, 
+    470
+  ], 
+  "heads": [[357, 0, 0]], 
+  "attrs": {"mxnet_version": ["int", 10500]}
+}

--- a/gluoncv/model_zoo/quantized/ssd_300_vgg16_atrous_voc_int8-symbol.json
+++ b/gluoncv/model_zoo/quantized/ssd_300_vgg16_atrous_voc_int8-symbol.json
@@ -1,0 +1,4867 @@
+{
+  "nodes": [
+    {
+      "op": "null", 
+      "name": "data", 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_init_scale", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "Constant_ssd0_vggatrousextractor0_init_scale_139813762548568", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1, 3, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "broadcast_mul", 
+      "name": "ssd0_vggatrousextractor0_broadcast_mul0", 
+      "inputs": [[0, 0, 0], [1, 0, 0]]
+    }, 
+    {
+      "op": "_contrib_quantize_v2", 
+      "name": "ssd0_vggatrousextractor0_broadcast_mul0_0_quantize", 
+      "attrs": {"out_type": "auto"}, 
+      "inputs": [[2, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"gaussian\", \"factor_type\": \"out\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64, 3, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_relu_0", 
+      "attrs": {
+        "max_calib_range": "799.719299", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [3, 1, 0], [3, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_broadcast_mul0_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_vggatrousextractor0_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "64", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_vggatrousextractor0_relu0_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[3, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5], 
+          "heads": [[4, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_conv1_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"gaussian\", \"factor_type\": \"out\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64, 64, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_conv1_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_relu_1", 
+      "attrs": {
+        "max_calib_range": "2801.616699", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[6, 0, 0], [7, 0, 0], [8, 0, 0], [6, 1, 0], [6, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_0_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_conv1_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_conv1_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_vggatrousextractor0_conv1_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "64", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_vggatrousextractor0_relu1_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[3, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5], 
+          "heads": [[4, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_quantized_pooling", 
+      "name": "quantized_ssd0_vggatrousextractor0_pooling0", 
+      "attrs": {
+        "kernel": "(2, 2)", 
+        "pool_type": "max", 
+        "pooling_convention": "full", 
+        "stride": "(2, 2)"
+      }, 
+      "inputs": [[9, 0, 0], [9, 1, 0], [9, 2, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_conv2_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"gaussian\", \"factor_type\": \"out\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128, 64, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_conv2_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_relu_2", 
+      "attrs": {
+        "max_calib_range": "5245.505859", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[10, 0, 0], [11, 0, 0], [12, 0, 0], [10, 1, 0], [10, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_pooling0_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_conv2_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_conv2_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_vggatrousextractor0_conv2_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "128", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_vggatrousextractor0_relu2_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[3, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5], 
+          "heads": [[4, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_conv3_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"gaussian\", \"factor_type\": \"out\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128, 128, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_conv3_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_relu_3", 
+      "attrs": {
+        "max_calib_range": "6962.976562", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[13, 0, 0], [14, 0, 0], [15, 0, 0], [13, 1, 0], [13, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_2_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_conv3_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_conv3_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_vggatrousextractor0_conv3_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "128", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_vggatrousextractor0_relu3_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[3, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5], 
+          "heads": [[4, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_quantized_pooling", 
+      "name": "quantized_ssd0_vggatrousextractor0_pooling1", 
+      "attrs": {
+        "kernel": "(2, 2)", 
+        "pool_type": "max", 
+        "pooling_convention": "full", 
+        "stride": "(2, 2)"
+      }, 
+      "inputs": [[16, 0, 0], [16, 1, 0], [16, 2, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_conv4_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"gaussian\", \"factor_type\": \"out\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256, 128, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_conv4_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_relu_4", 
+      "attrs": {
+        "max_calib_range": "6951.934082", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[17, 0, 0], [18, 0, 0], [19, 0, 0], [17, 1, 0], [17, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_pooling1_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_conv4_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_conv4_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_vggatrousextractor0_conv4_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "256", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_vggatrousextractor0_relu4_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[3, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5], 
+          "heads": [[4, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_conv5_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"gaussian\", \"factor_type\": \"out\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256, 256, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_conv5_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_relu_5", 
+      "attrs": {
+        "max_calib_range": "5921.893066", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[20, 0, 0], [21, 0, 0], [22, 0, 0], [20, 1, 0], [20, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_4_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_conv5_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_conv5_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_vggatrousextractor0_conv5_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "256", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_vggatrousextractor0_relu5_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[3, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5], 
+          "heads": [[4, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_conv6_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"gaussian\", \"factor_type\": \"out\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256, 256, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_conv6_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_relu_6", 
+      "attrs": {
+        "max_calib_range": "5161.966797", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[23, 0, 0], [24, 0, 0], [25, 0, 0], [23, 1, 0], [23, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_5_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_conv6_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_conv6_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_vggatrousextractor0_conv6_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "256", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_vggatrousextractor0_relu6_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[3, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5], 
+          "heads": [[4, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_quantized_pooling", 
+      "name": "quantized_ssd0_vggatrousextractor0_pooling2", 
+      "attrs": {
+        "kernel": "(2, 2)", 
+        "pool_type": "max", 
+        "pooling_convention": "full", 
+        "stride": "(2, 2)"
+      }, 
+      "inputs": [[26, 0, 0], [26, 1, 0], [26, 2, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_conv7_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"gaussian\", \"factor_type\": \"out\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 256, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_conv7_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_relu_7", 
+      "attrs": {
+        "max_calib_range": "4225.403320", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[27, 0, 0], [28, 0, 0], [29, 0, 0], [27, 1, 0], [27, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_pooling2_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_conv7_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_conv7_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_vggatrousextractor0_conv7_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "512", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_vggatrousextractor0_relu7_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[3, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5], 
+          "heads": [[4, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_conv8_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"gaussian\", \"factor_type\": \"out\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 512, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_conv8_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_relu_8", 
+      "attrs": {
+        "max_calib_range": "1302.792358", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[30, 0, 0], [31, 0, 0], [32, 0, 0], [30, 1, 0], [30, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_7_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_conv8_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_conv8_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_vggatrousextractor0_conv8_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "512", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_vggatrousextractor0_relu8_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[3, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5], 
+          "heads": [[4, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_conv9_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"gaussian\", \"factor_type\": \"out\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 512, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_conv9_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_relu_9", 
+      "attrs": {
+        "max_calib_range": "658.651978", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[33, 0, 0], [34, 0, 0], [35, 0, 0], [33, 1, 0], [33, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_8_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_conv9_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_conv9_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_vggatrousextractor0_conv9_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "512", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_vggatrousextractor0_relu9_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[3, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5], 
+          "heads": [[4, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_relu_9_dequantize", 
+      "inputs": [[36, 0, 0], [36, 1, 0], [36, 2, 0]]
+    }, 
+    {
+      "op": "L2Normalization", 
+      "name": "ssd0_vggatrousextractor0_normalize0_l2normalization0", 
+      "attrs": {
+        "eps": "1e-05", 
+        "mode": "channel"
+      }, 
+      "inputs": [[37, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_normalize0_normalize_scale", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"constant\", {\"value\": 20}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1, 512, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "broadcast_mul", 
+      "name": "ssd0_vggatrousextractor0_normalize0_broadcast_mul0", 
+      "inputs": [[38, 0, 0], [39, 0, 0]]
+    }, 
+    {
+      "op": "_contrib_quantize_v2", 
+      "name": "ssd0_vggatrousextractor0_normalize0_broadcast_mul0_0_quantize", 
+      "attrs": {"out_type": "auto"}, 
+      "inputs": [[40, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor0_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"uniform\", \"factor_type\": \"avg\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(84, 512, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor0_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(84,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_10", 
+      "attrs": {
+        "max_calib_range": "15.419542", 
+        "min_calib_range": "-6.482797", 
+        "quantized": "true"
+      }, 
+      "inputs": [[41, 0, 0], [42, 0, 0], [43, 0, 0], [41, 1, 0], [41, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_normalize0_broadcast_mul0_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor0_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor0_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_convpredictor0_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "84", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4], 
+          "heads": [[3, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_10_dequantize", 
+      "inputs": [[44, 0, 0], [44, 1, 0], [44, 2, 0]]
+    }, 
+    {
+      "op": "transpose", 
+      "name": "ssd0_transpose0", 
+      "attrs": {"axes": "(0, 2, 3, 1)"}, 
+      "inputs": [[45, 0, 0]]
+    }, 
+    {
+      "op": "Flatten", 
+      "name": "ssd0_flatten0", 
+      "inputs": [[46, 0, 0]]
+    }, 
+    {
+      "op": "_contrib_quantized_pooling", 
+      "name": "quantized_ssd0_vggatrousextractor0_pooling3", 
+      "attrs": {
+        "kernel": "(2, 2)", 
+        "pool_type": "max", 
+        "pooling_convention": "full", 
+        "stride": "(2, 2)"
+      }, 
+      "inputs": [[36, 0, 0], [36, 1, 0], [36, 2, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_conv10_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"gaussian\", \"factor_type\": \"out\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 512, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_conv10_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_relu_11", 
+      "attrs": {
+        "max_calib_range": "422.220123", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[48, 0, 0], [49, 0, 0], [50, 0, 0], [48, 1, 0], [48, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_pooling3_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_conv10_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_conv10_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_vggatrousextractor0_conv10_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "512", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_vggatrousextractor0_relu10_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[3, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5], 
+          "heads": [[4, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_conv11_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"gaussian\", \"factor_type\": \"out\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 512, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_conv11_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_relu_12", 
+      "attrs": {
+        "max_calib_range": "186.000427", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[51, 0, 0], [52, 0, 0], [53, 0, 0], [51, 1, 0], [51, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_11_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_conv11_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_conv11_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_vggatrousextractor0_conv11_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "512", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_vggatrousextractor0_relu11_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[3, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5], 
+          "heads": [[4, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_conv12_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"gaussian\", \"factor_type\": \"out\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 512, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_conv12_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_relu_13", 
+      "attrs": {
+        "max_calib_range": "129.571381", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[54, 0, 0], [55, 0, 0], [56, 0, 0], [54, 1, 0], [54, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_12_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_conv12_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_conv12_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_vggatrousextractor0_conv12_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "512", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_vggatrousextractor0_relu12_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[3, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5], 
+          "heads": [[4, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_quantized_pooling", 
+      "name": "quantized_ssd0_vggatrousextractor0_pooling4", 
+      "attrs": {
+        "kernel": "(3, 3)", 
+        "pad": "(1, 1)", 
+        "pool_type": "max", 
+        "pooling_convention": "full", 
+        "stride": "(1, 1)"
+      }, 
+      "inputs": [[57, 0, 0], [57, 1, 0], [57, 2, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_dilated_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"gaussian\", \"factor_type\": \"out\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024, 512, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_dilated_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_relu_14", 
+      "attrs": {
+        "max_calib_range": "31.570829", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[58, 0, 0], [59, 0, 0], [60, 0, 0], [58, 1, 0], [58, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_pooling4_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_dilated_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_dilated_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_vggatrousextractor0_dilated_conv0_fwd", 
+              "attrs": {
+                "dilate": "(6, 6)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "1024", 
+                "num_group": "1", 
+                "pad": "(6, 6)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_vggatrousextractor0_dilated_relu0_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[3, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5], 
+          "heads": [[4, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_dilated_conv1_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"gaussian\", \"factor_type\": \"out\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024, 1024, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_dilated_conv1_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_relu_15", 
+      "attrs": {
+        "max_calib_range": "10.395283", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[61, 0, 0], [62, 0, 0], [63, 0, 0], [61, 1, 0], [61, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_14_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_dilated_conv1_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_dilated_conv1_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_vggatrousextractor0_dilated_conv1_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "1024", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_vggatrousextractor0_dilated_relu1_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[3, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5], 
+          "heads": [[4, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor2_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"uniform\", \"factor_type\": \"avg\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(126, 1024, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor2_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(126,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_16", 
+      "attrs": {
+        "max_calib_range": "31.327047", 
+        "min_calib_range": "-8.904353", 
+        "quantized": "true"
+      }, 
+      "inputs": [[64, 0, 0], [65, 0, 0], [66, 0, 0], [64, 1, 0], [64, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_15_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor2_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor2_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_convpredictor2_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "126", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4], 
+          "heads": [[3, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_16_dequantize", 
+      "inputs": [[67, 0, 0], [67, 1, 0], [67, 2, 0]]
+    }, 
+    {
+      "op": "transpose", 
+      "name": "ssd0_transpose1", 
+      "attrs": {"axes": "(0, 2, 3, 1)"}, 
+      "inputs": [[68, 0, 0]]
+    }, 
+    {
+      "op": "Flatten", 
+      "name": "ssd0_flatten1", 
+      "inputs": [[69, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_extra0_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"gaussian\", \"factor_type\": \"out\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256, 1024, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_extra0_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_relu_17", 
+      "attrs": {
+        "max_calib_range": "8.586086", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[64, 0, 0], [71, 0, 0], [72, 0, 0], [64, 1, 0], [64, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_15_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_extra0_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_extra0_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_vggatrousextractor0_extra0_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "256", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_vggatrousextractor0_extra0_relu0_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[3, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5], 
+          "heads": [[4, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_extra0_conv1_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"gaussian\", \"factor_type\": \"out\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 256, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_extra0_conv1_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_relu_18", 
+      "attrs": {
+        "max_calib_range": "10.733885", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[73, 0, 0], [74, 0, 0], [75, 0, 0], [73, 1, 0], [73, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_17_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_extra0_conv1_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_extra0_conv1_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_vggatrousextractor0_extra0_conv1_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "512", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(2, 2)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_vggatrousextractor0_extra0_relu1_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[3, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5], 
+          "heads": [[4, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor4_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"uniform\", \"factor_type\": \"avg\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(126, 512, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor4_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(126,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_19", 
+      "attrs": {
+        "max_calib_range": "29.058624", 
+        "min_calib_range": "-14.042579", 
+        "quantized": "true"
+      }, 
+      "inputs": [[76, 0, 0], [77, 0, 0], [78, 0, 0], [76, 1, 0], [76, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_18_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor4_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor4_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_convpredictor4_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "126", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4], 
+          "heads": [[3, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_19_dequantize", 
+      "inputs": [[79, 0, 0], [79, 1, 0], [79, 2, 0]]
+    }, 
+    {
+      "op": "transpose", 
+      "name": "ssd0_transpose2", 
+      "attrs": {"axes": "(0, 2, 3, 1)"}, 
+      "inputs": [[80, 0, 0]]
+    }, 
+    {
+      "op": "Flatten", 
+      "name": "ssd0_flatten2", 
+      "inputs": [[81, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_extra1_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"gaussian\", \"factor_type\": \"out\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128, 512, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_extra1_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_relu_20", 
+      "attrs": {
+        "max_calib_range": "13.220951", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[76, 0, 0], [83, 0, 0], [84, 0, 0], [76, 1, 0], [76, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_18_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_extra1_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_extra1_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_vggatrousextractor0_extra1_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "128", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_vggatrousextractor0_extra1_relu0_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[3, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5], 
+          "heads": [[4, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_extra1_conv1_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"gaussian\", \"factor_type\": \"out\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256, 128, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_extra1_conv1_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_relu_21", 
+      "attrs": {
+        "max_calib_range": "15.064709", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[85, 0, 0], [86, 0, 0], [87, 0, 0], [85, 1, 0], [85, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_20_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_extra1_conv1_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_extra1_conv1_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_vggatrousextractor0_extra1_conv1_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "256", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(2, 2)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_vggatrousextractor0_extra1_relu1_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[3, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5], 
+          "heads": [[4, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor6_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"uniform\", \"factor_type\": \"avg\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(126, 256, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor6_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(126,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_22", 
+      "attrs": {
+        "max_calib_range": "27.599642", 
+        "min_calib_range": "-12.862319", 
+        "quantized": "true"
+      }, 
+      "inputs": [[88, 0, 0], [89, 0, 0], [90, 0, 0], [88, 1, 0], [88, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_21_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor6_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor6_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_convpredictor6_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "126", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4], 
+          "heads": [[3, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_22_dequantize", 
+      "inputs": [[91, 0, 0], [91, 1, 0], [91, 2, 0]]
+    }, 
+    {
+      "op": "transpose", 
+      "name": "ssd0_transpose3", 
+      "attrs": {"axes": "(0, 2, 3, 1)"}, 
+      "inputs": [[92, 0, 0]]
+    }, 
+    {
+      "op": "Flatten", 
+      "name": "ssd0_flatten3", 
+      "inputs": [[93, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_extra2_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"gaussian\", \"factor_type\": \"out\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128, 256, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_extra2_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_relu_23", 
+      "attrs": {
+        "max_calib_range": "17.194489", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[88, 0, 0], [95, 0, 0], [96, 0, 0], [88, 1, 0], [88, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_21_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_extra2_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_extra2_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_vggatrousextractor0_extra2_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "128", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_vggatrousextractor0_extra2_relu0_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[3, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5], 
+          "heads": [[4, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_extra2_conv1_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"gaussian\", \"factor_type\": \"out\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256, 128, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_extra2_conv1_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_relu_24", 
+      "attrs": {
+        "max_calib_range": "17.794985", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[97, 0, 0], [98, 0, 0], [99, 0, 0], [97, 1, 0], [97, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_23_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_extra2_conv1_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_extra2_conv1_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_vggatrousextractor0_extra2_conv1_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "256", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_vggatrousextractor0_extra2_relu1_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[3, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5], 
+          "heads": [[4, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor8_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"uniform\", \"factor_type\": \"avg\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(84, 256, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor8_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(84,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_25", 
+      "attrs": {
+        "max_calib_range": "23.415764", 
+        "min_calib_range": "-14.546038", 
+        "quantized": "true"
+      }, 
+      "inputs": [[100, 0, 0], [101, 0, 0], [102, 0, 0], [100, 1, 0], [100, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_24_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor8_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor8_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_convpredictor8_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "84", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4], 
+          "heads": [[3, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_25_dequantize", 
+      "inputs": [[103, 0, 0], [103, 1, 0], [103, 2, 0]]
+    }, 
+    {
+      "op": "transpose", 
+      "name": "ssd0_transpose4", 
+      "attrs": {"axes": "(0, 2, 3, 1)"}, 
+      "inputs": [[104, 0, 0]]
+    }, 
+    {
+      "op": "Flatten", 
+      "name": "ssd0_flatten4", 
+      "inputs": [[105, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_extra3_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"gaussian\", \"factor_type\": \"out\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128, 256, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_extra3_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_relu_26", 
+      "attrs": {
+        "max_calib_range": "19.868343", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[100, 0, 0], [107, 0, 0], [108, 0, 0], [100, 1, 0], [100, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_24_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_extra3_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_extra3_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_vggatrousextractor0_extra3_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "128", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_vggatrousextractor0_extra3_relu0_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[3, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5], 
+          "heads": [[4, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_extra3_conv1_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"gaussian\", \"factor_type\": \"out\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256, 128, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_extra3_conv1_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_relu_27", 
+      "attrs": {
+        "max_calib_range": "24.279285", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[109, 0, 0], [110, 0, 0], [111, 0, 0], [109, 1, 0], [109, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_26_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_extra3_conv1_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_extra3_conv1_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_vggatrousextractor0_extra3_conv1_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "256", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_vggatrousextractor0_extra3_relu1_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[3, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5], 
+          "heads": [[4, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor10_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"uniform\", \"factor_type\": \"avg\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(84, 256, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor10_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(84,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_28", 
+      "attrs": {
+        "max_calib_range": "22.051943", 
+        "min_calib_range": "-13.183455", 
+        "quantized": "true"
+      }, 
+      "inputs": [[112, 0, 0], [113, 0, 0], [114, 0, 0], [112, 1, 0], [112, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_27_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor10_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor10_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_convpredictor10_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "84", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4], 
+          "heads": [[3, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_28_dequantize", 
+      "inputs": [[115, 0, 0], [115, 1, 0], [115, 2, 0]]
+    }, 
+    {
+      "op": "transpose", 
+      "name": "ssd0_transpose5", 
+      "attrs": {"axes": "(0, 2, 3, 1)"}, 
+      "inputs": [[116, 0, 0]]
+    }, 
+    {
+      "op": "Flatten", 
+      "name": "ssd0_flatten5", 
+      "inputs": [[117, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat0", 
+      "attrs": {
+        "dim": "1", 
+        "num_args": "6"
+      }, 
+      "inputs": [[47, 0, 0], [70, 0, 0], [82, 0, 0], [94, 0, 0], [106, 0, 0], [118, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_reshape6", 
+      "attrs": {"shape": "(0, -1, 21)"}, 
+      "inputs": [[119, 0, 0]]
+    }, 
+    {
+      "op": "softmax", 
+      "name": "ssd0_softmax0", 
+      "attrs": {"axis": "-1"}, 
+      "inputs": [[120, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_multiperclassdecoder0_slice_axis0", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "1", 
+        "end": "None"
+      }, 
+      "inputs": [[121, 0, 0]]
+    }, 
+    {
+      "op": "_greater_scalar", 
+      "name": "ssd0_multiperclassdecoder0__greater_scalar0", 
+      "attrs": {"scalar": "0.01"}, 
+      "inputs": [[122, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_multiperclassdecoder0_slice_axis1", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "0", 
+        "end": "1"
+      }, 
+      "inputs": [[121, 0, 0]]
+    }, 
+    {
+      "op": "zeros_like", 
+      "name": "ssd0_multiperclassdecoder0_zeros_like0", 
+      "inputs": [[124, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar0", 
+      "attrs": {"scalar": "0"}, 
+      "inputs": [[125, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar1", 
+      "attrs": {"scalar": "1"}, 
+      "inputs": [[125, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar2", 
+      "attrs": {"scalar": "2"}, 
+      "inputs": [[125, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar3", 
+      "attrs": {"scalar": "3"}, 
+      "inputs": [[125, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar4", 
+      "attrs": {"scalar": "4"}, 
+      "inputs": [[125, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar5", 
+      "attrs": {"scalar": "5"}, 
+      "inputs": [[125, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar6", 
+      "attrs": {"scalar": "6"}, 
+      "inputs": [[125, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar7", 
+      "attrs": {"scalar": "7"}, 
+      "inputs": [[125, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar8", 
+      "attrs": {"scalar": "8"}, 
+      "inputs": [[125, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar9", 
+      "attrs": {"scalar": "9"}, 
+      "inputs": [[125, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar10", 
+      "attrs": {"scalar": "10"}, 
+      "inputs": [[125, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar11", 
+      "attrs": {"scalar": "11"}, 
+      "inputs": [[125, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar12", 
+      "attrs": {"scalar": "12"}, 
+      "inputs": [[125, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar13", 
+      "attrs": {"scalar": "13"}, 
+      "inputs": [[125, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar14", 
+      "attrs": {"scalar": "14"}, 
+      "inputs": [[125, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar15", 
+      "attrs": {"scalar": "15"}, 
+      "inputs": [[125, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar16", 
+      "attrs": {"scalar": "16"}, 
+      "inputs": [[125, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar17", 
+      "attrs": {"scalar": "17"}, 
+      "inputs": [[125, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar18", 
+      "attrs": {"scalar": "18"}, 
+      "inputs": [[125, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar19", 
+      "attrs": {"scalar": "19"}, 
+      "inputs": [[125, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_multiperclassdecoder0_concat0", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "20"
+      }, 
+      "inputs": [
+        [126, 0, 0], 
+        [127, 0, 0], 
+        [128, 0, 0], 
+        [129, 0, 0], 
+        [130, 0, 0], 
+        [131, 0, 0], 
+        [132, 0, 0], 
+        [133, 0, 0], 
+        [134, 0, 0], 
+        [135, 0, 0], 
+        [136, 0, 0], 
+        [137, 0, 0], 
+        [138, 0, 0], 
+        [139, 0, 0], 
+        [140, 0, 0], 
+        [141, 0, 0], 
+        [142, 0, 0], 
+        [143, 0, 0], 
+        [144, 0, 0], 
+        [145, 0, 0]
+      ]
+    }, 
+    {
+      "op": "ones_like", 
+      "name": "ssd0_multiperclassdecoder0_ones_like0", 
+      "inputs": [[146, 0, 0]]
+    }, 
+    {
+      "op": "_mul_scalar", 
+      "name": "ssd0_multiperclassdecoder0__mulscalar0", 
+      "attrs": {"scalar": "-1"}, 
+      "inputs": [[147, 0, 0]]
+    }, 
+    {
+      "op": "where", 
+      "name": "ssd0_multiperclassdecoder0_where0", 
+      "inputs": [[123, 0, 0], [146, 0, 0], [148, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis0", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "0", 
+        "end": "1"
+      }, 
+      "inputs": [[149, 0, 0]]
+    }, 
+    {
+      "op": "zeros_like", 
+      "name": "ssd0_multiperclassdecoder0_zeros_like1", 
+      "inputs": [[122, 0, 0]]
+    }, 
+    {
+      "op": "where", 
+      "name": "ssd0_multiperclassdecoder0_where1", 
+      "inputs": [[123, 0, 0], [122, 0, 0], [151, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis1", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "0", 
+        "end": "1"
+      }, 
+      "inputs": [[152, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor1_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"uniform\", \"factor_type\": \"avg\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(16, 512, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor1_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(16,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_29", 
+      "attrs": {
+        "max_calib_range": "4.669396", 
+        "min_calib_range": "-13.670727", 
+        "quantized": "true"
+      }, 
+      "inputs": [[41, 0, 0], [154, 0, 0], [155, 0, 0], [41, 1, 0], [41, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_normalize0_broadcast_mul0_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor1_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor1_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_convpredictor1_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "16", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4], 
+          "heads": [[3, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_29_dequantize", 
+      "inputs": [[156, 0, 0], [156, 1, 0], [156, 2, 0]]
+    }, 
+    {
+      "op": "transpose", 
+      "name": "ssd0_transpose6", 
+      "attrs": {"axes": "(0, 2, 3, 1)"}, 
+      "inputs": [[157, 0, 0]]
+    }, 
+    {
+      "op": "Flatten", 
+      "name": "ssd0_flatten6", 
+      "inputs": [[158, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor3_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"uniform\", \"factor_type\": \"avg\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(24, 1024, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor3_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(24,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_30", 
+      "attrs": {
+        "max_calib_range": "4.628121", 
+        "min_calib_range": "-4.542309", 
+        "quantized": "true"
+      }, 
+      "inputs": [[64, 0, 0], [160, 0, 0], [161, 0, 0], [64, 1, 0], [64, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_15_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor3_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor3_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_convpredictor3_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "24", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4], 
+          "heads": [[3, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_30_dequantize", 
+      "inputs": [[162, 0, 0], [162, 1, 0], [162, 2, 0]]
+    }, 
+    {
+      "op": "transpose", 
+      "name": "ssd0_transpose7", 
+      "attrs": {"axes": "(0, 2, 3, 1)"}, 
+      "inputs": [[163, 0, 0]]
+    }, 
+    {
+      "op": "Flatten", 
+      "name": "ssd0_flatten7", 
+      "inputs": [[164, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor5_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"uniform\", \"factor_type\": \"avg\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(24, 512, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor5_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(24,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_31", 
+      "attrs": {
+        "max_calib_range": "4.375800", 
+        "min_calib_range": "-4.347852", 
+        "quantized": "true"
+      }, 
+      "inputs": [[76, 0, 0], [166, 0, 0], [167, 0, 0], [76, 1, 0], [76, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_18_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor5_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor5_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_convpredictor5_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "24", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4], 
+          "heads": [[3, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_31_dequantize", 
+      "inputs": [[168, 0, 0], [168, 1, 0], [168, 2, 0]]
+    }, 
+    {
+      "op": "transpose", 
+      "name": "ssd0_transpose8", 
+      "attrs": {"axes": "(0, 2, 3, 1)"}, 
+      "inputs": [[169, 0, 0]]
+    }, 
+    {
+      "op": "Flatten", 
+      "name": "ssd0_flatten8", 
+      "inputs": [[170, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor7_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"uniform\", \"factor_type\": \"avg\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(24, 256, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor7_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(24,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_32", 
+      "attrs": {
+        "max_calib_range": "4.159054", 
+        "min_calib_range": "-4.141346", 
+        "quantized": "true"
+      }, 
+      "inputs": [[88, 0, 0], [172, 0, 0], [173, 0, 0], [88, 1, 0], [88, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_21_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor7_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor7_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_convpredictor7_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "24", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4], 
+          "heads": [[3, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_32_dequantize", 
+      "inputs": [[174, 0, 0], [174, 1, 0], [174, 2, 0]]
+    }, 
+    {
+      "op": "transpose", 
+      "name": "ssd0_transpose9", 
+      "attrs": {"axes": "(0, 2, 3, 1)"}, 
+      "inputs": [[175, 0, 0]]
+    }, 
+    {
+      "op": "Flatten", 
+      "name": "ssd0_flatten9", 
+      "inputs": [[176, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor9_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"uniform\", \"factor_type\": \"avg\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(16, 256, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor9_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(16,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_33", 
+      "attrs": {
+        "max_calib_range": "4.645521", 
+        "min_calib_range": "-4.844325", 
+        "quantized": "true"
+      }, 
+      "inputs": [[100, 0, 0], [178, 0, 0], [179, 0, 0], [100, 1, 0], [100, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_24_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor9_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor9_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_convpredictor9_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "16", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4], 
+          "heads": [[3, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_33_dequantize", 
+      "inputs": [[180, 0, 0], [180, 1, 0], [180, 2, 0]]
+    }, 
+    {
+      "op": "transpose", 
+      "name": "ssd0_transpose10", 
+      "attrs": {"axes": "(0, 2, 3, 1)"}, 
+      "inputs": [[181, 0, 0]]
+    }, 
+    {
+      "op": "Flatten", 
+      "name": "ssd0_flatten10", 
+      "inputs": [[182, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor11_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"uniform\", \"factor_type\": \"avg\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(16, 256, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor11_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(16,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_34", 
+      "attrs": {
+        "max_calib_range": "2.374739", 
+        "min_calib_range": "-3.898834", 
+        "quantized": "true"
+      }, 
+      "inputs": [[112, 0, 0], [184, 0, 0], [185, 0, 0], [112, 1, 0], [112, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_27_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor11_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor11_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_convpredictor11_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "16", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4], 
+          "heads": [[3, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_34_dequantize", 
+      "inputs": [[186, 0, 0], [186, 1, 0], [186, 2, 0]]
+    }, 
+    {
+      "op": "transpose", 
+      "name": "ssd0_transpose11", 
+      "attrs": {"axes": "(0, 2, 3, 1)"}, 
+      "inputs": [[187, 0, 0]]
+    }, 
+    {
+      "op": "Flatten", 
+      "name": "ssd0_flatten11", 
+      "inputs": [[188, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat1", 
+      "attrs": {
+        "dim": "1", 
+        "num_args": "6"
+      }, 
+      "inputs": [[159, 0, 0], [165, 0, 0], [171, 0, 0], [177, 0, 0], [183, 0, 0], [189, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_reshape7", 
+      "attrs": {"shape": "(0, -1, 4)"}, 
+      "inputs": [[190, 0, 0]]
+    }, 
+    {
+      "op": "SliceChannel", 
+      "name": "ssd0_normalizedboxcenterdecoder0_split1", 
+      "attrs": {
+        "axis": "-1", 
+        "num_outputs": "4"
+      }, 
+      "inputs": [[191, 0, 0]]
+    }, 
+    {
+      "op": "_mul_scalar", 
+      "name": "ssd0_normalizedboxcenterdecoder0__mulscalar0", 
+      "attrs": {"scalar": "0.1"}, 
+      "inputs": [[192, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_normalizedboxcenterdecoder0__plusscalar0", 
+      "attrs": {"scalar": "0.0"}, 
+      "inputs": [[193, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_ssdanchorgenerator0_anchor_0", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "Constant_ssd0_ssdanchorgenerator0_anchor_0_139808419932928", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1, 1, 128, 128, 16)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_mul_scalar", 
+      "name": "ssd0_ssdanchorgenerator0__mulscalar0", 
+      "attrs": {"scalar": "0"}, 
+      "inputs": [[40, 0, 0]]
+    }, 
+    {
+      "op": "slice_like", 
+      "name": "ssd0_ssdanchorgenerator0_slice_like0", 
+      "attrs": {"axes": "(2, 3)"}, 
+      "inputs": [[195, 0, 0], [196, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_ssdanchorgenerator0_reshape0", 
+      "attrs": {"shape": "(1, -1, 4)"}, 
+      "inputs": [[197, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_ssdanchorgenerator0_reshape1", 
+      "attrs": {"shape": "(1, -1, 4)"}, 
+      "inputs": [[198, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_reshape0", 
+      "attrs": {"shape": "(1, -1)"}, 
+      "inputs": [[199, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_ssdanchorgenerator1_anchor_1", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "Constant_ssd0_ssdanchorgenerator1_anchor_1_139809038384432", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1, 1, 64, 64, 24)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_relu_15_dequantize", 
+      "inputs": [[64, 0, 0], [64, 1, 0], [64, 2, 0]]
+    }, 
+    {
+      "op": "_mul_scalar", 
+      "name": "ssd0_ssdanchorgenerator1__mulscalar0", 
+      "attrs": {"scalar": "0"}, 
+      "inputs": [[202, 0, 0]]
+    }, 
+    {
+      "op": "slice_like", 
+      "name": "ssd0_ssdanchorgenerator1_slice_like0", 
+      "attrs": {"axes": "(2, 3)"}, 
+      "inputs": [[201, 0, 0], [203, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_ssdanchorgenerator1_reshape0", 
+      "attrs": {"shape": "(1, -1, 4)"}, 
+      "inputs": [[204, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_ssdanchorgenerator1_reshape1", 
+      "attrs": {"shape": "(1, -1, 4)"}, 
+      "inputs": [[205, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_reshape1", 
+      "attrs": {"shape": "(1, -1)"}, 
+      "inputs": [[206, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_ssdanchorgenerator2_anchor_2", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "Constant_ssd0_ssdanchorgenerator2_anchor_2_139809038383200", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1, 1, 32, 32, 24)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_relu_18_dequantize", 
+      "inputs": [[76, 0, 0], [76, 1, 0], [76, 2, 0]]
+    }, 
+    {
+      "op": "_mul_scalar", 
+      "name": "ssd0_ssdanchorgenerator2__mulscalar0", 
+      "attrs": {"scalar": "0"}, 
+      "inputs": [[209, 0, 0]]
+    }, 
+    {
+      "op": "slice_like", 
+      "name": "ssd0_ssdanchorgenerator2_slice_like0", 
+      "attrs": {"axes": "(2, 3)"}, 
+      "inputs": [[208, 0, 0], [210, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_ssdanchorgenerator2_reshape0", 
+      "attrs": {"shape": "(1, -1, 4)"}, 
+      "inputs": [[211, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_ssdanchorgenerator2_reshape1", 
+      "attrs": {"shape": "(1, -1, 4)"}, 
+      "inputs": [[212, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_reshape2", 
+      "attrs": {"shape": "(1, -1)"}, 
+      "inputs": [[213, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_ssdanchorgenerator3_anchor_3", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "Constant_ssd0_ssdanchorgenerator3_anchor_3_139808411376440", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1, 1, 16, 16, 24)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_relu_21_dequantize", 
+      "inputs": [[88, 0, 0], [88, 1, 0], [88, 2, 0]]
+    }, 
+    {
+      "op": "_mul_scalar", 
+      "name": "ssd0_ssdanchorgenerator3__mulscalar0", 
+      "attrs": {"scalar": "0"}, 
+      "inputs": [[216, 0, 0]]
+    }, 
+    {
+      "op": "slice_like", 
+      "name": "ssd0_ssdanchorgenerator3_slice_like0", 
+      "attrs": {"axes": "(2, 3)"}, 
+      "inputs": [[215, 0, 0], [217, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_ssdanchorgenerator3_reshape0", 
+      "attrs": {"shape": "(1, -1, 4)"}, 
+      "inputs": [[218, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_ssdanchorgenerator3_reshape1", 
+      "attrs": {"shape": "(1, -1, 4)"}, 
+      "inputs": [[219, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_reshape3", 
+      "attrs": {"shape": "(1, -1)"}, 
+      "inputs": [[220, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_ssdanchorgenerator4_anchor_4", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "Constant_ssd0_ssdanchorgenerator4_anchor_4_139808411376328", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1, 1, 16, 16, 16)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_relu_24_dequantize", 
+      "inputs": [[100, 0, 0], [100, 1, 0], [100, 2, 0]]
+    }, 
+    {
+      "op": "_mul_scalar", 
+      "name": "ssd0_ssdanchorgenerator4__mulscalar0", 
+      "attrs": {"scalar": "0"}, 
+      "inputs": [[223, 0, 0]]
+    }, 
+    {
+      "op": "slice_like", 
+      "name": "ssd0_ssdanchorgenerator4_slice_like0", 
+      "attrs": {"axes": "(2, 3)"}, 
+      "inputs": [[222, 0, 0], [224, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_ssdanchorgenerator4_reshape0", 
+      "attrs": {"shape": "(1, -1, 4)"}, 
+      "inputs": [[225, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_ssdanchorgenerator4_reshape1", 
+      "attrs": {"shape": "(1, -1, 4)"}, 
+      "inputs": [[226, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_reshape4", 
+      "attrs": {"shape": "(1, -1)"}, 
+      "inputs": [[227, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_ssdanchorgenerator5_anchor_5", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "Constant_ssd0_ssdanchorgenerator5_anchor_5_139808411424920", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1, 1, 16, 16, 16)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_relu_27_dequantize", 
+      "inputs": [[112, 0, 0], [112, 1, 0], [112, 2, 0]]
+    }, 
+    {
+      "op": "_mul_scalar", 
+      "name": "ssd0_ssdanchorgenerator5__mulscalar0", 
+      "attrs": {"scalar": "0"}, 
+      "inputs": [[230, 0, 0]]
+    }, 
+    {
+      "op": "slice_like", 
+      "name": "ssd0_ssdanchorgenerator5_slice_like0", 
+      "attrs": {"axes": "(2, 3)"}, 
+      "inputs": [[229, 0, 0], [231, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_ssdanchorgenerator5_reshape0", 
+      "attrs": {"shape": "(1, -1, 4)"}, 
+      "inputs": [[232, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_ssdanchorgenerator5_reshape1", 
+      "attrs": {"shape": "(1, -1, 4)"}, 
+      "inputs": [[233, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_reshape5", 
+      "attrs": {"shape": "(1, -1)"}, 
+      "inputs": [[234, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat2", 
+      "attrs": {
+        "dim": "1", 
+        "num_args": "6"
+      }, 
+      "inputs": [[200, 0, 0], [207, 0, 0], [214, 0, 0], [221, 0, 0], [228, 0, 0], [235, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_reshape8", 
+      "attrs": {"shape": "(1, -1, 4)"}, 
+      "inputs": [[236, 0, 0]]
+    }, 
+    {
+      "op": "SliceChannel", 
+      "name": "ssd0_normalizedboxcenterdecoder0_split0", 
+      "attrs": {
+        "axis": "-1", 
+        "num_outputs": "4"
+      }, 
+      "inputs": [[237, 0, 0]]
+    }, 
+    {
+      "op": "broadcast_mul", 
+      "name": "ssd0_normalizedboxcenterdecoder0_broadcast_mul0", 
+      "inputs": [[194, 0, 0], [238, 2, 0]]
+    }, 
+    {
+      "op": "broadcast_add", 
+      "name": "ssd0_normalizedboxcenterdecoder0_broadcast_add0", 
+      "inputs": [[239, 0, 0], [238, 0, 0]]
+    }, 
+    {
+      "op": "_mul_scalar", 
+      "name": "ssd0_normalizedboxcenterdecoder0__mulscalar2", 
+      "attrs": {"scalar": "0.2"}, 
+      "inputs": [[192, 2, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_normalizedboxcenterdecoder0__plusscalar2", 
+      "attrs": {"scalar": "0.0"}, 
+      "inputs": [[241, 0, 0]]
+    }, 
+    {
+      "op": "exp", 
+      "name": "ssd0_normalizedboxcenterdecoder0_exp0", 
+      "inputs": [[242, 0, 0]]
+    }, 
+    {
+      "op": "broadcast_mul", 
+      "name": "ssd0_normalizedboxcenterdecoder0_broadcast_mul2", 
+      "inputs": [[243, 0, 0], [238, 2, 0]]
+    }, 
+    {
+      "op": "_div_scalar", 
+      "name": "ssd0_normalizedboxcenterdecoder0__divscalar0", 
+      "attrs": {"scalar": "2"}, 
+      "inputs": [[244, 0, 0]]
+    }, 
+    {
+      "op": "elemwise_sub", 
+      "name": "ssd0_normalizedboxcenterdecoder0__minus0", 
+      "inputs": [[240, 0, 0], [245, 0, 0]]
+    }, 
+    {
+      "op": "_mul_scalar", 
+      "name": "ssd0_normalizedboxcenterdecoder0__mulscalar1", 
+      "attrs": {"scalar": "0.1"}, 
+      "inputs": [[192, 1, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_normalizedboxcenterdecoder0__plusscalar1", 
+      "attrs": {"scalar": "0.0"}, 
+      "inputs": [[247, 0, 0]]
+    }, 
+    {
+      "op": "broadcast_mul", 
+      "name": "ssd0_normalizedboxcenterdecoder0_broadcast_mul1", 
+      "inputs": [[248, 0, 0], [238, 3, 0]]
+    }, 
+    {
+      "op": "broadcast_add", 
+      "name": "ssd0_normalizedboxcenterdecoder0_broadcast_add1", 
+      "inputs": [[249, 0, 0], [238, 1, 0]]
+    }, 
+    {
+      "op": "_mul_scalar", 
+      "name": "ssd0_normalizedboxcenterdecoder0__mulscalar3", 
+      "attrs": {"scalar": "0.2"}, 
+      "inputs": [[192, 3, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_normalizedboxcenterdecoder0__plusscalar3", 
+      "attrs": {"scalar": "0.0"}, 
+      "inputs": [[251, 0, 0]]
+    }, 
+    {
+      "op": "exp", 
+      "name": "ssd0_normalizedboxcenterdecoder0_exp1", 
+      "inputs": [[252, 0, 0]]
+    }, 
+    {
+      "op": "broadcast_mul", 
+      "name": "ssd0_normalizedboxcenterdecoder0_broadcast_mul3", 
+      "inputs": [[253, 0, 0], [238, 3, 0]]
+    }, 
+    {
+      "op": "_div_scalar", 
+      "name": "ssd0_normalizedboxcenterdecoder0__divscalar1", 
+      "attrs": {"scalar": "2"}, 
+      "inputs": [[254, 0, 0]]
+    }, 
+    {
+      "op": "elemwise_sub", 
+      "name": "ssd0_normalizedboxcenterdecoder0__minus1", 
+      "inputs": [[250, 0, 0], [255, 0, 0]]
+    }, 
+    {
+      "op": "elemwise_add", 
+      "name": "ssd0_normalizedboxcenterdecoder0__plus0", 
+      "inputs": [[240, 0, 0], [245, 0, 0]]
+    }, 
+    {
+      "op": "elemwise_add", 
+      "name": "ssd0_normalizedboxcenterdecoder0__plus1", 
+      "inputs": [[250, 0, 0], [255, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_normalizedboxcenterdecoder0_concat0", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "4"
+      }, 
+      "inputs": [[246, 0, 0], [256, 0, 0], [257, 0, 0], [258, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat3", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[150, 0, 0], [153, 0, 0], [259, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis2", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "1", 
+        "end": "2"
+      }, 
+      "inputs": [[149, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis3", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "1", 
+        "end": "2"
+      }, 
+      "inputs": [[152, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat4", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[261, 0, 0], [262, 0, 0], [259, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis4", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "2", 
+        "end": "3"
+      }, 
+      "inputs": [[149, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis5", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "2", 
+        "end": "3"
+      }, 
+      "inputs": [[152, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat5", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[264, 0, 0], [265, 0, 0], [259, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis6", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "3", 
+        "end": "4"
+      }, 
+      "inputs": [[149, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis7", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "3", 
+        "end": "4"
+      }, 
+      "inputs": [[152, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat6", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[267, 0, 0], [268, 0, 0], [259, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis8", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "4", 
+        "end": "5"
+      }, 
+      "inputs": [[149, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis9", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "4", 
+        "end": "5"
+      }, 
+      "inputs": [[152, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat7", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[270, 0, 0], [271, 0, 0], [259, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis10", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "5", 
+        "end": "6"
+      }, 
+      "inputs": [[149, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis11", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "5", 
+        "end": "6"
+      }, 
+      "inputs": [[152, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat8", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[273, 0, 0], [274, 0, 0], [259, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis12", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "6", 
+        "end": "7"
+      }, 
+      "inputs": [[149, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis13", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "6", 
+        "end": "7"
+      }, 
+      "inputs": [[152, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat9", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[276, 0, 0], [277, 0, 0], [259, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis14", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "7", 
+        "end": "8"
+      }, 
+      "inputs": [[149, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis15", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "7", 
+        "end": "8"
+      }, 
+      "inputs": [[152, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat10", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[279, 0, 0], [280, 0, 0], [259, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis16", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "8", 
+        "end": "9"
+      }, 
+      "inputs": [[149, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis17", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "8", 
+        "end": "9"
+      }, 
+      "inputs": [[152, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat11", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[282, 0, 0], [283, 0, 0], [259, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis18", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "9", 
+        "end": "10"
+      }, 
+      "inputs": [[149, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis19", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "9", 
+        "end": "10"
+      }, 
+      "inputs": [[152, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat12", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[285, 0, 0], [286, 0, 0], [259, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis20", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "10", 
+        "end": "11"
+      }, 
+      "inputs": [[149, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis21", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "10", 
+        "end": "11"
+      }, 
+      "inputs": [[152, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat13", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[288, 0, 0], [289, 0, 0], [259, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis22", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "11", 
+        "end": "12"
+      }, 
+      "inputs": [[149, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis23", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "11", 
+        "end": "12"
+      }, 
+      "inputs": [[152, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat14", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[291, 0, 0], [292, 0, 0], [259, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis24", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "12", 
+        "end": "13"
+      }, 
+      "inputs": [[149, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis25", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "12", 
+        "end": "13"
+      }, 
+      "inputs": [[152, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat15", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[294, 0, 0], [295, 0, 0], [259, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis26", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "13", 
+        "end": "14"
+      }, 
+      "inputs": [[149, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis27", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "13", 
+        "end": "14"
+      }, 
+      "inputs": [[152, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat16", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[297, 0, 0], [298, 0, 0], [259, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis28", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "14", 
+        "end": "15"
+      }, 
+      "inputs": [[149, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis29", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "14", 
+        "end": "15"
+      }, 
+      "inputs": [[152, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat17", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[300, 0, 0], [301, 0, 0], [259, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis30", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "15", 
+        "end": "16"
+      }, 
+      "inputs": [[149, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis31", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "15", 
+        "end": "16"
+      }, 
+      "inputs": [[152, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat18", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[303, 0, 0], [304, 0, 0], [259, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis32", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "16", 
+        "end": "17"
+      }, 
+      "inputs": [[149, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis33", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "16", 
+        "end": "17"
+      }, 
+      "inputs": [[152, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat19", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[306, 0, 0], [307, 0, 0], [259, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis34", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "17", 
+        "end": "18"
+      }, 
+      "inputs": [[149, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis35", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "17", 
+        "end": "18"
+      }, 
+      "inputs": [[152, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat20", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[309, 0, 0], [310, 0, 0], [259, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis36", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "18", 
+        "end": "19"
+      }, 
+      "inputs": [[149, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis37", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "18", 
+        "end": "19"
+      }, 
+      "inputs": [[152, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat21", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[312, 0, 0], [313, 0, 0], [259, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis38", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "19", 
+        "end": "20"
+      }, 
+      "inputs": [[149, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis39", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "19", 
+        "end": "20"
+      }, 
+      "inputs": [[152, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat22", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[315, 0, 0], [316, 0, 0], [259, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat23", 
+      "attrs": {
+        "dim": "1", 
+        "num_args": "20"
+      }, 
+      "inputs": [
+        [260, 0, 0], 
+        [263, 0, 0], 
+        [266, 0, 0], 
+        [269, 0, 0], 
+        [272, 0, 0], 
+        [275, 0, 0], 
+        [278, 0, 0], 
+        [281, 0, 0], 
+        [284, 0, 0], 
+        [287, 0, 0], 
+        [290, 0, 0], 
+        [293, 0, 0], 
+        [296, 0, 0], 
+        [299, 0, 0], 
+        [302, 0, 0], 
+        [305, 0, 0], 
+        [308, 0, 0], 
+        [311, 0, 0], 
+        [314, 0, 0], 
+        [317, 0, 0]
+      ]
+    }, 
+    {
+      "op": "_contrib_box_nms", 
+      "name": "ssd0_box_nms0", 
+      "attrs": {
+        "coord_start": "2", 
+        "force_suppress": "False", 
+        "id_index": "0", 
+        "overlap_thresh": "0.45", 
+        "score_index": "1", 
+        "topk": "200", 
+        "valid_thresh": "0.01"
+      }, 
+      "inputs": [[318, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis40", 
+      "attrs": {
+        "axis": "1", 
+        "begin": "0", 
+        "end": "100"
+      }, 
+      "inputs": [[319, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis41", 
+      "attrs": {
+        "axis": "2", 
+        "begin": "0", 
+        "end": "1"
+      }, 
+      "inputs": [[320, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis42", 
+      "attrs": {
+        "axis": "2", 
+        "begin": "1", 
+        "end": "2"
+      }, 
+      "inputs": [[320, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis43", 
+      "attrs": {
+        "axis": "2", 
+        "begin": "2", 
+        "end": "6"
+      }, 
+      "inputs": [[320, 0, 0]]
+    }
+  ], 
+  "arg_nodes": [
+    0, 
+    1, 
+    4, 
+    5, 
+    7, 
+    8, 
+    11, 
+    12, 
+    14, 
+    15, 
+    18, 
+    19, 
+    21, 
+    22, 
+    24, 
+    25, 
+    28, 
+    29, 
+    31, 
+    32, 
+    34, 
+    35, 
+    39, 
+    42, 
+    43, 
+    49, 
+    50, 
+    52, 
+    53, 
+    55, 
+    56, 
+    59, 
+    60, 
+    62, 
+    63, 
+    65, 
+    66, 
+    71, 
+    72, 
+    74, 
+    75, 
+    77, 
+    78, 
+    83, 
+    84, 
+    86, 
+    87, 
+    89, 
+    90, 
+    95, 
+    96, 
+    98, 
+    99, 
+    101, 
+    102, 
+    107, 
+    108, 
+    110, 
+    111, 
+    113, 
+    114, 
+    154, 
+    155, 
+    160, 
+    161, 
+    166, 
+    167, 
+    172, 
+    173, 
+    178, 
+    179, 
+    184, 
+    185, 
+    195, 
+    201, 
+    208, 
+    215, 
+    222, 
+    229
+  ], 
+  "node_row_ptr": [
+    0, 
+    1, 
+    2, 
+    3, 
+    6, 
+    7, 
+    8, 
+    11, 
+    12, 
+    13, 
+    16, 
+    19, 
+    20, 
+    21, 
+    24, 
+    25, 
+    26, 
+    29, 
+    32, 
+    33, 
+    34, 
+    37, 
+    38, 
+    39, 
+    42, 
+    43, 
+    44, 
+    47, 
+    50, 
+    51, 
+    52, 
+    55, 
+    56, 
+    57, 
+    60, 
+    61, 
+    62, 
+    65, 
+    66, 
+    68, 
+    69, 
+    70, 
+    73, 
+    74, 
+    75, 
+    78, 
+    79, 
+    80, 
+    81, 
+    84, 
+    85, 
+    86, 
+    89, 
+    90, 
+    91, 
+    94, 
+    95, 
+    96, 
+    99, 
+    102, 
+    103, 
+    104, 
+    107, 
+    108, 
+    109, 
+    112, 
+    113, 
+    114, 
+    117, 
+    118, 
+    119, 
+    120, 
+    121, 
+    122, 
+    125, 
+    126, 
+    127, 
+    130, 
+    131, 
+    132, 
+    135, 
+    136, 
+    137, 
+    138, 
+    139, 
+    140, 
+    143, 
+    144, 
+    145, 
+    148, 
+    149, 
+    150, 
+    153, 
+    154, 
+    155, 
+    156, 
+    157, 
+    158, 
+    161, 
+    162, 
+    163, 
+    166, 
+    167, 
+    168, 
+    171, 
+    172, 
+    173, 
+    174, 
+    175, 
+    176, 
+    179, 
+    180, 
+    181, 
+    184, 
+    185, 
+    186, 
+    189, 
+    190, 
+    191, 
+    192, 
+    193, 
+    194, 
+    195, 
+    196, 
+    197, 
+    198, 
+    199, 
+    200, 
+    201, 
+    202, 
+    203, 
+    204, 
+    205, 
+    206, 
+    207, 
+    208, 
+    209, 
+    210, 
+    211, 
+    212, 
+    213, 
+    214, 
+    215, 
+    216, 
+    217, 
+    218, 
+    219, 
+    220, 
+    221, 
+    222, 
+    223, 
+    224, 
+    225, 
+    226, 
+    227, 
+    228, 
+    229, 
+    232, 
+    233, 
+    234, 
+    235, 
+    236, 
+    237, 
+    240, 
+    241, 
+    242, 
+    243, 
+    244, 
+    245, 
+    248, 
+    249, 
+    250, 
+    251, 
+    252, 
+    253, 
+    256, 
+    257, 
+    258, 
+    259, 
+    260, 
+    261, 
+    264, 
+    265, 
+    266, 
+    267, 
+    268, 
+    269, 
+    272, 
+    273, 
+    274, 
+    275, 
+    276, 
+    277, 
+    281, 
+    282, 
+    283, 
+    284, 
+    285, 
+    286, 
+    287, 
+    288, 
+    289, 
+    290, 
+    291, 
+    292, 
+    293, 
+    294, 
+    295, 
+    296, 
+    297, 
+    298, 
+    299, 
+    300, 
+    301, 
+    302, 
+    303, 
+    304, 
+    305, 
+    306, 
+    307, 
+    308, 
+    309, 
+    310, 
+    311, 
+    312, 
+    313, 
+    314, 
+    315, 
+    316, 
+    317, 
+    318, 
+    319, 
+    320, 
+    321, 
+    322, 
+    323, 
+    324, 
+    325, 
+    326, 
+    330, 
+    331, 
+    332, 
+    333, 
+    334, 
+    335, 
+    336, 
+    337, 
+    338, 
+    339, 
+    340, 
+    341, 
+    342, 
+    343, 
+    344, 
+    345, 
+    346, 
+    347, 
+    348, 
+    349, 
+    350, 
+    351, 
+    352, 
+    353, 
+    354, 
+    355, 
+    356, 
+    357, 
+    358, 
+    359, 
+    360, 
+    361, 
+    362, 
+    363, 
+    364, 
+    365, 
+    366, 
+    367, 
+    368, 
+    369, 
+    370, 
+    371, 
+    372, 
+    373, 
+    374, 
+    375, 
+    376, 
+    377, 
+    378, 
+    379, 
+    380, 
+    381, 
+    382, 
+    383, 
+    384, 
+    385, 
+    386, 
+    387, 
+    388, 
+    389, 
+    390, 
+    391, 
+    392, 
+    393, 
+    394, 
+    395, 
+    396, 
+    397, 
+    398, 
+    399, 
+    400, 
+    401, 
+    402, 
+    403, 
+    404, 
+    405, 
+    406, 
+    407, 
+    408, 
+    409, 
+    410, 
+    412, 
+    413, 
+    414, 
+    415, 
+    416
+  ], 
+  "heads": [[321, 0, 0], [322, 0, 0], [323, 0, 0]], 
+  "attrs": {"mxnet_version": ["int", 10500]}
+}

--- a/gluoncv/model_zoo/quantized/ssd_512_mobilenet1.0_voc_int8-symbol.json
+++ b/gluoncv/model_zoo/quantized/ssd_512_mobilenet1.0_voc_int8-symbol.json
@@ -1,0 +1,7991 @@
+{
+  "nodes": [
+    {
+      "op": "null", 
+      "name": "data", 
+      "inputs": []
+    }, 
+    {
+      "op": "_contrib_quantize_v2", 
+      "name": "data_quantize", 
+      "attrs": {"out_type": "auto"}, 
+      "inputs": [[0, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(32, 0, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm0_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm0_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm0_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm0_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_0", 
+      "attrs": {
+        "max_calib_range": "1.971370", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[1, 0, 0], [2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 1], [6, 0, 1], [1, 1, 0], [1, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "data0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_mobilenet0_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "32", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(2, 2)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm0_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm0_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm0_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm0_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_mobilenet0_batchnorm0_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_mobilenet0_relu0_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_conv1_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(32, 0, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm1_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm1_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm1_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm1_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_1", 
+      "attrs": {
+        "max_calib_range": "4.843816", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[7, 0, 0], [8, 0, 0], [9, 0, 0], [10, 0, 0], [11, 0, 1], [12, 0, 1], [7, 1, 0], [7, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_0_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_conv1_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_mobilenet0_conv1_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "32", 
+                "num_group": "32", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm1_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm1_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm1_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm1_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_mobilenet0_batchnorm1_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_mobilenet0_relu1_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_conv2_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64, 0, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm2_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm2_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm2_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm2_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_2", 
+      "attrs": {
+        "max_calib_range": "12.230622", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[13, 0, 0], [14, 0, 0], [15, 0, 0], [16, 0, 0], [17, 0, 1], [18, 0, 1], [13, 1, 0], [13, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_1_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_conv2_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_mobilenet0_conv2_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "64", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm2_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm2_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm2_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm2_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_mobilenet0_batchnorm2_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_mobilenet0_relu2_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_conv3_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64, 0, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm3_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm3_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm3_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm3_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_3", 
+      "attrs": {
+        "max_calib_range": "4.503809", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[19, 0, 0], [20, 0, 0], [21, 0, 0], [22, 0, 0], [23, 0, 1], [24, 0, 1], [19, 1, 0], [19, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_2_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_conv3_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_mobilenet0_conv3_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "64", 
+                "num_group": "64", 
+                "pad": "(1, 1)", 
+                "stride": "(2, 2)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm3_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm3_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm3_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm3_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_mobilenet0_batchnorm3_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_mobilenet0_relu3_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_conv4_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128, 0, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm4_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm4_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm4_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm4_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_4", 
+      "attrs": {
+        "max_calib_range": "3.454003", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[25, 0, 0], [26, 0, 0], [27, 0, 0], [28, 0, 0], [29, 0, 1], [30, 0, 1], [25, 1, 0], [25, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_3_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_conv4_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_mobilenet0_conv4_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "128", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm4_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm4_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm4_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm4_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_mobilenet0_batchnorm4_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_mobilenet0_relu4_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_conv5_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128, 0, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm5_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm5_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm5_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm5_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_5", 
+      "attrs": {
+        "max_calib_range": "4.388649", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[31, 0, 0], [32, 0, 0], [33, 0, 0], [34, 0, 0], [35, 0, 1], [36, 0, 1], [31, 1, 0], [31, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_4_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_conv5_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_mobilenet0_conv5_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "128", 
+                "num_group": "128", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm5_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm5_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm5_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm5_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_mobilenet0_batchnorm5_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_mobilenet0_relu5_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_conv6_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128, 0, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm6_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm6_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm6_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm6_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_6", 
+      "attrs": {
+        "max_calib_range": "3.698938", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[37, 0, 0], [38, 0, 0], [39, 0, 0], [40, 0, 0], [41, 0, 1], [42, 0, 1], [37, 1, 0], [37, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_5_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_conv6_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_mobilenet0_conv6_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "128", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm6_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm6_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm6_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm6_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_mobilenet0_batchnorm6_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_mobilenet0_relu6_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_conv7_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128, 0, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm7_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm7_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm7_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm7_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_7", 
+      "attrs": {
+        "max_calib_range": "3.953003", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[43, 0, 0], [44, 0, 0], [45, 0, 0], [46, 0, 0], [47, 0, 1], [48, 0, 1], [43, 1, 0], [43, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_6_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_conv7_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_mobilenet0_conv7_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "128", 
+                "num_group": "128", 
+                "pad": "(1, 1)", 
+                "stride": "(2, 2)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm7_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm7_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm7_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm7_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_mobilenet0_batchnorm7_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_mobilenet0_relu7_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_conv8_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256, 0, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm8_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm8_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm8_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm8_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_8", 
+      "attrs": {
+        "max_calib_range": "2.041146", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[49, 0, 0], [50, 0, 0], [51, 0, 0], [52, 0, 0], [53, 0, 1], [54, 0, 1], [49, 1, 0], [49, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_7_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_conv8_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_mobilenet0_conv8_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "256", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm8_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm8_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm8_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm8_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_mobilenet0_batchnorm8_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_mobilenet0_relu8_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_conv9_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256, 0, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm9_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm9_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm9_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm9_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_9", 
+      "attrs": {
+        "max_calib_range": "3.181829", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[55, 0, 0], [56, 0, 0], [57, 0, 0], [58, 0, 0], [59, 0, 1], [60, 0, 1], [55, 1, 0], [55, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_8_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_conv9_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_mobilenet0_conv9_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "256", 
+                "num_group": "256", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm9_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm9_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm9_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm9_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_mobilenet0_batchnorm9_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_mobilenet0_relu9_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_conv10_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256, 0, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm10_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm10_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm10_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm10_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_10", 
+      "attrs": {
+        "max_calib_range": "1.957919", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[61, 0, 0], [62, 0, 0], [63, 0, 0], [64, 0, 0], [65, 0, 1], [66, 0, 1], [61, 1, 0], [61, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_9_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_conv10_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_mobilenet0_conv10_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "256", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm10_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm10_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm10_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm10_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_mobilenet0_batchnorm10_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_mobilenet0_relu10_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_conv11_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256, 0, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm11_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm11_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm11_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm11_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_11", 
+      "attrs": {
+        "max_calib_range": "3.375719", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[67, 0, 0], [68, 0, 0], [69, 0, 0], [70, 0, 0], [71, 0, 1], [72, 0, 1], [67, 1, 0], [67, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_10_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_conv11_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_mobilenet0_conv11_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "256", 
+                "num_group": "256", 
+                "pad": "(1, 1)", 
+                "stride": "(2, 2)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm11_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm11_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm11_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm11_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_mobilenet0_batchnorm11_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_mobilenet0_relu11_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_conv12_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 0, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm12_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm12_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm12_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm12_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_12", 
+      "attrs": {
+        "max_calib_range": "1.671821", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[73, 0, 0], [74, 0, 0], [75, 0, 0], [76, 0, 0], [77, 0, 1], [78, 0, 1], [73, 1, 0], [73, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_11_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_conv12_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_mobilenet0_conv12_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "512", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm12_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm12_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm12_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm12_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_mobilenet0_batchnorm12_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_mobilenet0_relu12_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_conv13_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 0, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm13_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm13_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm13_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm13_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_13", 
+      "attrs": {
+        "max_calib_range": "3.777070", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[79, 0, 0], [80, 0, 0], [81, 0, 0], [82, 0, 0], [83, 0, 1], [84, 0, 1], [79, 1, 0], [79, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_12_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_conv13_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_mobilenet0_conv13_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "512", 
+                "num_group": "512", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm13_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm13_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm13_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm13_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_mobilenet0_batchnorm13_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_mobilenet0_relu13_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_conv14_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 0, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm14_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm14_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm14_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm14_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_14", 
+      "attrs": {
+        "max_calib_range": "1.441661", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[85, 0, 0], [86, 0, 0], [87, 0, 0], [88, 0, 0], [89, 0, 1], [90, 0, 1], [85, 1, 0], [85, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_13_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_conv14_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_mobilenet0_conv14_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "512", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm14_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm14_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm14_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm14_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_mobilenet0_batchnorm14_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_mobilenet0_relu14_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_conv15_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 0, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm15_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm15_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm15_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm15_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_15", 
+      "attrs": {
+        "max_calib_range": "3.497429", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[91, 0, 0], [92, 0, 0], [93, 0, 0], [94, 0, 0], [95, 0, 1], [96, 0, 1], [91, 1, 0], [91, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_14_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_conv15_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_mobilenet0_conv15_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "512", 
+                "num_group": "512", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm15_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm15_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm15_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm15_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_mobilenet0_batchnorm15_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_mobilenet0_relu15_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_conv16_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 0, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm16_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm16_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm16_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm16_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_16", 
+      "attrs": {
+        "max_calib_range": "1.592348", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[97, 0, 0], [98, 0, 0], [99, 0, 0], [100, 0, 0], [101, 0, 1], [102, 0, 1], [97, 1, 0], [97, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_15_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_conv16_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_mobilenet0_conv16_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "512", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm16_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm16_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm16_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm16_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_mobilenet0_batchnorm16_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_mobilenet0_relu16_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_conv17_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 0, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm17_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm17_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm17_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm17_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_17", 
+      "attrs": {
+        "max_calib_range": "5.516345", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[103, 0, 0], [104, 0, 0], [105, 0, 0], [106, 0, 0], [107, 0, 1], [108, 0, 1], [103, 1, 0], [103, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_16_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_conv17_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_mobilenet0_conv17_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "512", 
+                "num_group": "512", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm17_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm17_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm17_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm17_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_mobilenet0_batchnorm17_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_mobilenet0_relu17_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_conv18_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 0, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm18_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm18_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm18_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm18_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_18", 
+      "attrs": {
+        "max_calib_range": "1.715310", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[109, 0, 0], [110, 0, 0], [111, 0, 0], [112, 0, 0], [113, 0, 1], [114, 0, 1], [109, 1, 0], [109, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_17_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_conv18_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_mobilenet0_conv18_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "512", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm18_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm18_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm18_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm18_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_mobilenet0_batchnorm18_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_mobilenet0_relu18_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_conv19_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 0, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm19_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm19_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm19_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm19_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_19", 
+      "attrs": {
+        "max_calib_range": "3.596492", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[115, 0, 0], [116, 0, 0], [117, 0, 0], [118, 0, 0], [119, 0, 1], [120, 0, 1], [115, 1, 0], [115, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_18_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_conv19_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_mobilenet0_conv19_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "512", 
+                "num_group": "512", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm19_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm19_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm19_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm19_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_mobilenet0_batchnorm19_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_mobilenet0_relu19_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_conv20_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 0, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm20_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm20_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm20_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm20_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_20", 
+      "attrs": {
+        "max_calib_range": "1.897627", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[121, 0, 0], [122, 0, 0], [123, 0, 0], [124, 0, 0], [125, 0, 1], [126, 0, 1], [121, 1, 0], [121, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_19_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_conv20_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_mobilenet0_conv20_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "512", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm20_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm20_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm20_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm20_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_mobilenet0_batchnorm20_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_mobilenet0_relu20_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_conv21_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 0, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm21_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm21_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm21_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm21_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_21", 
+      "attrs": {
+        "max_calib_range": "3.805538", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[127, 0, 0], [128, 0, 0], [129, 0, 0], [130, 0, 0], [131, 0, 1], [132, 0, 1], [127, 1, 0], [127, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_20_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_conv21_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_mobilenet0_conv21_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "512", 
+                "num_group": "512", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm21_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm21_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm21_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm21_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_mobilenet0_batchnorm21_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_mobilenet0_relu21_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_conv22_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 0, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm22_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm22_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm22_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm22_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_22", 
+      "attrs": {
+        "max_calib_range": "9.088818", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[133, 0, 0], [134, 0, 0], [135, 0, 0], [136, 0, 0], [137, 0, 1], [138, 0, 1], [133, 1, 0], [133, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_21_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_conv22_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_mobilenet0_conv22_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "512", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm22_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm22_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm22_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm22_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_mobilenet0_batchnorm22_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_mobilenet0_relu22_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor0_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"uniform\", \"factor_type\": \"avg\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(84, 512, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor0_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(84,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_23", 
+      "attrs": {
+        "max_calib_range": "19.190063", 
+        "min_calib_range": "-9.174813", 
+        "quantized": "true"
+      }, 
+      "inputs": [[139, 0, 0], [140, 0, 0], [141, 0, 0], [139, 1, 0], [139, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_22_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor0_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor0_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_convpredictor0_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "84", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4], 
+          "heads": [[3, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_23_dequantize", 
+      "inputs": [[142, 0, 0], [142, 1, 0], [142, 2, 0]]
+    }, 
+    {
+      "op": "transpose", 
+      "name": "ssd0_transpose0", 
+      "attrs": {"axes": "(0, 2, 3, 1)"}, 
+      "inputs": [[143, 0, 0]]
+    }, 
+    {
+      "op": "Flatten", 
+      "name": "ssd0_flatten0", 
+      "inputs": [[144, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_conv23_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 0, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm23_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm23_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm23_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm23_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_24", 
+      "attrs": {
+        "max_calib_range": "3.597511", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[139, 0, 0], [146, 0, 0], [147, 0, 0], [148, 0, 0], [149, 0, 1], [150, 0, 1], [139, 1, 0], [139, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_22_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_conv23_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_mobilenet0_conv23_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "512", 
+                "num_group": "512", 
+                "pad": "(1, 1)", 
+                "stride": "(2, 2)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm23_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm23_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm23_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm23_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_mobilenet0_batchnorm23_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_mobilenet0_relu23_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_conv24_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024, 0, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm24_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm24_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm24_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm24_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_25", 
+      "attrs": {
+        "max_calib_range": "1.158367", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[151, 0, 0], [152, 0, 0], [153, 0, 0], [154, 0, 0], [155, 0, 1], [156, 0, 1], [151, 1, 0], [151, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_24_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_conv24_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_mobilenet0_conv24_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "1024", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm24_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm24_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm24_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm24_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_mobilenet0_batchnorm24_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_mobilenet0_relu24_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_conv25_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024, 0, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm25_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm25_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm25_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm25_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_26", 
+      "attrs": {
+        "max_calib_range": "2.240377", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[157, 0, 0], [158, 0, 0], [159, 0, 0], [160, 0, 0], [161, 0, 1], [162, 0, 1], [157, 1, 0], [157, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_25_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_conv25_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_mobilenet0_conv25_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "1024", 
+                "num_group": "1024", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm25_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm25_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm25_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm25_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_mobilenet0_batchnorm25_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_mobilenet0_relu25_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_conv26_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024, 0, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm26_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm26_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm26_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_mobilenet0_batchnorm26_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_27", 
+      "attrs": {
+        "max_calib_range": "7.350129", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[163, 0, 0], [164, 0, 0], [165, 0, 0], [166, 0, 0], [167, 0, 1], [168, 0, 1], [163, 1, 0], [163, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_26_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_conv26_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_mobilenet0_conv26_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "1024", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm26_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm26_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm26_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_mobilenet0_batchnorm26_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_mobilenet0_batchnorm26_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_mobilenet0_relu26_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor2_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"uniform\", \"factor_type\": \"avg\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(126, 1024, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor2_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(126,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_28", 
+      "attrs": {
+        "max_calib_range": "38.167236", 
+        "min_calib_range": "-20.917624", 
+        "quantized": "true"
+      }, 
+      "inputs": [[169, 0, 0], [170, 0, 0], [171, 0, 0], [169, 1, 0], [169, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_27_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor2_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor2_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_convpredictor2_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "126", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4], 
+          "heads": [[3, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_28_dequantize", 
+      "inputs": [[172, 0, 0], [172, 1, 0], [172, 2, 0]]
+    }, 
+    {
+      "op": "transpose", 
+      "name": "ssd0_transpose1", 
+      "attrs": {"axes": "(0, 2, 3, 1)"}, 
+      "inputs": [[173, 0, 0]]
+    }, 
+    {
+      "op": "Flatten", 
+      "name": "ssd0_flatten1", 
+      "inputs": [[174, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_trans_conv0_weight", 
+      "attrs": {
+        "__init__": "<mxnet.initializer.Xavier object at 0x7f823a6c93c8>", 
+        "kernel": "(1, 1)", 
+        "no_bias": "True", 
+        "num_filter": "512"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_trans_bn0_gamma", 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_trans_bn0_beta", 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_trans_bn0_moving_mean", 
+      "attrs": {"__init__": "[\"zero\", {}]"}, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_trans_bn0_moving_var", 
+      "attrs": {"__init__": "[\"one\", {}]"}, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_29", 
+      "attrs": {
+        "max_calib_range": "7.552732", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[169, 0, 0], [176, 0, 0], [177, 0, 0], [178, 0, 0], [179, 0, 1], [180, 0, 1], [169, 1, 0], [169, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_27_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_trans_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_expand_trans_conv0", 
+              "attrs": {
+                "__init__": "<mxnet.initializer.Xavier object at 0x7f823a6c93c8>", 
+                "kernel": "(1, 1)", 
+                "no_bias": "True", 
+                "num_filter": "512"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_trans_bn0_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_trans_bn0_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_trans_bn0_moving_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_trans_bn0_moving_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_expand_trans_bn0", 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_expand_trans_relu0", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_conv0_weight", 
+      "attrs": {
+        "__init__": "<mxnet.initializer.Xavier object at 0x7f823a6c93c8>", 
+        "kernel": "(3, 3)", 
+        "no_bias": "True", 
+        "num_filter": "512", 
+        "pad": "(1, 1)", 
+        "stride": "(2, 2)"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_bn0_gamma", 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_bn0_beta", 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_bn0_moving_mean", 
+      "attrs": {"__init__": "[\"zero\", {}]"}, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_bn0_moving_var", 
+      "attrs": {"__init__": "[\"one\", {}]"}, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_30", 
+      "attrs": {
+        "max_calib_range": "8.410916", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[181, 0, 0], [182, 0, 0], [183, 0, 0], [184, 0, 0], [185, 0, 1], [186, 0, 1], [181, 1, 0], [181, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_29_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_expand_conv0", 
+              "attrs": {
+                "__init__": "<mxnet.initializer.Xavier object at 0x7f823a6c93c8>", 
+                "kernel": "(3, 3)", 
+                "no_bias": "True", 
+                "num_filter": "512", 
+                "pad": "(1, 1)", 
+                "stride": "(2, 2)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_bn0_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_bn0_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_bn0_moving_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_bn0_moving_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_expand_bn0", 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_expand_reu0", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor4_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"uniform\", \"factor_type\": \"avg\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(126, 512, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor4_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(126,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_31", 
+      "attrs": {
+        "max_calib_range": "21.583117", 
+        "min_calib_range": "-9.307992", 
+        "quantized": "true"
+      }, 
+      "inputs": [[187, 0, 0], [188, 0, 0], [189, 0, 0], [187, 1, 0], [187, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_30_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor4_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor4_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_convpredictor4_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "126", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4], 
+          "heads": [[3, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_31_dequantize", 
+      "inputs": [[190, 0, 0], [190, 1, 0], [190, 2, 0]]
+    }, 
+    {
+      "op": "transpose", 
+      "name": "ssd0_transpose2", 
+      "attrs": {"axes": "(0, 2, 3, 1)"}, 
+      "inputs": [[191, 0, 0]]
+    }, 
+    {
+      "op": "Flatten", 
+      "name": "ssd0_flatten2", 
+      "inputs": [[192, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_trans_conv1_weight", 
+      "attrs": {
+        "__init__": "<mxnet.initializer.Xavier object at 0x7f823a6c93c8>", 
+        "kernel": "(1, 1)", 
+        "no_bias": "True", 
+        "num_filter": "512"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_trans_bn1_gamma", 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_trans_bn1_beta", 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_trans_bn1_moving_mean", 
+      "attrs": {"__init__": "[\"zero\", {}]"}, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_trans_bn1_moving_var", 
+      "attrs": {"__init__": "[\"one\", {}]"}, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_32", 
+      "attrs": {
+        "max_calib_range": "7.923760", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[187, 0, 0], [194, 0, 0], [195, 0, 0], [196, 0, 0], [197, 0, 1], [198, 0, 1], [187, 1, 0], [187, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_30_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_trans_conv1_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_expand_trans_conv1", 
+              "attrs": {
+                "__init__": "<mxnet.initializer.Xavier object at 0x7f823a6c93c8>", 
+                "kernel": "(1, 1)", 
+                "no_bias": "True", 
+                "num_filter": "512"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_trans_bn1_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_trans_bn1_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_trans_bn1_moving_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_trans_bn1_moving_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_expand_trans_bn1", 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_expand_trans_relu1", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_conv1_weight", 
+      "attrs": {
+        "__init__": "<mxnet.initializer.Xavier object at 0x7f823a6c93c8>", 
+        "kernel": "(3, 3)", 
+        "no_bias": "True", 
+        "num_filter": "512", 
+        "pad": "(1, 1)", 
+        "stride": "(2, 2)"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_bn1_gamma", 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_bn1_beta", 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_bn1_moving_mean", 
+      "attrs": {"__init__": "[\"zero\", {}]"}, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_bn1_moving_var", 
+      "attrs": {"__init__": "[\"one\", {}]"}, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_33", 
+      "attrs": {
+        "max_calib_range": "8.464465", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[199, 0, 0], [200, 0, 0], [201, 0, 0], [202, 0, 0], [203, 0, 1], [204, 0, 1], [199, 1, 0], [199, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_32_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_conv1_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_expand_conv1", 
+              "attrs": {
+                "__init__": "<mxnet.initializer.Xavier object at 0x7f823a6c93c8>", 
+                "kernel": "(3, 3)", 
+                "no_bias": "True", 
+                "num_filter": "512", 
+                "pad": "(1, 1)", 
+                "stride": "(2, 2)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_bn1_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_bn1_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_bn1_moving_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_bn1_moving_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_expand_bn1", 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_expand_reu1", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor6_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"uniform\", \"factor_type\": \"avg\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(126, 512, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor6_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(126,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_34", 
+      "attrs": {
+        "max_calib_range": "17.421074", 
+        "min_calib_range": "-9.638062", 
+        "quantized": "true"
+      }, 
+      "inputs": [[205, 0, 0], [206, 0, 0], [207, 0, 0], [205, 1, 0], [205, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_33_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor6_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor6_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_convpredictor6_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "126", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4], 
+          "heads": [[3, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_34_dequantize", 
+      "inputs": [[208, 0, 0], [208, 1, 0], [208, 2, 0]]
+    }, 
+    {
+      "op": "transpose", 
+      "name": "ssd0_transpose3", 
+      "attrs": {"axes": "(0, 2, 3, 1)"}, 
+      "inputs": [[209, 0, 0]]
+    }, 
+    {
+      "op": "Flatten", 
+      "name": "ssd0_flatten3", 
+      "inputs": [[210, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_trans_conv2_weight", 
+      "attrs": {
+        "__init__": "<mxnet.initializer.Xavier object at 0x7f823a6c93c8>", 
+        "kernel": "(1, 1)", 
+        "no_bias": "True", 
+        "num_filter": "256"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_trans_bn2_gamma", 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_trans_bn2_beta", 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_trans_bn2_moving_mean", 
+      "attrs": {"__init__": "[\"zero\", {}]"}, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_trans_bn2_moving_var", 
+      "attrs": {"__init__": "[\"one\", {}]"}, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_35", 
+      "attrs": {
+        "max_calib_range": "8.838045", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[205, 0, 0], [212, 0, 0], [213, 0, 0], [214, 0, 0], [215, 0, 1], [216, 0, 1], [205, 1, 0], [205, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_33_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_trans_conv2_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_expand_trans_conv2", 
+              "attrs": {
+                "__init__": "<mxnet.initializer.Xavier object at 0x7f823a6c93c8>", 
+                "kernel": "(1, 1)", 
+                "no_bias": "True", 
+                "num_filter": "256"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_trans_bn2_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_trans_bn2_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_trans_bn2_moving_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_trans_bn2_moving_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_expand_trans_bn2", 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_expand_trans_relu2", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_conv2_weight", 
+      "attrs": {
+        "__init__": "<mxnet.initializer.Xavier object at 0x7f823a6c93c8>", 
+        "kernel": "(3, 3)", 
+        "no_bias": "True", 
+        "num_filter": "256", 
+        "pad": "(1, 1)", 
+        "stride": "(2, 2)"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_bn2_gamma", 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_bn2_beta", 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_bn2_moving_mean", 
+      "attrs": {"__init__": "[\"zero\", {}]"}, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_bn2_moving_var", 
+      "attrs": {"__init__": "[\"one\", {}]"}, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_36", 
+      "attrs": {
+        "max_calib_range": "7.621830", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[217, 0, 0], [218, 0, 0], [219, 0, 0], [220, 0, 0], [221, 0, 1], [222, 0, 1], [217, 1, 0], [217, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_35_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_conv2_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_expand_conv2", 
+              "attrs": {
+                "__init__": "<mxnet.initializer.Xavier object at 0x7f823a6c93c8>", 
+                "kernel": "(3, 3)", 
+                "no_bias": "True", 
+                "num_filter": "256", 
+                "pad": "(1, 1)", 
+                "stride": "(2, 2)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_bn2_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_bn2_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_bn2_moving_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_bn2_moving_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_expand_bn2", 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_expand_reu2", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor8_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"uniform\", \"factor_type\": \"avg\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(84, 256, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor8_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(84,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_37", 
+      "attrs": {
+        "max_calib_range": "10.199381", 
+        "min_calib_range": "-4.840173", 
+        "quantized": "true"
+      }, 
+      "inputs": [[223, 0, 0], [224, 0, 0], [225, 0, 0], [223, 1, 0], [223, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_36_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor8_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor8_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_convpredictor8_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "84", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4], 
+          "heads": [[3, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_37_dequantize", 
+      "inputs": [[226, 0, 0], [226, 1, 0], [226, 2, 0]]
+    }, 
+    {
+      "op": "transpose", 
+      "name": "ssd0_transpose4", 
+      "attrs": {"axes": "(0, 2, 3, 1)"}, 
+      "inputs": [[227, 0, 0]]
+    }, 
+    {
+      "op": "Flatten", 
+      "name": "ssd0_flatten4", 
+      "inputs": [[228, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_trans_conv3_weight", 
+      "attrs": {
+        "__init__": "<mxnet.initializer.Xavier object at 0x7f823a6c93c8>", 
+        "kernel": "(1, 1)", 
+        "no_bias": "True", 
+        "num_filter": "256"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_trans_bn3_gamma", 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_trans_bn3_beta", 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_trans_bn3_moving_mean", 
+      "attrs": {"__init__": "[\"zero\", {}]"}, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_trans_bn3_moving_var", 
+      "attrs": {"__init__": "[\"one\", {}]"}, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_38", 
+      "attrs": {
+        "max_calib_range": "7.274212", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[223, 0, 0], [230, 0, 0], [231, 0, 0], [232, 0, 0], [233, 0, 1], [234, 0, 1], [223, 1, 0], [223, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_36_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_trans_conv3_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_expand_trans_conv3", 
+              "attrs": {
+                "__init__": "<mxnet.initializer.Xavier object at 0x7f823a6c93c8>", 
+                "kernel": "(1, 1)", 
+                "no_bias": "True", 
+                "num_filter": "256"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_trans_bn3_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_trans_bn3_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_trans_bn3_moving_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_trans_bn3_moving_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_expand_trans_bn3", 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_expand_trans_relu3", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_conv3_weight", 
+      "attrs": {
+        "__init__": "<mxnet.initializer.Xavier object at 0x7f823a6c93c8>", 
+        "kernel": "(3, 3)", 
+        "no_bias": "True", 
+        "num_filter": "256", 
+        "pad": "(1, 1)", 
+        "stride": "(2, 2)"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_bn3_gamma", 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_bn3_beta", 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_bn3_moving_mean", 
+      "attrs": {"__init__": "[\"zero\", {}]"}, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_bn3_moving_var", 
+      "attrs": {"__init__": "[\"one\", {}]"}, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_39", 
+      "attrs": {
+        "max_calib_range": "6.971924", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[235, 0, 0], [236, 0, 0], [237, 0, 0], [238, 0, 0], [239, 0, 1], [240, 0, 1], [235, 1, 0], [235, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_38_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_conv3_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_expand_conv3", 
+              "attrs": {
+                "__init__": "<mxnet.initializer.Xavier object at 0x7f823a6c93c8>", 
+                "kernel": "(3, 3)", 
+                "no_bias": "True", 
+                "num_filter": "256", 
+                "pad": "(1, 1)", 
+                "stride": "(2, 2)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_bn3_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_bn3_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_bn3_moving_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_bn3_moving_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_expand_bn3", 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_expand_reu3", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor10_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"uniform\", \"factor_type\": \"avg\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(84, 256, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor10_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(84,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_40", 
+      "attrs": {
+        "max_calib_range": "13.234236", 
+        "min_calib_range": "-6.174638", 
+        "quantized": "true"
+      }, 
+      "inputs": [[241, 0, 0], [242, 0, 0], [243, 0, 0], [241, 1, 0], [241, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_39_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor10_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor10_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_convpredictor10_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "84", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4], 
+          "heads": [[3, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_40_dequantize", 
+      "inputs": [[244, 0, 0], [244, 1, 0], [244, 2, 0]]
+    }, 
+    {
+      "op": "transpose", 
+      "name": "ssd0_transpose5", 
+      "attrs": {"axes": "(0, 2, 3, 1)"}, 
+      "inputs": [[245, 0, 0]]
+    }, 
+    {
+      "op": "Flatten", 
+      "name": "ssd0_flatten5", 
+      "inputs": [[246, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat0", 
+      "attrs": {
+        "dim": "1", 
+        "num_args": "6"
+      }, 
+      "inputs": [[145, 0, 0], [175, 0, 0], [193, 0, 0], [211, 0, 0], [229, 0, 0], [247, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_reshape6", 
+      "attrs": {"shape": "(0, -1, 21)"}, 
+      "inputs": [[248, 0, 0]]
+    }, 
+    {
+      "op": "softmax", 
+      "name": "ssd0_softmax0", 
+      "attrs": {"axis": "-1"}, 
+      "inputs": [[249, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_multiperclassdecoder0_slice_axis0", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "1", 
+        "end": "None"
+      }, 
+      "inputs": [[250, 0, 0]]
+    }, 
+    {
+      "op": "_greater_scalar", 
+      "name": "ssd0_multiperclassdecoder0__greater_scalar0", 
+      "attrs": {"scalar": "0.01"}, 
+      "inputs": [[251, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_multiperclassdecoder0_slice_axis1", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "0", 
+        "end": "1"
+      }, 
+      "inputs": [[250, 0, 0]]
+    }, 
+    {
+      "op": "zeros_like", 
+      "name": "ssd0_multiperclassdecoder0_zeros_like0", 
+      "inputs": [[253, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar0", 
+      "attrs": {"scalar": "0"}, 
+      "inputs": [[254, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar1", 
+      "attrs": {"scalar": "1"}, 
+      "inputs": [[254, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar2", 
+      "attrs": {"scalar": "2"}, 
+      "inputs": [[254, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar3", 
+      "attrs": {"scalar": "3"}, 
+      "inputs": [[254, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar4", 
+      "attrs": {"scalar": "4"}, 
+      "inputs": [[254, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar5", 
+      "attrs": {"scalar": "5"}, 
+      "inputs": [[254, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar6", 
+      "attrs": {"scalar": "6"}, 
+      "inputs": [[254, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar7", 
+      "attrs": {"scalar": "7"}, 
+      "inputs": [[254, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar8", 
+      "attrs": {"scalar": "8"}, 
+      "inputs": [[254, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar9", 
+      "attrs": {"scalar": "9"}, 
+      "inputs": [[254, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar10", 
+      "attrs": {"scalar": "10"}, 
+      "inputs": [[254, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar11", 
+      "attrs": {"scalar": "11"}, 
+      "inputs": [[254, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar12", 
+      "attrs": {"scalar": "12"}, 
+      "inputs": [[254, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar13", 
+      "attrs": {"scalar": "13"}, 
+      "inputs": [[254, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar14", 
+      "attrs": {"scalar": "14"}, 
+      "inputs": [[254, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar15", 
+      "attrs": {"scalar": "15"}, 
+      "inputs": [[254, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar16", 
+      "attrs": {"scalar": "16"}, 
+      "inputs": [[254, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar17", 
+      "attrs": {"scalar": "17"}, 
+      "inputs": [[254, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar18", 
+      "attrs": {"scalar": "18"}, 
+      "inputs": [[254, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar19", 
+      "attrs": {"scalar": "19"}, 
+      "inputs": [[254, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_multiperclassdecoder0_concat0", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "20"
+      }, 
+      "inputs": [
+        [255, 0, 0], 
+        [256, 0, 0], 
+        [257, 0, 0], 
+        [258, 0, 0], 
+        [259, 0, 0], 
+        [260, 0, 0], 
+        [261, 0, 0], 
+        [262, 0, 0], 
+        [263, 0, 0], 
+        [264, 0, 0], 
+        [265, 0, 0], 
+        [266, 0, 0], 
+        [267, 0, 0], 
+        [268, 0, 0], 
+        [269, 0, 0], 
+        [270, 0, 0], 
+        [271, 0, 0], 
+        [272, 0, 0], 
+        [273, 0, 0], 
+        [274, 0, 0]
+      ]
+    }, 
+    {
+      "op": "ones_like", 
+      "name": "ssd0_multiperclassdecoder0_ones_like0", 
+      "inputs": [[275, 0, 0]]
+    }, 
+    {
+      "op": "_mul_scalar", 
+      "name": "ssd0_multiperclassdecoder0__mulscalar0", 
+      "attrs": {"scalar": "-1"}, 
+      "inputs": [[276, 0, 0]]
+    }, 
+    {
+      "op": "where", 
+      "name": "ssd0_multiperclassdecoder0_where0", 
+      "inputs": [[252, 0, 0], [275, 0, 0], [277, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis0", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "0", 
+        "end": "1"
+      }, 
+      "inputs": [[278, 0, 0]]
+    }, 
+    {
+      "op": "zeros_like", 
+      "name": "ssd0_multiperclassdecoder0_zeros_like1", 
+      "inputs": [[251, 0, 0]]
+    }, 
+    {
+      "op": "where", 
+      "name": "ssd0_multiperclassdecoder0_where1", 
+      "inputs": [[252, 0, 0], [251, 0, 0], [280, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis1", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "0", 
+        "end": "1"
+      }, 
+      "inputs": [[281, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor1_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"uniform\", \"factor_type\": \"avg\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(16, 512, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor1_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(16,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_41", 
+      "attrs": {
+        "max_calib_range": "4.876158", 
+        "min_calib_range": "-12.747149", 
+        "quantized": "true"
+      }, 
+      "inputs": [[139, 0, 0], [283, 0, 0], [284, 0, 0], [139, 1, 0], [139, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_22_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor1_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor1_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_convpredictor1_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "16", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4], 
+          "heads": [[3, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_41_dequantize", 
+      "inputs": [[285, 0, 0], [285, 1, 0], [285, 2, 0]]
+    }, 
+    {
+      "op": "transpose", 
+      "name": "ssd0_transpose6", 
+      "attrs": {"axes": "(0, 2, 3, 1)"}, 
+      "inputs": [[286, 0, 0]]
+    }, 
+    {
+      "op": "Flatten", 
+      "name": "ssd0_flatten6", 
+      "inputs": [[287, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor3_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"uniform\", \"factor_type\": \"avg\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(24, 1024, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor3_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(24,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_42", 
+      "attrs": {
+        "max_calib_range": "4.302043", 
+        "min_calib_range": "-4.075301", 
+        "quantized": "true"
+      }, 
+      "inputs": [[169, 0, 0], [289, 0, 0], [290, 0, 0], [169, 1, 0], [169, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_27_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor3_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor3_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_convpredictor3_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "24", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4], 
+          "heads": [[3, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_42_dequantize", 
+      "inputs": [[291, 0, 0], [291, 1, 0], [291, 2, 0]]
+    }, 
+    {
+      "op": "transpose", 
+      "name": "ssd0_transpose7", 
+      "attrs": {"axes": "(0, 2, 3, 1)"}, 
+      "inputs": [[292, 0, 0]]
+    }, 
+    {
+      "op": "Flatten", 
+      "name": "ssd0_flatten7", 
+      "inputs": [[293, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor5_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"uniform\", \"factor_type\": \"avg\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(24, 512, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor5_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(24,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_43", 
+      "attrs": {
+        "max_calib_range": "4.123853", 
+        "min_calib_range": "-3.929893", 
+        "quantized": "true"
+      }, 
+      "inputs": [[187, 0, 0], [295, 0, 0], [296, 0, 0], [187, 1, 0], [187, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_30_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor5_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor5_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_convpredictor5_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "24", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4], 
+          "heads": [[3, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_43_dequantize", 
+      "inputs": [[297, 0, 0], [297, 1, 0], [297, 2, 0]]
+    }, 
+    {
+      "op": "transpose", 
+      "name": "ssd0_transpose8", 
+      "attrs": {"axes": "(0, 2, 3, 1)"}, 
+      "inputs": [[298, 0, 0]]
+    }, 
+    {
+      "op": "Flatten", 
+      "name": "ssd0_flatten8", 
+      "inputs": [[299, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor7_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"uniform\", \"factor_type\": \"avg\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(24, 512, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor7_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(24,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_44", 
+      "attrs": {
+        "max_calib_range": "3.868445", 
+        "min_calib_range": "-3.787183", 
+        "quantized": "true"
+      }, 
+      "inputs": [[205, 0, 0], [301, 0, 0], [302, 0, 0], [205, 1, 0], [205, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_33_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor7_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor7_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_convpredictor7_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "24", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4], 
+          "heads": [[3, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_44_dequantize", 
+      "inputs": [[303, 0, 0], [303, 1, 0], [303, 2, 0]]
+    }, 
+    {
+      "op": "transpose", 
+      "name": "ssd0_transpose9", 
+      "attrs": {"axes": "(0, 2, 3, 1)"}, 
+      "inputs": [[304, 0, 0]]
+    }, 
+    {
+      "op": "Flatten", 
+      "name": "ssd0_flatten9", 
+      "inputs": [[305, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor9_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"uniform\", \"factor_type\": \"avg\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(16, 256, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor9_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(16,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_45", 
+      "attrs": {
+        "max_calib_range": "2.882389", 
+        "min_calib_range": "-2.954468", 
+        "quantized": "true"
+      }, 
+      "inputs": [[223, 0, 0], [307, 0, 0], [308, 0, 0], [223, 1, 0], [223, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_36_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor9_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor9_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_convpredictor9_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "16", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4], 
+          "heads": [[3, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_45_dequantize", 
+      "inputs": [[309, 0, 0], [309, 1, 0], [309, 2, 0]]
+    }, 
+    {
+      "op": "transpose", 
+      "name": "ssd0_transpose10", 
+      "attrs": {"axes": "(0, 2, 3, 1)"}, 
+      "inputs": [[310, 0, 0]]
+    }, 
+    {
+      "op": "Flatten", 
+      "name": "ssd0_flatten10", 
+      "inputs": [[311, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor11_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"uniform\", \"factor_type\": \"avg\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(16, 256, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor11_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(16,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_46", 
+      "attrs": {
+        "max_calib_range": "3.188980", 
+        "min_calib_range": "-3.491082", 
+        "quantized": "true"
+      }, 
+      "inputs": [[241, 0, 0], [313, 0, 0], [314, 0, 0], [241, 1, 0], [241, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_39_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor11_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor11_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_convpredictor11_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "16", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4], 
+          "heads": [[3, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_46_dequantize", 
+      "inputs": [[315, 0, 0], [315, 1, 0], [315, 2, 0]]
+    }, 
+    {
+      "op": "transpose", 
+      "name": "ssd0_transpose11", 
+      "attrs": {"axes": "(0, 2, 3, 1)"}, 
+      "inputs": [[316, 0, 0]]
+    }, 
+    {
+      "op": "Flatten", 
+      "name": "ssd0_flatten11", 
+      "inputs": [[317, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat1", 
+      "attrs": {
+        "dim": "1", 
+        "num_args": "6"
+      }, 
+      "inputs": [[288, 0, 0], [294, 0, 0], [300, 0, 0], [306, 0, 0], [312, 0, 0], [318, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_reshape7", 
+      "attrs": {"shape": "(0, -1, 4)"}, 
+      "inputs": [[319, 0, 0]]
+    }, 
+    {
+      "op": "SliceChannel", 
+      "name": "ssd0_normalizedboxcenterdecoder0_split1", 
+      "attrs": {
+        "axis": "-1", 
+        "num_outputs": "4"
+      }, 
+      "inputs": [[320, 0, 0]]
+    }, 
+    {
+      "op": "_mul_scalar", 
+      "name": "ssd0_normalizedboxcenterdecoder0__mulscalar0", 
+      "attrs": {"scalar": "0.1"}, 
+      "inputs": [[321, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_normalizedboxcenterdecoder0__plusscalar0", 
+      "attrs": {"scalar": "0.0"}, 
+      "inputs": [[322, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_ssdanchorgenerator0_anchor_0", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "Constant_ssd0_ssdanchorgenerator0_anchor_0_140197381553736", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1, 1, 128, 128, 16)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_bn_relu_22_dequantize", 
+      "inputs": [[139, 0, 0], [139, 1, 0], [139, 2, 0]]
+    }, 
+    {
+      "op": "_mul_scalar", 
+      "name": "ssd0_ssdanchorgenerator0__mulscalar0", 
+      "attrs": {"scalar": "0"}, 
+      "inputs": [[325, 0, 0]]
+    }, 
+    {
+      "op": "slice_like", 
+      "name": "ssd0_ssdanchorgenerator0_slice_like0", 
+      "attrs": {"axes": "(2, 3)"}, 
+      "inputs": [[324, 0, 0], [326, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_ssdanchorgenerator0_reshape0", 
+      "attrs": {"shape": "(1, -1, 4)"}, 
+      "inputs": [[327, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_ssdanchorgenerator0_reshape1", 
+      "attrs": {"shape": "(1, -1, 4)"}, 
+      "inputs": [[328, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_reshape0", 
+      "attrs": {"shape": "(1, -1)"}, 
+      "inputs": [[329, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_ssdanchorgenerator1_anchor_1", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "Constant_ssd0_ssdanchorgenerator1_anchor_1_140197901880120", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1, 1, 64, 64, 24)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_bn_relu_27_dequantize", 
+      "inputs": [[169, 0, 0], [169, 1, 0], [169, 2, 0]]
+    }, 
+    {
+      "op": "_mul_scalar", 
+      "name": "ssd0_ssdanchorgenerator1__mulscalar0", 
+      "attrs": {"scalar": "0"}, 
+      "inputs": [[332, 0, 0]]
+    }, 
+    {
+      "op": "slice_like", 
+      "name": "ssd0_ssdanchorgenerator1_slice_like0", 
+      "attrs": {"axes": "(2, 3)"}, 
+      "inputs": [[331, 0, 0], [333, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_ssdanchorgenerator1_reshape0", 
+      "attrs": {"shape": "(1, -1, 4)"}, 
+      "inputs": [[334, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_ssdanchorgenerator1_reshape1", 
+      "attrs": {"shape": "(1, -1, 4)"}, 
+      "inputs": [[335, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_reshape1", 
+      "attrs": {"shape": "(1, -1)"}, 
+      "inputs": [[336, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_ssdanchorgenerator2_anchor_2", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "Constant_ssd0_ssdanchorgenerator2_anchor_2_140197302707984", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1, 1, 32, 32, 24)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_bn_relu_30_dequantize", 
+      "inputs": [[187, 0, 0], [187, 1, 0], [187, 2, 0]]
+    }, 
+    {
+      "op": "_mul_scalar", 
+      "name": "ssd0_ssdanchorgenerator2__mulscalar0", 
+      "attrs": {"scalar": "0"}, 
+      "inputs": [[339, 0, 0]]
+    }, 
+    {
+      "op": "slice_like", 
+      "name": "ssd0_ssdanchorgenerator2_slice_like0", 
+      "attrs": {"axes": "(2, 3)"}, 
+      "inputs": [[338, 0, 0], [340, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_ssdanchorgenerator2_reshape0", 
+      "attrs": {"shape": "(1, -1, 4)"}, 
+      "inputs": [[341, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_ssdanchorgenerator2_reshape1", 
+      "attrs": {"shape": "(1, -1, 4)"}, 
+      "inputs": [[342, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_reshape2", 
+      "attrs": {"shape": "(1, -1)"}, 
+      "inputs": [[343, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_ssdanchorgenerator3_anchor_3", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "Constant_ssd0_ssdanchorgenerator3_anchor_3_140197302671624", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1, 1, 16, 16, 24)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_bn_relu_33_dequantize", 
+      "inputs": [[205, 0, 0], [205, 1, 0], [205, 2, 0]]
+    }, 
+    {
+      "op": "_mul_scalar", 
+      "name": "ssd0_ssdanchorgenerator3__mulscalar0", 
+      "attrs": {"scalar": "0"}, 
+      "inputs": [[346, 0, 0]]
+    }, 
+    {
+      "op": "slice_like", 
+      "name": "ssd0_ssdanchorgenerator3_slice_like0", 
+      "attrs": {"axes": "(2, 3)"}, 
+      "inputs": [[345, 0, 0], [347, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_ssdanchorgenerator3_reshape0", 
+      "attrs": {"shape": "(1, -1, 4)"}, 
+      "inputs": [[348, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_ssdanchorgenerator3_reshape1", 
+      "attrs": {"shape": "(1, -1, 4)"}, 
+      "inputs": [[349, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_reshape3", 
+      "attrs": {"shape": "(1, -1)"}, 
+      "inputs": [[350, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_ssdanchorgenerator4_anchor_4", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "Constant_ssd0_ssdanchorgenerator4_anchor_4_140197302672464", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1, 1, 16, 16, 16)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_bn_relu_36_dequantize", 
+      "inputs": [[223, 0, 0], [223, 1, 0], [223, 2, 0]]
+    }, 
+    {
+      "op": "_mul_scalar", 
+      "name": "ssd0_ssdanchorgenerator4__mulscalar0", 
+      "attrs": {"scalar": "0"}, 
+      "inputs": [[353, 0, 0]]
+    }, 
+    {
+      "op": "slice_like", 
+      "name": "ssd0_ssdanchorgenerator4_slice_like0", 
+      "attrs": {"axes": "(2, 3)"}, 
+      "inputs": [[352, 0, 0], [354, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_ssdanchorgenerator4_reshape0", 
+      "attrs": {"shape": "(1, -1, 4)"}, 
+      "inputs": [[355, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_ssdanchorgenerator4_reshape1", 
+      "attrs": {"shape": "(1, -1, 4)"}, 
+      "inputs": [[356, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_reshape4", 
+      "attrs": {"shape": "(1, -1)"}, 
+      "inputs": [[357, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_ssdanchorgenerator5_anchor_5", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "Constant_ssd0_ssdanchorgenerator5_anchor_5_140197302621128", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1, 1, 16, 16, 16)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_bn_relu_39_dequantize", 
+      "inputs": [[241, 0, 0], [241, 1, 0], [241, 2, 0]]
+    }, 
+    {
+      "op": "_mul_scalar", 
+      "name": "ssd0_ssdanchorgenerator5__mulscalar0", 
+      "attrs": {"scalar": "0"}, 
+      "inputs": [[360, 0, 0]]
+    }, 
+    {
+      "op": "slice_like", 
+      "name": "ssd0_ssdanchorgenerator5_slice_like0", 
+      "attrs": {"axes": "(2, 3)"}, 
+      "inputs": [[359, 0, 0], [361, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_ssdanchorgenerator5_reshape0", 
+      "attrs": {"shape": "(1, -1, 4)"}, 
+      "inputs": [[362, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_ssdanchorgenerator5_reshape1", 
+      "attrs": {"shape": "(1, -1, 4)"}, 
+      "inputs": [[363, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_reshape5", 
+      "attrs": {"shape": "(1, -1)"}, 
+      "inputs": [[364, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat2", 
+      "attrs": {
+        "dim": "1", 
+        "num_args": "6"
+      }, 
+      "inputs": [[330, 0, 0], [337, 0, 0], [344, 0, 0], [351, 0, 0], [358, 0, 0], [365, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_reshape8", 
+      "attrs": {"shape": "(1, -1, 4)"}, 
+      "inputs": [[366, 0, 0]]
+    }, 
+    {
+      "op": "SliceChannel", 
+      "name": "ssd0_normalizedboxcenterdecoder0_split0", 
+      "attrs": {
+        "axis": "-1", 
+        "num_outputs": "4"
+      }, 
+      "inputs": [[367, 0, 0]]
+    }, 
+    {
+      "op": "broadcast_mul", 
+      "name": "ssd0_normalizedboxcenterdecoder0_broadcast_mul0", 
+      "inputs": [[323, 0, 0], [368, 2, 0]]
+    }, 
+    {
+      "op": "broadcast_add", 
+      "name": "ssd0_normalizedboxcenterdecoder0_broadcast_add0", 
+      "inputs": [[369, 0, 0], [368, 0, 0]]
+    }, 
+    {
+      "op": "_mul_scalar", 
+      "name": "ssd0_normalizedboxcenterdecoder0__mulscalar2", 
+      "attrs": {"scalar": "0.2"}, 
+      "inputs": [[321, 2, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_normalizedboxcenterdecoder0__plusscalar2", 
+      "attrs": {"scalar": "0.0"}, 
+      "inputs": [[371, 0, 0]]
+    }, 
+    {
+      "op": "exp", 
+      "name": "ssd0_normalizedboxcenterdecoder0_exp0", 
+      "inputs": [[372, 0, 0]]
+    }, 
+    {
+      "op": "broadcast_mul", 
+      "name": "ssd0_normalizedboxcenterdecoder0_broadcast_mul2", 
+      "inputs": [[373, 0, 0], [368, 2, 0]]
+    }, 
+    {
+      "op": "_div_scalar", 
+      "name": "ssd0_normalizedboxcenterdecoder0__divscalar0", 
+      "attrs": {"scalar": "2"}, 
+      "inputs": [[374, 0, 0]]
+    }, 
+    {
+      "op": "elemwise_sub", 
+      "name": "ssd0_normalizedboxcenterdecoder0__minus0", 
+      "inputs": [[370, 0, 0], [375, 0, 0]]
+    }, 
+    {
+      "op": "_mul_scalar", 
+      "name": "ssd0_normalizedboxcenterdecoder0__mulscalar1", 
+      "attrs": {"scalar": "0.1"}, 
+      "inputs": [[321, 1, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_normalizedboxcenterdecoder0__plusscalar1", 
+      "attrs": {"scalar": "0.0"}, 
+      "inputs": [[377, 0, 0]]
+    }, 
+    {
+      "op": "broadcast_mul", 
+      "name": "ssd0_normalizedboxcenterdecoder0_broadcast_mul1", 
+      "inputs": [[378, 0, 0], [368, 3, 0]]
+    }, 
+    {
+      "op": "broadcast_add", 
+      "name": "ssd0_normalizedboxcenterdecoder0_broadcast_add1", 
+      "inputs": [[379, 0, 0], [368, 1, 0]]
+    }, 
+    {
+      "op": "_mul_scalar", 
+      "name": "ssd0_normalizedboxcenterdecoder0__mulscalar3", 
+      "attrs": {"scalar": "0.2"}, 
+      "inputs": [[321, 3, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_normalizedboxcenterdecoder0__plusscalar3", 
+      "attrs": {"scalar": "0.0"}, 
+      "inputs": [[381, 0, 0]]
+    }, 
+    {
+      "op": "exp", 
+      "name": "ssd0_normalizedboxcenterdecoder0_exp1", 
+      "inputs": [[382, 0, 0]]
+    }, 
+    {
+      "op": "broadcast_mul", 
+      "name": "ssd0_normalizedboxcenterdecoder0_broadcast_mul3", 
+      "inputs": [[383, 0, 0], [368, 3, 0]]
+    }, 
+    {
+      "op": "_div_scalar", 
+      "name": "ssd0_normalizedboxcenterdecoder0__divscalar1", 
+      "attrs": {"scalar": "2"}, 
+      "inputs": [[384, 0, 0]]
+    }, 
+    {
+      "op": "elemwise_sub", 
+      "name": "ssd0_normalizedboxcenterdecoder0__minus1", 
+      "inputs": [[380, 0, 0], [385, 0, 0]]
+    }, 
+    {
+      "op": "elemwise_add", 
+      "name": "ssd0_normalizedboxcenterdecoder0__plus0", 
+      "inputs": [[370, 0, 0], [375, 0, 0]]
+    }, 
+    {
+      "op": "elemwise_add", 
+      "name": "ssd0_normalizedboxcenterdecoder0__plus1", 
+      "inputs": [[380, 0, 0], [385, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_normalizedboxcenterdecoder0_concat0", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "4"
+      }, 
+      "inputs": [[376, 0, 0], [386, 0, 0], [387, 0, 0], [388, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat3", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[279, 0, 0], [282, 0, 0], [389, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis2", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "1", 
+        "end": "2"
+      }, 
+      "inputs": [[278, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis3", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "1", 
+        "end": "2"
+      }, 
+      "inputs": [[281, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat4", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[391, 0, 0], [392, 0, 0], [389, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis4", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "2", 
+        "end": "3"
+      }, 
+      "inputs": [[278, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis5", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "2", 
+        "end": "3"
+      }, 
+      "inputs": [[281, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat5", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[394, 0, 0], [395, 0, 0], [389, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis6", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "3", 
+        "end": "4"
+      }, 
+      "inputs": [[278, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis7", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "3", 
+        "end": "4"
+      }, 
+      "inputs": [[281, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat6", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[397, 0, 0], [398, 0, 0], [389, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis8", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "4", 
+        "end": "5"
+      }, 
+      "inputs": [[278, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis9", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "4", 
+        "end": "5"
+      }, 
+      "inputs": [[281, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat7", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[400, 0, 0], [401, 0, 0], [389, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis10", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "5", 
+        "end": "6"
+      }, 
+      "inputs": [[278, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis11", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "5", 
+        "end": "6"
+      }, 
+      "inputs": [[281, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat8", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[403, 0, 0], [404, 0, 0], [389, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis12", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "6", 
+        "end": "7"
+      }, 
+      "inputs": [[278, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis13", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "6", 
+        "end": "7"
+      }, 
+      "inputs": [[281, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat9", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[406, 0, 0], [407, 0, 0], [389, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis14", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "7", 
+        "end": "8"
+      }, 
+      "inputs": [[278, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis15", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "7", 
+        "end": "8"
+      }, 
+      "inputs": [[281, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat10", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[409, 0, 0], [410, 0, 0], [389, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis16", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "8", 
+        "end": "9"
+      }, 
+      "inputs": [[278, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis17", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "8", 
+        "end": "9"
+      }, 
+      "inputs": [[281, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat11", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[412, 0, 0], [413, 0, 0], [389, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis18", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "9", 
+        "end": "10"
+      }, 
+      "inputs": [[278, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis19", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "9", 
+        "end": "10"
+      }, 
+      "inputs": [[281, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat12", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[415, 0, 0], [416, 0, 0], [389, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis20", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "10", 
+        "end": "11"
+      }, 
+      "inputs": [[278, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis21", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "10", 
+        "end": "11"
+      }, 
+      "inputs": [[281, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat13", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[418, 0, 0], [419, 0, 0], [389, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis22", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "11", 
+        "end": "12"
+      }, 
+      "inputs": [[278, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis23", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "11", 
+        "end": "12"
+      }, 
+      "inputs": [[281, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat14", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[421, 0, 0], [422, 0, 0], [389, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis24", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "12", 
+        "end": "13"
+      }, 
+      "inputs": [[278, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis25", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "12", 
+        "end": "13"
+      }, 
+      "inputs": [[281, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat15", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[424, 0, 0], [425, 0, 0], [389, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis26", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "13", 
+        "end": "14"
+      }, 
+      "inputs": [[278, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis27", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "13", 
+        "end": "14"
+      }, 
+      "inputs": [[281, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat16", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[427, 0, 0], [428, 0, 0], [389, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis28", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "14", 
+        "end": "15"
+      }, 
+      "inputs": [[278, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis29", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "14", 
+        "end": "15"
+      }, 
+      "inputs": [[281, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat17", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[430, 0, 0], [431, 0, 0], [389, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis30", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "15", 
+        "end": "16"
+      }, 
+      "inputs": [[278, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis31", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "15", 
+        "end": "16"
+      }, 
+      "inputs": [[281, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat18", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[433, 0, 0], [434, 0, 0], [389, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis32", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "16", 
+        "end": "17"
+      }, 
+      "inputs": [[278, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis33", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "16", 
+        "end": "17"
+      }, 
+      "inputs": [[281, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat19", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[436, 0, 0], [437, 0, 0], [389, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis34", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "17", 
+        "end": "18"
+      }, 
+      "inputs": [[278, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis35", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "17", 
+        "end": "18"
+      }, 
+      "inputs": [[281, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat20", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[439, 0, 0], [440, 0, 0], [389, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis36", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "18", 
+        "end": "19"
+      }, 
+      "inputs": [[278, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis37", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "18", 
+        "end": "19"
+      }, 
+      "inputs": [[281, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat21", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[442, 0, 0], [443, 0, 0], [389, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis38", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "19", 
+        "end": "20"
+      }, 
+      "inputs": [[278, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis39", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "19", 
+        "end": "20"
+      }, 
+      "inputs": [[281, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat22", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[445, 0, 0], [446, 0, 0], [389, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat23", 
+      "attrs": {
+        "dim": "1", 
+        "num_args": "20"
+      }, 
+      "inputs": [
+        [390, 0, 0], 
+        [393, 0, 0], 
+        [396, 0, 0], 
+        [399, 0, 0], 
+        [402, 0, 0], 
+        [405, 0, 0], 
+        [408, 0, 0], 
+        [411, 0, 0], 
+        [414, 0, 0], 
+        [417, 0, 0], 
+        [420, 0, 0], 
+        [423, 0, 0], 
+        [426, 0, 0], 
+        [429, 0, 0], 
+        [432, 0, 0], 
+        [435, 0, 0], 
+        [438, 0, 0], 
+        [441, 0, 0], 
+        [444, 0, 0], 
+        [447, 0, 0]
+      ]
+    }, 
+    {
+      "op": "_contrib_box_nms", 
+      "name": "ssd0_box_nms0", 
+      "attrs": {
+        "coord_start": "2", 
+        "force_suppress": "False", 
+        "id_index": "0", 
+        "overlap_thresh": "0.45", 
+        "score_index": "1", 
+        "topk": "200", 
+        "valid_thresh": "0.01"
+      }, 
+      "inputs": [[448, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis40", 
+      "attrs": {
+        "axis": "1", 
+        "begin": "0", 
+        "end": "100"
+      }, 
+      "inputs": [[449, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis41", 
+      "attrs": {
+        "axis": "2", 
+        "begin": "0", 
+        "end": "1"
+      }, 
+      "inputs": [[450, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis42", 
+      "attrs": {
+        "axis": "2", 
+        "begin": "1", 
+        "end": "2"
+      }, 
+      "inputs": [[450, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis43", 
+      "attrs": {
+        "axis": "2", 
+        "begin": "2", 
+        "end": "6"
+      }, 
+      "inputs": [[450, 0, 0]]
+    }
+  ], 
+  "arg_nodes": [
+    0, 
+    2, 
+    3, 
+    4, 
+    5, 
+    6, 
+    8, 
+    9, 
+    10, 
+    11, 
+    12, 
+    14, 
+    15, 
+    16, 
+    17, 
+    18, 
+    20, 
+    21, 
+    22, 
+    23, 
+    24, 
+    26, 
+    27, 
+    28, 
+    29, 
+    30, 
+    32, 
+    33, 
+    34, 
+    35, 
+    36, 
+    38, 
+    39, 
+    40, 
+    41, 
+    42, 
+    44, 
+    45, 
+    46, 
+    47, 
+    48, 
+    50, 
+    51, 
+    52, 
+    53, 
+    54, 
+    56, 
+    57, 
+    58, 
+    59, 
+    60, 
+    62, 
+    63, 
+    64, 
+    65, 
+    66, 
+    68, 
+    69, 
+    70, 
+    71, 
+    72, 
+    74, 
+    75, 
+    76, 
+    77, 
+    78, 
+    80, 
+    81, 
+    82, 
+    83, 
+    84, 
+    86, 
+    87, 
+    88, 
+    89, 
+    90, 
+    92, 
+    93, 
+    94, 
+    95, 
+    96, 
+    98, 
+    99, 
+    100, 
+    101, 
+    102, 
+    104, 
+    105, 
+    106, 
+    107, 
+    108, 
+    110, 
+    111, 
+    112, 
+    113, 
+    114, 
+    116, 
+    117, 
+    118, 
+    119, 
+    120, 
+    122, 
+    123, 
+    124, 
+    125, 
+    126, 
+    128, 
+    129, 
+    130, 
+    131, 
+    132, 
+    134, 
+    135, 
+    136, 
+    137, 
+    138, 
+    140, 
+    141, 
+    146, 
+    147, 
+    148, 
+    149, 
+    150, 
+    152, 
+    153, 
+    154, 
+    155, 
+    156, 
+    158, 
+    159, 
+    160, 
+    161, 
+    162, 
+    164, 
+    165, 
+    166, 
+    167, 
+    168, 
+    170, 
+    171, 
+    176, 
+    177, 
+    178, 
+    179, 
+    180, 
+    182, 
+    183, 
+    184, 
+    185, 
+    186, 
+    188, 
+    189, 
+    194, 
+    195, 
+    196, 
+    197, 
+    198, 
+    200, 
+    201, 
+    202, 
+    203, 
+    204, 
+    206, 
+    207, 
+    212, 
+    213, 
+    214, 
+    215, 
+    216, 
+    218, 
+    219, 
+    220, 
+    221, 
+    222, 
+    224, 
+    225, 
+    230, 
+    231, 
+    232, 
+    233, 
+    234, 
+    236, 
+    237, 
+    238, 
+    239, 
+    240, 
+    242, 
+    243, 
+    283, 
+    284, 
+    289, 
+    290, 
+    295, 
+    296, 
+    301, 
+    302, 
+    307, 
+    308, 
+    313, 
+    314, 
+    324, 
+    331, 
+    338, 
+    345, 
+    352, 
+    359
+  ], 
+  "node_row_ptr": [
+    0, 
+    1, 
+    4, 
+    5, 
+    6, 
+    7, 
+    8, 
+    9, 
+    12, 
+    13, 
+    14, 
+    15, 
+    16, 
+    17, 
+    20, 
+    21, 
+    22, 
+    23, 
+    24, 
+    25, 
+    28, 
+    29, 
+    30, 
+    31, 
+    32, 
+    33, 
+    36, 
+    37, 
+    38, 
+    39, 
+    40, 
+    41, 
+    44, 
+    45, 
+    46, 
+    47, 
+    48, 
+    49, 
+    52, 
+    53, 
+    54, 
+    55, 
+    56, 
+    57, 
+    60, 
+    61, 
+    62, 
+    63, 
+    64, 
+    65, 
+    68, 
+    69, 
+    70, 
+    71, 
+    72, 
+    73, 
+    76, 
+    77, 
+    78, 
+    79, 
+    80, 
+    81, 
+    84, 
+    85, 
+    86, 
+    87, 
+    88, 
+    89, 
+    92, 
+    93, 
+    94, 
+    95, 
+    96, 
+    97, 
+    100, 
+    101, 
+    102, 
+    103, 
+    104, 
+    105, 
+    108, 
+    109, 
+    110, 
+    111, 
+    112, 
+    113, 
+    116, 
+    117, 
+    118, 
+    119, 
+    120, 
+    121, 
+    124, 
+    125, 
+    126, 
+    127, 
+    128, 
+    129, 
+    132, 
+    133, 
+    134, 
+    135, 
+    136, 
+    137, 
+    140, 
+    141, 
+    142, 
+    143, 
+    144, 
+    145, 
+    148, 
+    149, 
+    150, 
+    151, 
+    152, 
+    153, 
+    156, 
+    157, 
+    158, 
+    159, 
+    160, 
+    161, 
+    164, 
+    165, 
+    166, 
+    167, 
+    168, 
+    169, 
+    172, 
+    173, 
+    174, 
+    175, 
+    176, 
+    177, 
+    180, 
+    181, 
+    182, 
+    183, 
+    184, 
+    185, 
+    188, 
+    189, 
+    190, 
+    193, 
+    194, 
+    195, 
+    196, 
+    197, 
+    198, 
+    199, 
+    200, 
+    201, 
+    204, 
+    205, 
+    206, 
+    207, 
+    208, 
+    209, 
+    212, 
+    213, 
+    214, 
+    215, 
+    216, 
+    217, 
+    220, 
+    221, 
+    222, 
+    223, 
+    224, 
+    225, 
+    228, 
+    229, 
+    230, 
+    233, 
+    234, 
+    235, 
+    236, 
+    237, 
+    238, 
+    239, 
+    240, 
+    241, 
+    244, 
+    245, 
+    246, 
+    247, 
+    248, 
+    249, 
+    252, 
+    253, 
+    254, 
+    257, 
+    258, 
+    259, 
+    260, 
+    261, 
+    262, 
+    263, 
+    264, 
+    265, 
+    268, 
+    269, 
+    270, 
+    271, 
+    272, 
+    273, 
+    276, 
+    277, 
+    278, 
+    281, 
+    282, 
+    283, 
+    284, 
+    285, 
+    286, 
+    287, 
+    288, 
+    289, 
+    292, 
+    293, 
+    294, 
+    295, 
+    296, 
+    297, 
+    300, 
+    301, 
+    302, 
+    305, 
+    306, 
+    307, 
+    308, 
+    309, 
+    310, 
+    311, 
+    312, 
+    313, 
+    316, 
+    317, 
+    318, 
+    319, 
+    320, 
+    321, 
+    324, 
+    325, 
+    326, 
+    329, 
+    330, 
+    331, 
+    332, 
+    333, 
+    334, 
+    335, 
+    336, 
+    337, 
+    338, 
+    339, 
+    340, 
+    341, 
+    342, 
+    343, 
+    344, 
+    345, 
+    346, 
+    347, 
+    348, 
+    349, 
+    350, 
+    351, 
+    352, 
+    353, 
+    354, 
+    355, 
+    356, 
+    357, 
+    358, 
+    359, 
+    360, 
+    361, 
+    362, 
+    363, 
+    364, 
+    365, 
+    366, 
+    367, 
+    368, 
+    369, 
+    372, 
+    373, 
+    374, 
+    375, 
+    376, 
+    377, 
+    380, 
+    381, 
+    382, 
+    383, 
+    384, 
+    385, 
+    388, 
+    389, 
+    390, 
+    391, 
+    392, 
+    393, 
+    396, 
+    397, 
+    398, 
+    399, 
+    400, 
+    401, 
+    404, 
+    405, 
+    406, 
+    407, 
+    408, 
+    409, 
+    412, 
+    413, 
+    414, 
+    415, 
+    416, 
+    417, 
+    421, 
+    422, 
+    423, 
+    424, 
+    425, 
+    426, 
+    427, 
+    428, 
+    429, 
+    430, 
+    431, 
+    432, 
+    433, 
+    434, 
+    435, 
+    436, 
+    437, 
+    438, 
+    439, 
+    440, 
+    441, 
+    442, 
+    443, 
+    444, 
+    445, 
+    446, 
+    447, 
+    448, 
+    449, 
+    450, 
+    451, 
+    452, 
+    453, 
+    454, 
+    455, 
+    456, 
+    457, 
+    458, 
+    459, 
+    460, 
+    461, 
+    462, 
+    463, 
+    464, 
+    465, 
+    466, 
+    467, 
+    471, 
+    472, 
+    473, 
+    474, 
+    475, 
+    476, 
+    477, 
+    478, 
+    479, 
+    480, 
+    481, 
+    482, 
+    483, 
+    484, 
+    485, 
+    486, 
+    487, 
+    488, 
+    489, 
+    490, 
+    491, 
+    492, 
+    493, 
+    494, 
+    495, 
+    496, 
+    497, 
+    498, 
+    499, 
+    500, 
+    501, 
+    502, 
+    503, 
+    504, 
+    505, 
+    506, 
+    507, 
+    508, 
+    509, 
+    510, 
+    511, 
+    512, 
+    513, 
+    514, 
+    515, 
+    516, 
+    517, 
+    518, 
+    519, 
+    520, 
+    521, 
+    522, 
+    523, 
+    524, 
+    525, 
+    526, 
+    527, 
+    528, 
+    529, 
+    530, 
+    531, 
+    532, 
+    533, 
+    534, 
+    535, 
+    536, 
+    537, 
+    538, 
+    539, 
+    540, 
+    541, 
+    542, 
+    543, 
+    544, 
+    545, 
+    546, 
+    547, 
+    548, 
+    549, 
+    550, 
+    551, 
+    553, 
+    554, 
+    555, 
+    556, 
+    557
+  ], 
+  "heads": [[451, 0, 0], [452, 0, 0], [453, 0, 0]], 
+  "attrs": {"mxnet_version": ["int", 10500]}
+}

--- a/gluoncv/model_zoo/quantized/ssd_512_resnet50_v1_voc_int8-symbol.json
+++ b/gluoncv/model_zoo/quantized/ssd_512_resnet50_v1_voc_int8-symbol.json
@@ -1,0 +1,13552 @@
+{
+  "nodes": [
+    {
+      "op": "null", 
+      "name": "data", 
+      "inputs": []
+    }, 
+    {
+      "op": "_contrib_quantize_v2", 
+      "name": "data_quantize", 
+      "attrs": {"out_type": "auto"}, 
+      "inputs": [[0, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64, 0, 7, 7)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_batchnorm0_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_batchnorm0_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_batchnorm0_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_batchnorm0_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_0", 
+      "attrs": {
+        "max_calib_range": "4.332401", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[1, 0, 0], [2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 1], [6, 0, 1], [1, 1, 0], [1, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "data0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_resnetv10_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(7, 7)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "64", 
+                "num_group": "1", 
+                "pad": "(3, 3)", 
+                "stride": "(2, 2)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_batchnorm0_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_batchnorm0_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_batchnorm0_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_batchnorm0_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_resnetv10_batchnorm0_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_resnetv10_relu0_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_quantized_pooling", 
+      "name": "quantized_ssd0_resnetv10_pool0_fwd", 
+      "attrs": {
+        "global_pool": "False", 
+        "kernel": "(3, 3)", 
+        "layout": "NCHW", 
+        "pad": "(1, 1)", 
+        "pool_type": "max", 
+        "pooling_convention": "valid", 
+        "stride": "(2, 2)"
+      }, 
+      "inputs": [[7, 0, 0], [7, 1, 0], [7, 2, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64, 0, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_batchnorm0_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_batchnorm0_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_batchnorm0_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_batchnorm0_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_1", 
+      "attrs": {
+        "max_calib_range": "2.686990", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[8, 0, 0], [9, 0, 0], [10, 0, 0], [11, 0, 0], [12, 0, 0], [13, 0, 1], [14, 0, 1], [8, 1, 0], [8, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_pool0_fwd_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_resnetv10_stage1_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "64", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_batchnorm0_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_batchnorm0_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_batchnorm0_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_batchnorm0_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_resnetv10_stage1_batchnorm0_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_resnetv10_stage1_relu0_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[8, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12
+          ], 
+          "heads": [[9, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_conv1_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64, 64, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_batchnorm1_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_batchnorm1_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_batchnorm1_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_batchnorm1_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_2", 
+      "attrs": {
+        "max_calib_range": "2.207719", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[15, 0, 0], [16, 0, 0], [17, 0, 0], [18, 0, 0], [19, 0, 1], [20, 0, 1], [15, 1, 0], [15, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_1_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_conv1_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_resnetv10_stage1_conv1_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "64", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_batchnorm1_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_batchnorm1_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_batchnorm1_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_batchnorm1_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_resnetv10_stage1_batchnorm1_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_resnetv10_stage1_relu1_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_conv2_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256, 0, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_conv2_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_batchnorm2_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_batchnorm2_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_batchnorm2_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_batchnorm2_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_conv3_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256, 64, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_batchnorm3_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_batchnorm3_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_batchnorm3_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_batchnorm3_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_4", 
+      "attrs": {
+        "max_calib_range": "2.264818", 
+        "min_calib_range": "-4.511564", 
+        "quantized": "true", 
+        "with_bn": "true"
+      }, 
+      "inputs": [[8, 0, 0], [28, 0, 0], [29, 0, 0], [30, 0, 0], [31, 0, 1], [32, 0, 1], [8, 1, 0], [8, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_pool0_fwd_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_conv3_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_resnetv10_stage1_conv3_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "256", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_batchnorm3_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_batchnorm3_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_batchnorm3_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_batchnorm3_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_resnetv10_stage1_batchnorm3_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10], 
+          "heads": [[7, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_add_relu_3", 
+      "attrs": {
+        "max_calib_range": "2.577055", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_postsum_relu": "true", 
+        "with_sum": "true"
+      }, 
+      "inputs": [
+        [21, 0, 0], 
+        [22, 0, 0], 
+        [23, 0, 0], 
+        [24, 0, 0], 
+        [25, 0, 0], 
+        [26, 0, 1], 
+        [27, 0, 1], 
+        [33, 0, 0], 
+        [21, 1, 0], 
+        [21, 2, 0], 
+        [33, 1, 0], 
+        [33, 2, 0]
+      ], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_2_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_conv2_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_conv2_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_resnetv10_stage1_conv2_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "256", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_batchnorm2_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_batchnorm2_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_batchnorm2_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_batchnorm2_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_resnetv10_stage1_batchnorm2_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_batchnorm3_fwd_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "elemwise_add", 
+              "name": "ssd0_resnetv10_stage1__plus0", 
+              "inputs": [[8, 0, 0], [9, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_resnetv10_stage1_activation0", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[10, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7, 9], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12, 
+            13, 
+            14
+          ], 
+          "heads": [[11, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_conv4_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64, 0, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_conv4_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_batchnorm4_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_batchnorm4_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_batchnorm4_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_batchnorm4_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_5", 
+      "attrs": {
+        "max_calib_range": "2.307617", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[34, 0, 0], [35, 0, 0], [36, 0, 0], [37, 0, 0], [38, 0, 0], [39, 0, 1], [40, 0, 1], [34, 1, 0], [34, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_3_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_conv4_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_conv4_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_resnetv10_stage1_conv4_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "64", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_batchnorm4_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_batchnorm4_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_batchnorm4_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_batchnorm4_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_resnetv10_stage1_batchnorm4_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_resnetv10_stage1_relu2_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[8, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12
+          ], 
+          "heads": [[9, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_conv5_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64, 64, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_batchnorm5_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_batchnorm5_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_batchnorm5_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_batchnorm5_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_6", 
+      "attrs": {
+        "max_calib_range": "4.313608", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[41, 0, 0], [42, 0, 0], [43, 0, 0], [44, 0, 0], [45, 0, 1], [46, 0, 1], [41, 1, 0], [41, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_5_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_conv5_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_resnetv10_stage1_conv5_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "64", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_batchnorm5_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_batchnorm5_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_batchnorm5_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_batchnorm5_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_resnetv10_stage1_batchnorm5_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_resnetv10_stage1_relu3_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_conv6_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256, 0, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_conv6_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_batchnorm6_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_batchnorm6_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_batchnorm6_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_batchnorm6_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_add_relu_7", 
+      "attrs": {
+        "max_calib_range": "2.829698", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_postsum_relu": "true", 
+        "with_sum": "true"
+      }, 
+      "inputs": [
+        [47, 0, 0], 
+        [48, 0, 0], 
+        [49, 0, 0], 
+        [50, 0, 0], 
+        [51, 0, 0], 
+        [52, 0, 1], 
+        [53, 0, 1], 
+        [34, 0, 0], 
+        [47, 1, 0], 
+        [47, 2, 0], 
+        [34, 1, 0], 
+        [34, 2, 0]
+      ], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_6_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_conv6_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_conv6_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_resnetv10_stage1_conv6_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "256", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_batchnorm6_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_batchnorm6_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_batchnorm6_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_batchnorm6_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_resnetv10_stage1_batchnorm6_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_3_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "elemwise_add", 
+              "name": "ssd0_resnetv10_stage1__plus1", 
+              "inputs": [[8, 0, 0], [9, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_resnetv10_stage1_activation1", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[10, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7, 9], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12, 
+            13, 
+            14
+          ], 
+          "heads": [[11, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_conv7_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64, 0, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_conv7_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_batchnorm7_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_batchnorm7_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_batchnorm7_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_batchnorm7_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_8", 
+      "attrs": {
+        "max_calib_range": "2.742234", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[54, 0, 0], [55, 0, 0], [56, 0, 0], [57, 0, 0], [58, 0, 0], [59, 0, 1], [60, 0, 1], [54, 1, 0], [54, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_7_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_conv7_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_conv7_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_resnetv10_stage1_conv7_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "64", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_batchnorm7_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_batchnorm7_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_batchnorm7_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_batchnorm7_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_resnetv10_stage1_batchnorm7_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_resnetv10_stage1_relu4_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[8, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12
+          ], 
+          "heads": [[9, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_conv8_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64, 64, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_batchnorm8_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_batchnorm8_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_batchnorm8_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_batchnorm8_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_9", 
+      "attrs": {
+        "max_calib_range": "4.538939", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[61, 0, 0], [62, 0, 0], [63, 0, 0], [64, 0, 0], [65, 0, 1], [66, 0, 1], [61, 1, 0], [61, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_8_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_conv8_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_resnetv10_stage1_conv8_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "64", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_batchnorm8_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_batchnorm8_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_batchnorm8_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_batchnorm8_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_resnetv10_stage1_batchnorm8_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_resnetv10_stage1_relu5_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_conv9_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256, 0, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_conv9_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_batchnorm9_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_batchnorm9_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_batchnorm9_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage1_batchnorm9_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_add_relu_10", 
+      "attrs": {
+        "max_calib_range": "3.345585", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_postsum_relu": "true", 
+        "with_sum": "true"
+      }, 
+      "inputs": [
+        [67, 0, 0], 
+        [68, 0, 0], 
+        [69, 0, 0], 
+        [70, 0, 0], 
+        [71, 0, 0], 
+        [72, 0, 1], 
+        [73, 0, 1], 
+        [54, 0, 0], 
+        [67, 1, 0], 
+        [67, 2, 0], 
+        [54, 1, 0], 
+        [54, 2, 0]
+      ], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_9_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_conv9_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_conv9_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_resnetv10_stage1_conv9_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "256", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_batchnorm9_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_batchnorm9_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_batchnorm9_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage1_batchnorm9_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_resnetv10_stage1_batchnorm9_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_7_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "elemwise_add", 
+              "name": "ssd0_resnetv10_stage1__plus2", 
+              "inputs": [[8, 0, 0], [9, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_resnetv10_stage1_activation2", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[10, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7, 9], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12, 
+            13, 
+            14
+          ], 
+          "heads": [[11, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128, 0, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_batchnorm0_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_batchnorm0_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_batchnorm0_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_batchnorm0_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_11", 
+      "attrs": {
+        "max_calib_range": "1.899835", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[74, 0, 0], [75, 0, 0], [76, 0, 0], [77, 0, 0], [78, 0, 0], [79, 0, 1], [80, 0, 1], [74, 1, 0], [74, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_10_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_resnetv10_stage2_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "128", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(2, 2)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_batchnorm0_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_batchnorm0_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_batchnorm0_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_batchnorm0_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_resnetv10_stage2_batchnorm0_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_resnetv10_stage2_relu0_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[8, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12
+          ], 
+          "heads": [[9, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_conv1_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128, 128, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_batchnorm1_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_batchnorm1_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_batchnorm1_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_batchnorm1_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_12", 
+      "attrs": {
+        "max_calib_range": "2.669875", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[81, 0, 0], [82, 0, 0], [83, 0, 0], [84, 0, 0], [85, 0, 1], [86, 0, 1], [81, 1, 0], [81, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_11_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_conv1_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_resnetv10_stage2_conv1_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "128", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_batchnorm1_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_batchnorm1_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_batchnorm1_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_batchnorm1_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_resnetv10_stage2_batchnorm1_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_resnetv10_stage2_relu1_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_conv2_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 0, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_conv2_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_batchnorm2_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_batchnorm2_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_batchnorm2_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_batchnorm2_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_conv3_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 256, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_batchnorm3_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_batchnorm3_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_batchnorm3_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_batchnorm3_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_14", 
+      "attrs": {
+        "max_calib_range": "1.988914", 
+        "min_calib_range": "-1.961015", 
+        "quantized": "true", 
+        "with_bn": "true"
+      }, 
+      "inputs": [[74, 0, 0], [94, 0, 0], [95, 0, 0], [96, 0, 0], [97, 0, 1], [98, 0, 1], [74, 1, 0], [74, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_10_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_conv3_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_resnetv10_stage2_conv3_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "512", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(2, 2)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_batchnorm3_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_batchnorm3_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_batchnorm3_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_batchnorm3_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_resnetv10_stage2_batchnorm3_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10], 
+          "heads": [[7, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_add_relu_13", 
+      "attrs": {
+        "max_calib_range": "2.612540", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_postsum_relu": "true", 
+        "with_sum": "true"
+      }, 
+      "inputs": [
+        [87, 0, 0], 
+        [88, 0, 0], 
+        [89, 0, 0], 
+        [90, 0, 0], 
+        [91, 0, 0], 
+        [92, 0, 1], 
+        [93, 0, 1], 
+        [99, 0, 0], 
+        [87, 1, 0], 
+        [87, 2, 0], 
+        [99, 1, 0], 
+        [99, 2, 0]
+      ], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_12_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_conv2_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_conv2_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_resnetv10_stage2_conv2_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "512", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_batchnorm2_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_batchnorm2_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_batchnorm2_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_batchnorm2_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_resnetv10_stage2_batchnorm2_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_batchnorm3_fwd_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "elemwise_add", 
+              "name": "ssd0_resnetv10_stage2__plus0", 
+              "inputs": [[8, 0, 0], [9, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_resnetv10_stage2_activation0", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[10, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7, 9], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12, 
+            13, 
+            14
+          ], 
+          "heads": [[11, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_conv4_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128, 0, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_conv4_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_batchnorm4_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_batchnorm4_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_batchnorm4_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_batchnorm4_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_15", 
+      "attrs": {
+        "max_calib_range": "2.297476", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[100, 0, 0], [101, 0, 0], [102, 0, 0], [103, 0, 0], [104, 0, 0], [105, 0, 1], [106, 0, 1], [100, 1, 0], [100, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_13_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_conv4_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_conv4_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_resnetv10_stage2_conv4_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "128", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_batchnorm4_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_batchnorm4_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_batchnorm4_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_batchnorm4_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_resnetv10_stage2_batchnorm4_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_resnetv10_stage2_relu2_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[8, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12
+          ], 
+          "heads": [[9, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_conv5_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128, 128, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_batchnorm5_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_batchnorm5_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_batchnorm5_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_batchnorm5_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_16", 
+      "attrs": {
+        "max_calib_range": "2.287407", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[107, 0, 0], [108, 0, 0], [109, 0, 0], [110, 0, 0], [111, 0, 1], [112, 0, 1], [107, 1, 0], [107, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_15_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_conv5_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_resnetv10_stage2_conv5_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "128", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_batchnorm5_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_batchnorm5_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_batchnorm5_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_batchnorm5_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_resnetv10_stage2_batchnorm5_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_resnetv10_stage2_relu3_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_conv6_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 0, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_conv6_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_batchnorm6_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_batchnorm6_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_batchnorm6_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_batchnorm6_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_add_relu_17", 
+      "attrs": {
+        "max_calib_range": "3.371729", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_postsum_relu": "true", 
+        "with_sum": "true"
+      }, 
+      "inputs": [
+        [113, 0, 0], 
+        [114, 0, 0], 
+        [115, 0, 0], 
+        [116, 0, 0], 
+        [117, 0, 0], 
+        [118, 0, 1], 
+        [119, 0, 1], 
+        [100, 0, 0], 
+        [113, 1, 0], 
+        [113, 2, 0], 
+        [100, 1, 0], 
+        [100, 2, 0]
+      ], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_16_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_conv6_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_conv6_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_resnetv10_stage2_conv6_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "512", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_batchnorm6_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_batchnorm6_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_batchnorm6_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_batchnorm6_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_resnetv10_stage2_batchnorm6_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_13_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "elemwise_add", 
+              "name": "ssd0_resnetv10_stage2__plus1", 
+              "inputs": [[8, 0, 0], [9, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_resnetv10_stage2_activation1", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[10, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7, 9], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12, 
+            13, 
+            14
+          ], 
+          "heads": [[11, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_conv7_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128, 0, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_conv7_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_batchnorm7_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_batchnorm7_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_batchnorm7_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_batchnorm7_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_18", 
+      "attrs": {
+        "max_calib_range": "2.269738", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[120, 0, 0], [121, 0, 0], [122, 0, 0], [123, 0, 0], [124, 0, 0], [125, 0, 1], [126, 0, 1], [120, 1, 0], [120, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_17_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_conv7_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_conv7_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_resnetv10_stage2_conv7_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "128", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_batchnorm7_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_batchnorm7_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_batchnorm7_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_batchnorm7_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_resnetv10_stage2_batchnorm7_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_resnetv10_stage2_relu4_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[8, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12
+          ], 
+          "heads": [[9, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_conv8_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128, 128, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_batchnorm8_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_batchnorm8_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_batchnorm8_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_batchnorm8_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_19", 
+      "attrs": {
+        "max_calib_range": "3.264528", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[127, 0, 0], [128, 0, 0], [129, 0, 0], [130, 0, 0], [131, 0, 1], [132, 0, 1], [127, 1, 0], [127, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_18_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_conv8_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_resnetv10_stage2_conv8_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "128", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_batchnorm8_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_batchnorm8_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_batchnorm8_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_batchnorm8_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_resnetv10_stage2_batchnorm8_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_resnetv10_stage2_relu5_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_conv9_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 0, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_conv9_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_batchnorm9_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_batchnorm9_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_batchnorm9_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_batchnorm9_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_add_relu_20", 
+      "attrs": {
+        "max_calib_range": "3.448743", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_postsum_relu": "true", 
+        "with_sum": "true"
+      }, 
+      "inputs": [
+        [133, 0, 0], 
+        [134, 0, 0], 
+        [135, 0, 0], 
+        [136, 0, 0], 
+        [137, 0, 0], 
+        [138, 0, 1], 
+        [139, 0, 1], 
+        [120, 0, 0], 
+        [133, 1, 0], 
+        [133, 2, 0], 
+        [120, 1, 0], 
+        [120, 2, 0]
+      ], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_19_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_conv9_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_conv9_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_resnetv10_stage2_conv9_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "512", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_batchnorm9_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_batchnorm9_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_batchnorm9_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_batchnorm9_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_resnetv10_stage2_batchnorm9_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_17_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "elemwise_add", 
+              "name": "ssd0_resnetv10_stage2__plus2", 
+              "inputs": [[8, 0, 0], [9, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_resnetv10_stage2_activation2", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[10, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7, 9], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12, 
+            13, 
+            14
+          ], 
+          "heads": [[11, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_conv10_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128, 0, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_conv10_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_batchnorm10_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_batchnorm10_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_batchnorm10_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_batchnorm10_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_21", 
+      "attrs": {
+        "max_calib_range": "3.416933", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[140, 0, 0], [141, 0, 0], [142, 0, 0], [143, 0, 0], [144, 0, 0], [145, 0, 1], [146, 0, 1], [140, 1, 0], [140, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_20_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_conv10_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_conv10_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_resnetv10_stage2_conv10_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "128", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_batchnorm10_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_batchnorm10_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_batchnorm10_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_batchnorm10_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_resnetv10_stage2_batchnorm10_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_resnetv10_stage2_relu6_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[8, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12
+          ], 
+          "heads": [[9, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_conv11_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128, 128, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_batchnorm11_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_batchnorm11_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_batchnorm11_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_batchnorm11_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_22", 
+      "attrs": {
+        "max_calib_range": "3.628044", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[147, 0, 0], [148, 0, 0], [149, 0, 0], [150, 0, 0], [151, 0, 1], [152, 0, 1], [147, 1, 0], [147, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_21_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_conv11_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_resnetv10_stage2_conv11_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "128", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_batchnorm11_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_batchnorm11_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_batchnorm11_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_batchnorm11_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_resnetv10_stage2_batchnorm11_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_resnetv10_stage2_relu7_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_conv12_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 0, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_conv12_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_batchnorm12_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_batchnorm12_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_batchnorm12_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage2_batchnorm12_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_add_relu_23", 
+      "attrs": {
+        "max_calib_range": "4.600730", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_postsum_relu": "true", 
+        "with_sum": "true"
+      }, 
+      "inputs": [
+        [153, 0, 0], 
+        [154, 0, 0], 
+        [155, 0, 0], 
+        [156, 0, 0], 
+        [157, 0, 0], 
+        [158, 0, 1], 
+        [159, 0, 1], 
+        [140, 0, 0], 
+        [153, 1, 0], 
+        [153, 2, 0], 
+        [140, 1, 0], 
+        [140, 2, 0]
+      ], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_22_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_conv12_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_conv12_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_resnetv10_stage2_conv12_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "512", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_batchnorm12_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_batchnorm12_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_batchnorm12_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage2_batchnorm12_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_resnetv10_stage2_batchnorm12_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_20_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "elemwise_add", 
+              "name": "ssd0_resnetv10_stage2__plus3", 
+              "inputs": [[8, 0, 0], [9, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_resnetv10_stage2_activation3", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[10, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7, 9], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12, 
+            13, 
+            14
+          ], 
+          "heads": [[11, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256, 0, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm0_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm0_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm0_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm0_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_24", 
+      "attrs": {
+        "max_calib_range": "1.802472", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[160, 0, 0], [161, 0, 0], [162, 0, 0], [163, 0, 0], [164, 0, 0], [165, 0, 1], [166, 0, 1], [160, 1, 0], [160, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_23_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_resnetv10_stage3_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "256", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(2, 2)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm0_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm0_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm0_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm0_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_resnetv10_stage3_batchnorm0_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_resnetv10_stage3_relu0_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[8, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12
+          ], 
+          "heads": [[9, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_conv1_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256, 256, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm1_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm1_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm1_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm1_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_25", 
+      "attrs": {
+        "max_calib_range": "1.549805", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[167, 0, 0], [168, 0, 0], [169, 0, 0], [170, 0, 0], [171, 0, 1], [172, 0, 1], [167, 1, 0], [167, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_24_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_conv1_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_resnetv10_stage3_conv1_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "256", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm1_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm1_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm1_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm1_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_resnetv10_stage3_batchnorm1_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_resnetv10_stage3_relu1_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_conv2_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024, 0, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_conv2_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm2_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm2_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm2_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm2_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_conv3_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024, 512, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm3_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm3_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm3_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm3_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_27", 
+      "attrs": {
+        "max_calib_range": "2.689998", 
+        "min_calib_range": "-1.766548", 
+        "quantized": "true", 
+        "with_bn": "true"
+      }, 
+      "inputs": [[160, 0, 0], [180, 0, 0], [181, 0, 0], [182, 0, 0], [183, 0, 1], [184, 0, 1], [160, 1, 0], [160, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_23_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_conv3_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_resnetv10_stage3_conv3_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "1024", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(2, 2)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm3_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm3_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm3_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm3_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_resnetv10_stage3_batchnorm3_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10], 
+          "heads": [[7, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_add_relu_26", 
+      "attrs": {
+        "max_calib_range": "3.006491", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_postsum_relu": "true", 
+        "with_sum": "true"
+      }, 
+      "inputs": [
+        [173, 0, 0], 
+        [174, 0, 0], 
+        [175, 0, 0], 
+        [176, 0, 0], 
+        [177, 0, 0], 
+        [178, 0, 1], 
+        [179, 0, 1], 
+        [185, 0, 0], 
+        [173, 1, 0], 
+        [173, 2, 0], 
+        [185, 1, 0], 
+        [185, 2, 0]
+      ], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_25_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_conv2_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_conv2_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_resnetv10_stage3_conv2_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "1024", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm2_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm2_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm2_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm2_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_resnetv10_stage3_batchnorm2_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm3_fwd_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "elemwise_add", 
+              "name": "ssd0_resnetv10_stage3__plus0", 
+              "inputs": [[8, 0, 0], [9, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_resnetv10_stage3_activation0", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[10, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7, 9], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12, 
+            13, 
+            14
+          ], 
+          "heads": [[11, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_conv4_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256, 0, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_conv4_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm4_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm4_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm4_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm4_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_28", 
+      "attrs": {
+        "max_calib_range": "1.235364", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[186, 0, 0], [187, 0, 0], [188, 0, 0], [189, 0, 0], [190, 0, 0], [191, 0, 1], [192, 0, 1], [186, 1, 0], [186, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_26_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_conv4_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_conv4_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_resnetv10_stage3_conv4_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "256", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm4_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm4_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm4_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm4_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_resnetv10_stage3_batchnorm4_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_resnetv10_stage3_relu2_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[8, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12
+          ], 
+          "heads": [[9, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_conv5_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256, 256, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm5_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm5_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm5_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm5_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_29", 
+      "attrs": {
+        "max_calib_range": "1.995211", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[193, 0, 0], [194, 0, 0], [195, 0, 0], [196, 0, 0], [197, 0, 1], [198, 0, 1], [193, 1, 0], [193, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_28_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_conv5_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_resnetv10_stage3_conv5_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "256", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm5_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm5_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm5_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm5_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_resnetv10_stage3_batchnorm5_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_resnetv10_stage3_relu3_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_conv6_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024, 0, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_conv6_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm6_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm6_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm6_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm6_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_add_relu_30", 
+      "attrs": {
+        "max_calib_range": "2.863562", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_postsum_relu": "true", 
+        "with_sum": "true"
+      }, 
+      "inputs": [
+        [199, 0, 0], 
+        [200, 0, 0], 
+        [201, 0, 0], 
+        [202, 0, 0], 
+        [203, 0, 0], 
+        [204, 0, 1], 
+        [205, 0, 1], 
+        [186, 0, 0], 
+        [199, 1, 0], 
+        [199, 2, 0], 
+        [186, 1, 0], 
+        [186, 2, 0]
+      ], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_29_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_conv6_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_conv6_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_resnetv10_stage3_conv6_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "1024", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm6_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm6_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm6_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm6_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_resnetv10_stage3_batchnorm6_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_26_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "elemwise_add", 
+              "name": "ssd0_resnetv10_stage3__plus1", 
+              "inputs": [[8, 0, 0], [9, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_resnetv10_stage3_activation1", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[10, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7, 9], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12, 
+            13, 
+            14
+          ], 
+          "heads": [[11, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_conv7_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256, 0, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_conv7_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm7_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm7_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm7_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm7_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_31", 
+      "attrs": {
+        "max_calib_range": "2.086985", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[206, 0, 0], [207, 0, 0], [208, 0, 0], [209, 0, 0], [210, 0, 0], [211, 0, 1], [212, 0, 1], [206, 1, 0], [206, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_30_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_conv7_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_conv7_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_resnetv10_stage3_conv7_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "256", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm7_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm7_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm7_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm7_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_resnetv10_stage3_batchnorm7_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_resnetv10_stage3_relu4_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[8, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12
+          ], 
+          "heads": [[9, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_conv8_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256, 256, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm8_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm8_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm8_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm8_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_32", 
+      "attrs": {
+        "max_calib_range": "2.434780", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[213, 0, 0], [214, 0, 0], [215, 0, 0], [216, 0, 0], [217, 0, 1], [218, 0, 1], [213, 1, 0], [213, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_31_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_conv8_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_resnetv10_stage3_conv8_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "256", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm8_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm8_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm8_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm8_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_resnetv10_stage3_batchnorm8_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_resnetv10_stage3_relu5_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_conv9_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024, 0, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_conv9_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm9_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm9_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm9_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm9_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_add_relu_33", 
+      "attrs": {
+        "max_calib_range": "3.269181", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_postsum_relu": "true", 
+        "with_sum": "true"
+      }, 
+      "inputs": [
+        [219, 0, 0], 
+        [220, 0, 0], 
+        [221, 0, 0], 
+        [222, 0, 0], 
+        [223, 0, 0], 
+        [224, 0, 1], 
+        [225, 0, 1], 
+        [206, 0, 0], 
+        [219, 1, 0], 
+        [219, 2, 0], 
+        [206, 1, 0], 
+        [206, 2, 0]
+      ], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_32_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_conv9_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_conv9_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_resnetv10_stage3_conv9_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "1024", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm9_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm9_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm9_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm9_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_resnetv10_stage3_batchnorm9_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_30_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "elemwise_add", 
+              "name": "ssd0_resnetv10_stage3__plus2", 
+              "inputs": [[8, 0, 0], [9, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_resnetv10_stage3_activation2", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[10, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7, 9], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12, 
+            13, 
+            14
+          ], 
+          "heads": [[11, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_conv10_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256, 0, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_conv10_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm10_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm10_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm10_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm10_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_34", 
+      "attrs": {
+        "max_calib_range": "2.594996", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[226, 0, 0], [227, 0, 0], [228, 0, 0], [229, 0, 0], [230, 0, 0], [231, 0, 1], [232, 0, 1], [226, 1, 0], [226, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_33_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_conv10_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_conv10_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_resnetv10_stage3_conv10_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "256", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm10_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm10_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm10_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm10_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_resnetv10_stage3_batchnorm10_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_resnetv10_stage3_relu6_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[8, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12
+          ], 
+          "heads": [[9, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_conv11_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256, 256, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm11_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm11_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm11_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm11_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_35", 
+      "attrs": {
+        "max_calib_range": "1.965995", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[233, 0, 0], [234, 0, 0], [235, 0, 0], [236, 0, 0], [237, 0, 1], [238, 0, 1], [233, 1, 0], [233, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_34_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_conv11_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_resnetv10_stage3_conv11_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "256", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm11_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm11_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm11_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm11_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_resnetv10_stage3_batchnorm11_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_resnetv10_stage3_relu7_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_conv12_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024, 0, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_conv12_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm12_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm12_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm12_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm12_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_add_relu_36", 
+      "attrs": {
+        "max_calib_range": "4.055032", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_postsum_relu": "true", 
+        "with_sum": "true"
+      }, 
+      "inputs": [
+        [239, 0, 0], 
+        [240, 0, 0], 
+        [241, 0, 0], 
+        [242, 0, 0], 
+        [243, 0, 0], 
+        [244, 0, 1], 
+        [245, 0, 1], 
+        [226, 0, 0], 
+        [239, 1, 0], 
+        [239, 2, 0], 
+        [226, 1, 0], 
+        [226, 2, 0]
+      ], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_35_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_conv12_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_conv12_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_resnetv10_stage3_conv12_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "1024", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm12_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm12_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm12_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm12_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_resnetv10_stage3_batchnorm12_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_33_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "elemwise_add", 
+              "name": "ssd0_resnetv10_stage3__plus3", 
+              "inputs": [[8, 0, 0], [9, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_resnetv10_stage3_activation3", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[10, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7, 9], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12, 
+            13, 
+            14
+          ], 
+          "heads": [[11, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_conv13_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256, 0, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_conv13_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm13_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm13_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm13_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm13_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_37", 
+      "attrs": {
+        "max_calib_range": "2.492171", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[246, 0, 0], [247, 0, 0], [248, 0, 0], [249, 0, 0], [250, 0, 0], [251, 0, 1], [252, 0, 1], [246, 1, 0], [246, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_36_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_conv13_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_conv13_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_resnetv10_stage3_conv13_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "256", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm13_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm13_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm13_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm13_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_resnetv10_stage3_batchnorm13_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_resnetv10_stage3_relu8_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[8, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12
+          ], 
+          "heads": [[9, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_conv14_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256, 256, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm14_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm14_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm14_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm14_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_38", 
+      "attrs": {
+        "max_calib_range": "1.502743", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[253, 0, 0], [254, 0, 0], [255, 0, 0], [256, 0, 0], [257, 0, 1], [258, 0, 1], [253, 1, 0], [253, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_37_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_conv14_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_resnetv10_stage3_conv14_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "256", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm14_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm14_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm14_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm14_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_resnetv10_stage3_batchnorm14_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_resnetv10_stage3_relu9_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_conv15_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024, 0, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_conv15_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm15_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm15_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm15_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm15_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_add_relu_39", 
+      "attrs": {
+        "max_calib_range": "4.041976", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_postsum_relu": "true", 
+        "with_sum": "true"
+      }, 
+      "inputs": [
+        [259, 0, 0], 
+        [260, 0, 0], 
+        [261, 0, 0], 
+        [262, 0, 0], 
+        [263, 0, 0], 
+        [264, 0, 1], 
+        [265, 0, 1], 
+        [246, 0, 0], 
+        [259, 1, 0], 
+        [259, 2, 0], 
+        [246, 1, 0], 
+        [246, 2, 0]
+      ], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_38_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_conv15_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_conv15_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_resnetv10_stage3_conv15_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "1024", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm15_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm15_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm15_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm15_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_resnetv10_stage3_batchnorm15_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_36_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "elemwise_add", 
+              "name": "ssd0_resnetv10_stage3__plus4", 
+              "inputs": [[8, 0, 0], [9, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_resnetv10_stage3_activation4", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[10, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7, 9], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12, 
+            13, 
+            14
+          ], 
+          "heads": [[11, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_conv16_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256, 0, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_conv16_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm16_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm16_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm16_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm16_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_40", 
+      "attrs": {
+        "max_calib_range": "2.213554", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[266, 0, 0], [267, 0, 0], [268, 0, 0], [269, 0, 0], [270, 0, 0], [271, 0, 1], [272, 0, 1], [266, 1, 0], [266, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_39_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_conv16_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_conv16_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_resnetv10_stage3_conv16_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "256", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm16_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm16_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm16_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm16_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_resnetv10_stage3_batchnorm16_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_resnetv10_stage3_relu10_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[8, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12
+          ], 
+          "heads": [[9, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_conv17_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256, 256, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm17_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm17_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm17_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm17_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_41", 
+      "attrs": {
+        "max_calib_range": "2.695974", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[273, 0, 0], [274, 0, 0], [275, 0, 0], [276, 0, 0], [277, 0, 1], [278, 0, 1], [273, 1, 0], [273, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_40_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_conv17_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_resnetv10_stage3_conv17_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "256", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm17_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm17_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm17_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm17_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_resnetv10_stage3_batchnorm17_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_resnetv10_stage3_relu11_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_conv18_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024, 0, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_conv18_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm18_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm18_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm18_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage3_batchnorm18_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_add_relu_42", 
+      "attrs": {
+        "max_calib_range": "7.908109", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_postsum_relu": "true", 
+        "with_sum": "true"
+      }, 
+      "inputs": [
+        [279, 0, 0], 
+        [280, 0, 0], 
+        [281, 0, 0], 
+        [282, 0, 0], 
+        [283, 0, 0], 
+        [284, 0, 1], 
+        [285, 0, 1], 
+        [266, 0, 0], 
+        [279, 1, 0], 
+        [279, 2, 0], 
+        [266, 1, 0], 
+        [266, 2, 0]
+      ], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_41_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_conv18_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_conv18_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_resnetv10_stage3_conv18_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "1024", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm18_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm18_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm18_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage3_batchnorm18_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_resnetv10_stage3_batchnorm18_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_39_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "elemwise_add", 
+              "name": "ssd0_resnetv10_stage3__plus5", 
+              "inputs": [[8, 0, 0], [9, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_resnetv10_stage3_activation5", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[10, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7, 9], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12, 
+            13, 
+            14
+          ], 
+          "heads": [[11, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor0_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"uniform\", \"factor_type\": \"avg\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(84, 1024, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor0_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(84,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_43", 
+      "attrs": {
+        "max_calib_range": "19.659945", 
+        "min_calib_range": "-8.495779", 
+        "quantized": "true"
+      }, 
+      "inputs": [[286, 0, 0], [287, 0, 0], [288, 0, 0], [286, 1, 0], [286, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_42_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor0_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor0_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_convpredictor0_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "84", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4], 
+          "heads": [[3, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_43_dequantize", 
+      "inputs": [[289, 0, 0], [289, 1, 0], [289, 2, 0]]
+    }, 
+    {
+      "op": "transpose", 
+      "name": "ssd0_transpose0", 
+      "attrs": {"axes": "(0, 2, 3, 1)"}, 
+      "inputs": [[290, 0, 0]]
+    }, 
+    {
+      "op": "Flatten", 
+      "name": "ssd0_flatten0", 
+      "inputs": [[291, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 0, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_batchnorm0_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_batchnorm0_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_batchnorm0_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_batchnorm0_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_44", 
+      "attrs": {
+        "max_calib_range": "1.884383", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[286, 0, 0], [293, 0, 0], [294, 0, 0], [295, 0, 0], [296, 0, 0], [297, 0, 1], [298, 0, 1], [286, 1, 0], [286, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_42_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_resnetv10_stage4_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "512", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(2, 2)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_batchnorm0_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_batchnorm0_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_batchnorm0_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_batchnorm0_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_resnetv10_stage4_batchnorm0_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_resnetv10_stage4_relu0_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[8, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12
+          ], 
+          "heads": [[9, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_conv1_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 512, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_batchnorm1_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_batchnorm1_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_batchnorm1_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_batchnorm1_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_45", 
+      "attrs": {
+        "max_calib_range": "1.644229", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[299, 0, 0], [300, 0, 0], [301, 0, 0], [302, 0, 0], [303, 0, 1], [304, 0, 1], [299, 1, 0], [299, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_44_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_conv1_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_resnetv10_stage4_conv1_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "512", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_batchnorm1_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_batchnorm1_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_batchnorm1_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_batchnorm1_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_resnetv10_stage4_batchnorm1_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_resnetv10_stage4_relu1_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_conv2_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(2048, 0, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_conv2_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(2048,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_batchnorm2_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_batchnorm2_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_batchnorm2_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_batchnorm2_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_conv3_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(2048, 1024, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_batchnorm3_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_batchnorm3_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_batchnorm3_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_batchnorm3_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_47", 
+      "attrs": {
+        "max_calib_range": "1.544881", 
+        "min_calib_range": "-2.576477", 
+        "quantized": "true", 
+        "with_bn": "true"
+      }, 
+      "inputs": [[286, 0, 0], [312, 0, 0], [313, 0, 0], [314, 0, 0], [315, 0, 1], [316, 0, 1], [286, 1, 0], [286, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_42_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_conv3_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_resnetv10_stage4_conv3_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "2048", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(2, 2)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_batchnorm3_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_batchnorm3_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_batchnorm3_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_batchnorm3_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_resnetv10_stage4_batchnorm3_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10], 
+          "heads": [[7, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_add_relu_46", 
+      "attrs": {
+        "max_calib_range": "1.779881", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_postsum_relu": "true", 
+        "with_sum": "true"
+      }, 
+      "inputs": [
+        [305, 0, 0], 
+        [306, 0, 0], 
+        [307, 0, 0], 
+        [308, 0, 0], 
+        [309, 0, 0], 
+        [310, 0, 1], 
+        [311, 0, 1], 
+        [317, 0, 0], 
+        [305, 1, 0], 
+        [305, 2, 0], 
+        [317, 1, 0], 
+        [317, 2, 0]
+      ], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_45_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_conv2_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_conv2_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_resnetv10_stage4_conv2_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "2048", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_batchnorm2_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_batchnorm2_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_batchnorm2_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_batchnorm2_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_resnetv10_stage4_batchnorm2_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_batchnorm3_fwd_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "elemwise_add", 
+              "name": "ssd0_resnetv10_stage4__plus0", 
+              "inputs": [[8, 0, 0], [9, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_resnetv10_stage4_activation0", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[10, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7, 9], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12, 
+            13, 
+            14
+          ], 
+          "heads": [[11, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_conv4_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 0, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_conv4_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_batchnorm4_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_batchnorm4_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_batchnorm4_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_batchnorm4_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_48", 
+      "attrs": {
+        "max_calib_range": "2.775825", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[318, 0, 0], [319, 0, 0], [320, 0, 0], [321, 0, 0], [322, 0, 0], [323, 0, 1], [324, 0, 1], [318, 1, 0], [318, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_46_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_conv4_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_conv4_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_resnetv10_stage4_conv4_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "512", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_batchnorm4_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_batchnorm4_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_batchnorm4_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_batchnorm4_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_resnetv10_stage4_batchnorm4_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_resnetv10_stage4_relu2_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[8, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12
+          ], 
+          "heads": [[9, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_conv5_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 512, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_batchnorm5_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_batchnorm5_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_batchnorm5_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_batchnorm5_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_49", 
+      "attrs": {
+        "max_calib_range": "2.255455", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[325, 0, 0], [326, 0, 0], [327, 0, 0], [328, 0, 0], [329, 0, 1], [330, 0, 1], [325, 1, 0], [325, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_48_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_conv5_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_resnetv10_stage4_conv5_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "512", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_batchnorm5_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_batchnorm5_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_batchnorm5_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_batchnorm5_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_resnetv10_stage4_batchnorm5_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_resnetv10_stage4_relu3_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_conv6_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(2048, 0, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_conv6_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(2048,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_batchnorm6_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_batchnorm6_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_batchnorm6_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_batchnorm6_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_add_relu_50", 
+      "attrs": {
+        "max_calib_range": "7.455605", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_postsum_relu": "true", 
+        "with_sum": "true"
+      }, 
+      "inputs": [
+        [331, 0, 0], 
+        [332, 0, 0], 
+        [333, 0, 0], 
+        [334, 0, 0], 
+        [335, 0, 0], 
+        [336, 0, 1], 
+        [337, 0, 1], 
+        [318, 0, 0], 
+        [331, 1, 0], 
+        [331, 2, 0], 
+        [318, 1, 0], 
+        [318, 2, 0]
+      ], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_49_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_conv6_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_conv6_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_resnetv10_stage4_conv6_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "2048", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_batchnorm6_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_batchnorm6_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_batchnorm6_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_batchnorm6_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_resnetv10_stage4_batchnorm6_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_46_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "elemwise_add", 
+              "name": "ssd0_resnetv10_stage4__plus1", 
+              "inputs": [[8, 0, 0], [9, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_resnetv10_stage4_activation1", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[10, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7, 9], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12, 
+            13, 
+            14
+          ], 
+          "heads": [[11, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_conv7_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 0, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_conv7_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_batchnorm7_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_batchnorm7_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_batchnorm7_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_batchnorm7_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_51", 
+      "attrs": {
+        "max_calib_range": "1.807768", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[338, 0, 0], [339, 0, 0], [340, 0, 0], [341, 0, 0], [342, 0, 0], [343, 0, 1], [344, 0, 1], [338, 1, 0], [338, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_50_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_conv7_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_conv7_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_resnetv10_stage4_conv7_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "512", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_batchnorm7_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_batchnorm7_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_batchnorm7_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_batchnorm7_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_resnetv10_stage4_batchnorm7_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_resnetv10_stage4_relu4_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[8, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12
+          ], 
+          "heads": [[9, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_conv8_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 512, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_batchnorm8_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_batchnorm8_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_batchnorm8_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_batchnorm8_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_52", 
+      "attrs": {
+        "max_calib_range": "1.883651", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[345, 0, 0], [346, 0, 0], [347, 0, 0], [348, 0, 0], [349, 0, 1], [350, 0, 1], [345, 1, 0], [345, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_51_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_conv8_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_resnetv10_stage4_conv8_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "True", 
+                "num_filter": "512", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_batchnorm8_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_batchnorm8_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_batchnorm8_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_batchnorm8_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_resnetv10_stage4_batchnorm8_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_resnetv10_stage4_relu5_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_conv9_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(2048, 0, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_conv9_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(2048,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_batchnorm9_gamma", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_batchnorm9_beta", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_batchnorm9_running_mean", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_resnetv10_stage4_batchnorm9_running_var", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "ones", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(0,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_add_relu_53", 
+      "attrs": {
+        "max_calib_range": "8.699316", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_postsum_relu": "true", 
+        "with_sum": "true"
+      }, 
+      "inputs": [
+        [351, 0, 0], 
+        [352, 0, 0], 
+        [353, 0, 0], 
+        [354, 0, 0], 
+        [355, 0, 0], 
+        [356, 0, 1], 
+        [357, 0, 1], 
+        [338, 0, 0], 
+        [351, 1, 0], 
+        [351, 2, 0], 
+        [338, 1, 0], 
+        [338, 2, 0]
+      ], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_52_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_conv9_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_conv9_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_resnetv10_stage4_conv9_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "2048", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_batchnorm9_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_batchnorm9_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_batchnorm9_running_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_resnetv10_stage4_batchnorm9_running_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_resnetv10_stage4_batchnorm9_fwd", 
+              "attrs": {
+                "axis": "1", 
+                "eps": "1e-05", 
+                "fix_gamma": "False", 
+                "momentum": "0.9", 
+                "use_global_stats": "False"
+              }, 
+              "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0], [7, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_50_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "elemwise_add", 
+              "name": "ssd0_resnetv10_stage4__plus2", 
+              "inputs": [[8, 0, 0], [9, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_resnetv10_stage4_activation2", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[10, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2, 4, 5, 6, 7, 9], 
+          "node_row_ptr": [
+            0, 
+            1, 
+            2, 
+            3, 
+            4, 
+            5, 
+            6, 
+            7, 
+            8, 
+            11, 
+            12, 
+            13, 
+            14
+          ], 
+          "heads": [[11, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor2_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"uniform\", \"factor_type\": \"avg\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(126, 2048, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor2_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(126,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_54", 
+      "attrs": {
+        "max_calib_range": "28.579041", 
+        "min_calib_range": "-8.671446", 
+        "quantized": "true"
+      }, 
+      "inputs": [[358, 0, 0], [359, 0, 0], [360, 0, 0], [358, 1, 0], [358, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_53_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor2_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor2_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_convpredictor2_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "126", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4], 
+          "heads": [[3, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_54_dequantize", 
+      "inputs": [[361, 0, 0], [361, 1, 0], [361, 2, 0]]
+    }, 
+    {
+      "op": "transpose", 
+      "name": "ssd0_transpose1", 
+      "attrs": {"axes": "(0, 2, 3, 1)"}, 
+      "inputs": [[362, 0, 0]]
+    }, 
+    {
+      "op": "Flatten", 
+      "name": "ssd0_flatten1", 
+      "inputs": [[363, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_trans_conv0_weight", 
+      "attrs": {
+        "__init__": "<mxnet.initializer.Xavier object at 0x7fa205838f60>", 
+        "kernel": "(1, 1)", 
+        "no_bias": "True", 
+        "num_filter": "512"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_trans_bn0_gamma", 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_trans_bn0_beta", 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_trans_bn0_moving_mean", 
+      "attrs": {"__init__": "[\"zero\", {}]"}, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_trans_bn0_moving_var", 
+      "attrs": {"__init__": "[\"one\", {}]"}, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_55", 
+      "attrs": {
+        "max_calib_range": "10.488618", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[358, 0, 0], [365, 0, 0], [366, 0, 0], [367, 0, 0], [368, 0, 1], [369, 0, 1], [358, 1, 0], [358, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_53_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_trans_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_expand_trans_conv0", 
+              "attrs": {
+                "__init__": "<mxnet.initializer.Xavier object at 0x7fa205838f60>", 
+                "kernel": "(1, 1)", 
+                "no_bias": "True", 
+                "num_filter": "512"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_trans_bn0_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_trans_bn0_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_trans_bn0_moving_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_trans_bn0_moving_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_expand_trans_bn0", 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_expand_trans_relu0", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_conv0_weight", 
+      "attrs": {
+        "__init__": "<mxnet.initializer.Xavier object at 0x7fa205838f60>", 
+        "kernel": "(3, 3)", 
+        "no_bias": "True", 
+        "num_filter": "512", 
+        "pad": "(1, 1)", 
+        "stride": "(2, 2)"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_bn0_gamma", 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_bn0_beta", 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_bn0_moving_mean", 
+      "attrs": {"__init__": "[\"zero\", {}]"}, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_bn0_moving_var", 
+      "attrs": {"__init__": "[\"one\", {}]"}, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_56", 
+      "attrs": {
+        "max_calib_range": "11.090785", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[370, 0, 0], [371, 0, 0], [372, 0, 0], [373, 0, 0], [374, 0, 1], [375, 0, 1], [370, 1, 0], [370, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_55_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_expand_conv0", 
+              "attrs": {
+                "__init__": "<mxnet.initializer.Xavier object at 0x7fa205838f60>", 
+                "kernel": "(3, 3)", 
+                "no_bias": "True", 
+                "num_filter": "512", 
+                "pad": "(1, 1)", 
+                "stride": "(2, 2)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_bn0_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_bn0_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_bn0_moving_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_bn0_moving_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_expand_bn0", 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_expand_reu0", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor4_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"uniform\", \"factor_type\": \"avg\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(126, 512, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor4_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(126,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_57", 
+      "attrs": {
+        "max_calib_range": "24.046902", 
+        "min_calib_range": "-7.792776", 
+        "quantized": "true"
+      }, 
+      "inputs": [[376, 0, 0], [377, 0, 0], [378, 0, 0], [376, 1, 0], [376, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_56_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor4_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor4_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_convpredictor4_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "126", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4], 
+          "heads": [[3, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_57_dequantize", 
+      "inputs": [[379, 0, 0], [379, 1, 0], [379, 2, 0]]
+    }, 
+    {
+      "op": "transpose", 
+      "name": "ssd0_transpose2", 
+      "attrs": {"axes": "(0, 2, 3, 1)"}, 
+      "inputs": [[380, 0, 0]]
+    }, 
+    {
+      "op": "Flatten", 
+      "name": "ssd0_flatten2", 
+      "inputs": [[381, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_trans_conv1_weight", 
+      "attrs": {
+        "__init__": "<mxnet.initializer.Xavier object at 0x7fa205838f60>", 
+        "kernel": "(1, 1)", 
+        "no_bias": "True", 
+        "num_filter": "512"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_trans_bn1_gamma", 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_trans_bn1_beta", 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_trans_bn1_moving_mean", 
+      "attrs": {"__init__": "[\"zero\", {}]"}, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_trans_bn1_moving_var", 
+      "attrs": {"__init__": "[\"one\", {}]"}, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_58", 
+      "attrs": {
+        "max_calib_range": "7.779199", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[376, 0, 0], [383, 0, 0], [384, 0, 0], [385, 0, 0], [386, 0, 1], [387, 0, 1], [376, 1, 0], [376, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_56_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_trans_conv1_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_expand_trans_conv1", 
+              "attrs": {
+                "__init__": "<mxnet.initializer.Xavier object at 0x7fa205838f60>", 
+                "kernel": "(1, 1)", 
+                "no_bias": "True", 
+                "num_filter": "512"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_trans_bn1_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_trans_bn1_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_trans_bn1_moving_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_trans_bn1_moving_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_expand_trans_bn1", 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_expand_trans_relu1", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_conv1_weight", 
+      "attrs": {
+        "__init__": "<mxnet.initializer.Xavier object at 0x7fa205838f60>", 
+        "kernel": "(3, 3)", 
+        "no_bias": "True", 
+        "num_filter": "512", 
+        "pad": "(1, 1)", 
+        "stride": "(2, 2)"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_bn1_gamma", 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_bn1_beta", 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_bn1_moving_mean", 
+      "attrs": {"__init__": "[\"zero\", {}]"}, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_bn1_moving_var", 
+      "attrs": {"__init__": "[\"one\", {}]"}, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_59", 
+      "attrs": {
+        "max_calib_range": "8.386677", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[388, 0, 0], [389, 0, 0], [390, 0, 0], [391, 0, 0], [392, 0, 1], [393, 0, 1], [388, 1, 0], [388, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_58_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_conv1_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_expand_conv1", 
+              "attrs": {
+                "__init__": "<mxnet.initializer.Xavier object at 0x7fa205838f60>", 
+                "kernel": "(3, 3)", 
+                "no_bias": "True", 
+                "num_filter": "512", 
+                "pad": "(1, 1)", 
+                "stride": "(2, 2)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_bn1_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_bn1_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_bn1_moving_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_bn1_moving_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_expand_bn1", 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_expand_reu1", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor6_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"uniform\", \"factor_type\": \"avg\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(126, 512, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor6_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(126,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_60", 
+      "attrs": {
+        "max_calib_range": "19.041187", 
+        "min_calib_range": "-9.823511", 
+        "quantized": "true"
+      }, 
+      "inputs": [[394, 0, 0], [395, 0, 0], [396, 0, 0], [394, 1, 0], [394, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_59_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor6_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor6_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_convpredictor6_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "126", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4], 
+          "heads": [[3, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_60_dequantize", 
+      "inputs": [[397, 0, 0], [397, 1, 0], [397, 2, 0]]
+    }, 
+    {
+      "op": "transpose", 
+      "name": "ssd0_transpose3", 
+      "attrs": {"axes": "(0, 2, 3, 1)"}, 
+      "inputs": [[398, 0, 0]]
+    }, 
+    {
+      "op": "Flatten", 
+      "name": "ssd0_flatten3", 
+      "inputs": [[399, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_trans_conv2_weight", 
+      "attrs": {
+        "__init__": "<mxnet.initializer.Xavier object at 0x7fa205838f60>", 
+        "kernel": "(1, 1)", 
+        "no_bias": "True", 
+        "num_filter": "256"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_trans_bn2_gamma", 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_trans_bn2_beta", 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_trans_bn2_moving_mean", 
+      "attrs": {"__init__": "[\"zero\", {}]"}, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_trans_bn2_moving_var", 
+      "attrs": {"__init__": "[\"one\", {}]"}, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_61", 
+      "attrs": {
+        "max_calib_range": "8.299225", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[394, 0, 0], [401, 0, 0], [402, 0, 0], [403, 0, 0], [404, 0, 1], [405, 0, 1], [394, 1, 0], [394, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_59_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_trans_conv2_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_expand_trans_conv2", 
+              "attrs": {
+                "__init__": "<mxnet.initializer.Xavier object at 0x7fa205838f60>", 
+                "kernel": "(1, 1)", 
+                "no_bias": "True", 
+                "num_filter": "256"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_trans_bn2_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_trans_bn2_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_trans_bn2_moving_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_trans_bn2_moving_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_expand_trans_bn2", 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_expand_trans_relu2", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_conv2_weight", 
+      "attrs": {
+        "__init__": "<mxnet.initializer.Xavier object at 0x7fa205838f60>", 
+        "kernel": "(3, 3)", 
+        "no_bias": "True", 
+        "num_filter": "256", 
+        "pad": "(1, 1)", 
+        "stride": "(2, 2)"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_bn2_gamma", 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_bn2_beta", 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_bn2_moving_mean", 
+      "attrs": {"__init__": "[\"zero\", {}]"}, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_bn2_moving_var", 
+      "attrs": {"__init__": "[\"one\", {}]"}, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_62", 
+      "attrs": {
+        "max_calib_range": "7.178945", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[406, 0, 0], [407, 0, 0], [408, 0, 0], [409, 0, 0], [410, 0, 1], [411, 0, 1], [406, 1, 0], [406, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_61_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_conv2_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_expand_conv2", 
+              "attrs": {
+                "__init__": "<mxnet.initializer.Xavier object at 0x7fa205838f60>", 
+                "kernel": "(3, 3)", 
+                "no_bias": "True", 
+                "num_filter": "256", 
+                "pad": "(1, 1)", 
+                "stride": "(2, 2)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_bn2_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_bn2_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_bn2_moving_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_bn2_moving_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_expand_bn2", 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_expand_reu2", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor8_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"uniform\", \"factor_type\": \"avg\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(84, 256, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor8_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(84,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_63", 
+      "attrs": {
+        "max_calib_range": "11.874625", 
+        "min_calib_range": "-7.385983", 
+        "quantized": "true"
+      }, 
+      "inputs": [[412, 0, 0], [413, 0, 0], [414, 0, 0], [412, 1, 0], [412, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_62_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor8_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor8_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_convpredictor8_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "84", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4], 
+          "heads": [[3, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_63_dequantize", 
+      "inputs": [[415, 0, 0], [415, 1, 0], [415, 2, 0]]
+    }, 
+    {
+      "op": "transpose", 
+      "name": "ssd0_transpose4", 
+      "attrs": {"axes": "(0, 2, 3, 1)"}, 
+      "inputs": [[416, 0, 0]]
+    }, 
+    {
+      "op": "Flatten", 
+      "name": "ssd0_flatten4", 
+      "inputs": [[417, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_trans_conv3_weight", 
+      "attrs": {
+        "__init__": "<mxnet.initializer.Xavier object at 0x7fa205838f60>", 
+        "kernel": "(1, 1)", 
+        "no_bias": "True", 
+        "num_filter": "256"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_trans_bn3_gamma", 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_trans_bn3_beta", 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_trans_bn3_moving_mean", 
+      "attrs": {"__init__": "[\"zero\", {}]"}, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_trans_bn3_moving_var", 
+      "attrs": {"__init__": "[\"one\", {}]"}, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_64", 
+      "attrs": {
+        "max_calib_range": "6.257237", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[412, 0, 0], [419, 0, 0], [420, 0, 0], [421, 0, 0], [422, 0, 1], [423, 0, 1], [412, 1, 0], [412, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_62_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_trans_conv3_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_expand_trans_conv3", 
+              "attrs": {
+                "__init__": "<mxnet.initializer.Xavier object at 0x7fa205838f60>", 
+                "kernel": "(1, 1)", 
+                "no_bias": "True", 
+                "num_filter": "256"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_trans_bn3_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_trans_bn3_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_trans_bn3_moving_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_trans_bn3_moving_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_expand_trans_bn3", 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_expand_trans_relu3", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_conv3_weight", 
+      "attrs": {
+        "__init__": "<mxnet.initializer.Xavier object at 0x7fa205838f60>", 
+        "kernel": "(3, 3)", 
+        "no_bias": "True", 
+        "num_filter": "256", 
+        "pad": "(1, 1)", 
+        "stride": "(2, 2)"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_bn3_gamma", 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_bn3_beta", 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_bn3_moving_mean", 
+      "attrs": {"__init__": "[\"zero\", {}]"}, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_expand_bn3_moving_var", 
+      "attrs": {"__init__": "[\"one\", {}]"}, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_bn_relu_65", 
+      "attrs": {
+        "max_calib_range": "7.613858", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_bn": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[424, 0, 0], [425, 0, 0], [426, 0, 0], [427, 0, 0], [428, 0, 1], [429, 0, 1], [424, 1, 0], [424, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_64_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_conv3_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_expand_conv3", 
+              "attrs": {
+                "__init__": "<mxnet.initializer.Xavier object at 0x7fa205838f60>", 
+                "kernel": "(3, 3)", 
+                "no_bias": "True", 
+                "num_filter": "256", 
+                "pad": "(1, 1)", 
+                "stride": "(2, 2)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0]]
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_bn3_gamma0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_bn3_beta0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_bn3_moving_mean0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_expand_bn3_moving_var0", 
+              "inputs": []
+            }, 
+            {
+              "op": "BatchNorm", 
+              "name": "ssd0_expand_bn3", 
+              "inputs": [[2, 0, 0], [3, 0, 0], [4, 0, 0], [5, 0, 0], [6, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_expand_reu3", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[7, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 3, 4, 5, 6], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5, 6, 7, 10, 11], 
+          "heads": [[8, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor10_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"uniform\", \"factor_type\": \"avg\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(84, 256, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor10_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(84,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_66", 
+      "attrs": {
+        "max_calib_range": "12.039816", 
+        "min_calib_range": "-5.889025", 
+        "quantized": "true"
+      }, 
+      "inputs": [[430, 0, 0], [431, 0, 0], [432, 0, 0], [430, 1, 0], [430, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_65_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor10_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor10_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_convpredictor10_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "84", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4], 
+          "heads": [[3, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_66_dequantize", 
+      "inputs": [[433, 0, 0], [433, 1, 0], [433, 2, 0]]
+    }, 
+    {
+      "op": "transpose", 
+      "name": "ssd0_transpose5", 
+      "attrs": {"axes": "(0, 2, 3, 1)"}, 
+      "inputs": [[434, 0, 0]]
+    }, 
+    {
+      "op": "Flatten", 
+      "name": "ssd0_flatten5", 
+      "inputs": [[435, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat0", 
+      "attrs": {
+        "dim": "1", 
+        "num_args": "6"
+      }, 
+      "inputs": [[292, 0, 0], [364, 0, 0], [382, 0, 0], [400, 0, 0], [418, 0, 0], [436, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_reshape6", 
+      "attrs": {"shape": "(0, -1, 21)"}, 
+      "inputs": [[437, 0, 0]]
+    }, 
+    {
+      "op": "softmax", 
+      "name": "ssd0_softmax0", 
+      "attrs": {"axis": "-1"}, 
+      "inputs": [[438, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_multiperclassdecoder0_slice_axis0", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "1", 
+        "end": "None"
+      }, 
+      "inputs": [[439, 0, 0]]
+    }, 
+    {
+      "op": "_greater_scalar", 
+      "name": "ssd0_multiperclassdecoder0__greater_scalar0", 
+      "attrs": {"scalar": "0.01"}, 
+      "inputs": [[440, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_multiperclassdecoder0_slice_axis1", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "0", 
+        "end": "1"
+      }, 
+      "inputs": [[439, 0, 0]]
+    }, 
+    {
+      "op": "zeros_like", 
+      "name": "ssd0_multiperclassdecoder0_zeros_like0", 
+      "inputs": [[442, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar0", 
+      "attrs": {"scalar": "0"}, 
+      "inputs": [[443, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar1", 
+      "attrs": {"scalar": "1"}, 
+      "inputs": [[443, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar2", 
+      "attrs": {"scalar": "2"}, 
+      "inputs": [[443, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar3", 
+      "attrs": {"scalar": "3"}, 
+      "inputs": [[443, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar4", 
+      "attrs": {"scalar": "4"}, 
+      "inputs": [[443, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar5", 
+      "attrs": {"scalar": "5"}, 
+      "inputs": [[443, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar6", 
+      "attrs": {"scalar": "6"}, 
+      "inputs": [[443, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar7", 
+      "attrs": {"scalar": "7"}, 
+      "inputs": [[443, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar8", 
+      "attrs": {"scalar": "8"}, 
+      "inputs": [[443, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar9", 
+      "attrs": {"scalar": "9"}, 
+      "inputs": [[443, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar10", 
+      "attrs": {"scalar": "10"}, 
+      "inputs": [[443, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar11", 
+      "attrs": {"scalar": "11"}, 
+      "inputs": [[443, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar12", 
+      "attrs": {"scalar": "12"}, 
+      "inputs": [[443, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar13", 
+      "attrs": {"scalar": "13"}, 
+      "inputs": [[443, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar14", 
+      "attrs": {"scalar": "14"}, 
+      "inputs": [[443, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar15", 
+      "attrs": {"scalar": "15"}, 
+      "inputs": [[443, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar16", 
+      "attrs": {"scalar": "16"}, 
+      "inputs": [[443, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar17", 
+      "attrs": {"scalar": "17"}, 
+      "inputs": [[443, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar18", 
+      "attrs": {"scalar": "18"}, 
+      "inputs": [[443, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar19", 
+      "attrs": {"scalar": "19"}, 
+      "inputs": [[443, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_multiperclassdecoder0_concat0", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "20"
+      }, 
+      "inputs": [
+        [444, 0, 0], 
+        [445, 0, 0], 
+        [446, 0, 0], 
+        [447, 0, 0], 
+        [448, 0, 0], 
+        [449, 0, 0], 
+        [450, 0, 0], 
+        [451, 0, 0], 
+        [452, 0, 0], 
+        [453, 0, 0], 
+        [454, 0, 0], 
+        [455, 0, 0], 
+        [456, 0, 0], 
+        [457, 0, 0], 
+        [458, 0, 0], 
+        [459, 0, 0], 
+        [460, 0, 0], 
+        [461, 0, 0], 
+        [462, 0, 0], 
+        [463, 0, 0]
+      ]
+    }, 
+    {
+      "op": "ones_like", 
+      "name": "ssd0_multiperclassdecoder0_ones_like0", 
+      "inputs": [[464, 0, 0]]
+    }, 
+    {
+      "op": "_mul_scalar", 
+      "name": "ssd0_multiperclassdecoder0__mulscalar0", 
+      "attrs": {"scalar": "-1"}, 
+      "inputs": [[465, 0, 0]]
+    }, 
+    {
+      "op": "where", 
+      "name": "ssd0_multiperclassdecoder0_where0", 
+      "inputs": [[441, 0, 0], [464, 0, 0], [466, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis0", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "0", 
+        "end": "1"
+      }, 
+      "inputs": [[467, 0, 0]]
+    }, 
+    {
+      "op": "zeros_like", 
+      "name": "ssd0_multiperclassdecoder0_zeros_like1", 
+      "inputs": [[440, 0, 0]]
+    }, 
+    {
+      "op": "where", 
+      "name": "ssd0_multiperclassdecoder0_where1", 
+      "inputs": [[441, 0, 0], [440, 0, 0], [469, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis1", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "0", 
+        "end": "1"
+      }, 
+      "inputs": [[470, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor1_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"uniform\", \"factor_type\": \"avg\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(16, 1024, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor1_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(16,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_67", 
+      "attrs": {
+        "max_calib_range": "4.708094", 
+        "min_calib_range": "-12.847954", 
+        "quantized": "true"
+      }, 
+      "inputs": [[286, 0, 0], [472, 0, 0], [473, 0, 0], [286, 1, 0], [286, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_42_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor1_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor1_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_convpredictor1_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "16", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4], 
+          "heads": [[3, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_67_dequantize", 
+      "inputs": [[474, 0, 0], [474, 1, 0], [474, 2, 0]]
+    }, 
+    {
+      "op": "transpose", 
+      "name": "ssd0_transpose6", 
+      "attrs": {"axes": "(0, 2, 3, 1)"}, 
+      "inputs": [[475, 0, 0]]
+    }, 
+    {
+      "op": "Flatten", 
+      "name": "ssd0_flatten6", 
+      "inputs": [[476, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor3_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"uniform\", \"factor_type\": \"avg\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(24, 2048, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor3_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(24,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_68", 
+      "attrs": {
+        "max_calib_range": "4.540250", 
+        "min_calib_range": "-4.375725", 
+        "quantized": "true"
+      }, 
+      "inputs": [[358, 0, 0], [478, 0, 0], [479, 0, 0], [358, 1, 0], [358, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_add_relu_53_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor3_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor3_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_convpredictor3_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "24", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4], 
+          "heads": [[3, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_68_dequantize", 
+      "inputs": [[480, 0, 0], [480, 1, 0], [480, 2, 0]]
+    }, 
+    {
+      "op": "transpose", 
+      "name": "ssd0_transpose7", 
+      "attrs": {"axes": "(0, 2, 3, 1)"}, 
+      "inputs": [[481, 0, 0]]
+    }, 
+    {
+      "op": "Flatten", 
+      "name": "ssd0_flatten7", 
+      "inputs": [[482, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor5_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"uniform\", \"factor_type\": \"avg\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(24, 512, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor5_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(24,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_69", 
+      "attrs": {
+        "max_calib_range": "4.226004", 
+        "min_calib_range": "-3.978005", 
+        "quantized": "true"
+      }, 
+      "inputs": [[376, 0, 0], [484, 0, 0], [485, 0, 0], [376, 1, 0], [376, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_56_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor5_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor5_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_convpredictor5_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "24", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4], 
+          "heads": [[3, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_69_dequantize", 
+      "inputs": [[486, 0, 0], [486, 1, 0], [486, 2, 0]]
+    }, 
+    {
+      "op": "transpose", 
+      "name": "ssd0_transpose8", 
+      "attrs": {"axes": "(0, 2, 3, 1)"}, 
+      "inputs": [[487, 0, 0]]
+    }, 
+    {
+      "op": "Flatten", 
+      "name": "ssd0_flatten8", 
+      "inputs": [[488, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor7_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"uniform\", \"factor_type\": \"avg\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(24, 512, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor7_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(24,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_70", 
+      "attrs": {
+        "max_calib_range": "4.201579", 
+        "min_calib_range": "-3.761112", 
+        "quantized": "true"
+      }, 
+      "inputs": [[394, 0, 0], [490, 0, 0], [491, 0, 0], [394, 1, 0], [394, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_59_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor7_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor7_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_convpredictor7_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "24", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4], 
+          "heads": [[3, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_70_dequantize", 
+      "inputs": [[492, 0, 0], [492, 1, 0], [492, 2, 0]]
+    }, 
+    {
+      "op": "transpose", 
+      "name": "ssd0_transpose9", 
+      "attrs": {"axes": "(0, 2, 3, 1)"}, 
+      "inputs": [[493, 0, 0]]
+    }, 
+    {
+      "op": "Flatten", 
+      "name": "ssd0_flatten9", 
+      "inputs": [[494, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor9_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"uniform\", \"factor_type\": \"avg\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(16, 256, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor9_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(16,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_71", 
+      "attrs": {
+        "max_calib_range": "2.977773", 
+        "min_calib_range": "-2.896950", 
+        "quantized": "true"
+      }, 
+      "inputs": [[412, 0, 0], [496, 0, 0], [497, 0, 0], [412, 1, 0], [412, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_62_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor9_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor9_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_convpredictor9_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "16", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4], 
+          "heads": [[3, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_71_dequantize", 
+      "inputs": [[498, 0, 0], [498, 1, 0], [498, 2, 0]]
+    }, 
+    {
+      "op": "transpose", 
+      "name": "ssd0_transpose10", 
+      "attrs": {"axes": "(0, 2, 3, 1)"}, 
+      "inputs": [[499, 0, 0]]
+    }, 
+    {
+      "op": "Flatten", 
+      "name": "ssd0_flatten10", 
+      "inputs": [[500, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor11_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"uniform\", \"factor_type\": \"avg\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(16, 256, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor11_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(16,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_72", 
+      "attrs": {
+        "max_calib_range": "2.902189", 
+        "min_calib_range": "-3.171603", 
+        "quantized": "true"
+      }, 
+      "inputs": [[430, 0, 0], [502, 0, 0], [503, 0, 0], [430, 1, 0], [430, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_bn_relu_65_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor11_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor11_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_convpredictor11_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "16", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4], 
+          "heads": [[3, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_72_dequantize", 
+      "inputs": [[504, 0, 0], [504, 1, 0], [504, 2, 0]]
+    }, 
+    {
+      "op": "transpose", 
+      "name": "ssd0_transpose11", 
+      "attrs": {"axes": "(0, 2, 3, 1)"}, 
+      "inputs": [[505, 0, 0]]
+    }, 
+    {
+      "op": "Flatten", 
+      "name": "ssd0_flatten11", 
+      "inputs": [[506, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat1", 
+      "attrs": {
+        "dim": "1", 
+        "num_args": "6"
+      }, 
+      "inputs": [[477, 0, 0], [483, 0, 0], [489, 0, 0], [495, 0, 0], [501, 0, 0], [507, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_reshape7", 
+      "attrs": {"shape": "(0, -1, 4)"}, 
+      "inputs": [[508, 0, 0]]
+    }, 
+    {
+      "op": "SliceChannel", 
+      "name": "ssd0_normalizedboxcenterdecoder0_split1", 
+      "attrs": {
+        "axis": "-1", 
+        "num_outputs": "4"
+      }, 
+      "inputs": [[509, 0, 0]]
+    }, 
+    {
+      "op": "_mul_scalar", 
+      "name": "ssd0_normalizedboxcenterdecoder0__mulscalar0", 
+      "attrs": {"scalar": "0.1"}, 
+      "inputs": [[510, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_normalizedboxcenterdecoder0__plusscalar0", 
+      "attrs": {"scalar": "0.0"}, 
+      "inputs": [[511, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_ssdanchorgenerator0_anchor_0", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "Constant_ssd0_ssdanchorgenerator0_anchor_0_140333853976112", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1, 1, 128, 128, 16)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_bn_add_relu_42_dequantize", 
+      "inputs": [[286, 0, 0], [286, 1, 0], [286, 2, 0]]
+    }, 
+    {
+      "op": "_mul_scalar", 
+      "name": "ssd0_ssdanchorgenerator0__mulscalar0", 
+      "attrs": {"scalar": "0"}, 
+      "inputs": [[514, 0, 0]]
+    }, 
+    {
+      "op": "slice_like", 
+      "name": "ssd0_ssdanchorgenerator0_slice_like0", 
+      "attrs": {"axes": "(2, 3)"}, 
+      "inputs": [[513, 0, 0], [515, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_ssdanchorgenerator0_reshape0", 
+      "attrs": {"shape": "(1, -1, 4)"}, 
+      "inputs": [[516, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_ssdanchorgenerator0_reshape1", 
+      "attrs": {"shape": "(1, -1, 4)"}, 
+      "inputs": [[517, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_reshape0", 
+      "attrs": {"shape": "(1, -1)"}, 
+      "inputs": [[518, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_ssdanchorgenerator1_anchor_1", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "Constant_ssd0_ssdanchorgenerator1_anchor_1_140333953868520", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1, 1, 64, 64, 24)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_bn_add_relu_53_dequantize", 
+      "inputs": [[358, 0, 0], [358, 1, 0], [358, 2, 0]]
+    }, 
+    {
+      "op": "_mul_scalar", 
+      "name": "ssd0_ssdanchorgenerator1__mulscalar0", 
+      "attrs": {"scalar": "0"}, 
+      "inputs": [[521, 0, 0]]
+    }, 
+    {
+      "op": "slice_like", 
+      "name": "ssd0_ssdanchorgenerator1_slice_like0", 
+      "attrs": {"axes": "(2, 3)"}, 
+      "inputs": [[520, 0, 0], [522, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_ssdanchorgenerator1_reshape0", 
+      "attrs": {"shape": "(1, -1, 4)"}, 
+      "inputs": [[523, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_ssdanchorgenerator1_reshape1", 
+      "attrs": {"shape": "(1, -1, 4)"}, 
+      "inputs": [[524, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_reshape1", 
+      "attrs": {"shape": "(1, -1)"}, 
+      "inputs": [[525, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_ssdanchorgenerator2_anchor_2", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "Constant_ssd0_ssdanchorgenerator2_anchor_2_140333853893296", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1, 1, 32, 32, 24)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_bn_relu_56_dequantize", 
+      "inputs": [[376, 0, 0], [376, 1, 0], [376, 2, 0]]
+    }, 
+    {
+      "op": "_mul_scalar", 
+      "name": "ssd0_ssdanchorgenerator2__mulscalar0", 
+      "attrs": {"scalar": "0"}, 
+      "inputs": [[528, 0, 0]]
+    }, 
+    {
+      "op": "slice_like", 
+      "name": "ssd0_ssdanchorgenerator2_slice_like0", 
+      "attrs": {"axes": "(2, 3)"}, 
+      "inputs": [[527, 0, 0], [529, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_ssdanchorgenerator2_reshape0", 
+      "attrs": {"shape": "(1, -1, 4)"}, 
+      "inputs": [[530, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_ssdanchorgenerator2_reshape1", 
+      "attrs": {"shape": "(1, -1, 4)"}, 
+      "inputs": [[531, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_reshape2", 
+      "attrs": {"shape": "(1, -1)"}, 
+      "inputs": [[532, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_ssdanchorgenerator3_anchor_3", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "Constant_ssd0_ssdanchorgenerator3_anchor_3_140333853894416", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1, 1, 16, 16, 24)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_bn_relu_59_dequantize", 
+      "inputs": [[394, 0, 0], [394, 1, 0], [394, 2, 0]]
+    }, 
+    {
+      "op": "_mul_scalar", 
+      "name": "ssd0_ssdanchorgenerator3__mulscalar0", 
+      "attrs": {"scalar": "0"}, 
+      "inputs": [[535, 0, 0]]
+    }, 
+    {
+      "op": "slice_like", 
+      "name": "ssd0_ssdanchorgenerator3_slice_like0", 
+      "attrs": {"axes": "(2, 3)"}, 
+      "inputs": [[534, 0, 0], [536, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_ssdanchorgenerator3_reshape0", 
+      "attrs": {"shape": "(1, -1, 4)"}, 
+      "inputs": [[537, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_ssdanchorgenerator3_reshape1", 
+      "attrs": {"shape": "(1, -1, 4)"}, 
+      "inputs": [[538, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_reshape3", 
+      "attrs": {"shape": "(1, -1)"}, 
+      "inputs": [[539, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_ssdanchorgenerator4_anchor_4", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "Constant_ssd0_ssdanchorgenerator4_anchor_4_140333853851320", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1, 1, 16, 16, 16)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_bn_relu_62_dequantize", 
+      "inputs": [[412, 0, 0], [412, 1, 0], [412, 2, 0]]
+    }, 
+    {
+      "op": "_mul_scalar", 
+      "name": "ssd0_ssdanchorgenerator4__mulscalar0", 
+      "attrs": {"scalar": "0"}, 
+      "inputs": [[542, 0, 0]]
+    }, 
+    {
+      "op": "slice_like", 
+      "name": "ssd0_ssdanchorgenerator4_slice_like0", 
+      "attrs": {"axes": "(2, 3)"}, 
+      "inputs": [[541, 0, 0], [543, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_ssdanchorgenerator4_reshape0", 
+      "attrs": {"shape": "(1, -1, 4)"}, 
+      "inputs": [[544, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_ssdanchorgenerator4_reshape1", 
+      "attrs": {"shape": "(1, -1, 4)"}, 
+      "inputs": [[545, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_reshape4", 
+      "attrs": {"shape": "(1, -1)"}, 
+      "inputs": [[546, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_ssdanchorgenerator5_anchor_5", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "Constant_ssd0_ssdanchorgenerator5_anchor_5_140333854295320", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1, 1, 16, 16, 16)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_bn_relu_65_dequantize", 
+      "inputs": [[430, 0, 0], [430, 1, 0], [430, 2, 0]]
+    }, 
+    {
+      "op": "_mul_scalar", 
+      "name": "ssd0_ssdanchorgenerator5__mulscalar0", 
+      "attrs": {"scalar": "0"}, 
+      "inputs": [[549, 0, 0]]
+    }, 
+    {
+      "op": "slice_like", 
+      "name": "ssd0_ssdanchorgenerator5_slice_like0", 
+      "attrs": {"axes": "(2, 3)"}, 
+      "inputs": [[548, 0, 0], [550, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_ssdanchorgenerator5_reshape0", 
+      "attrs": {"shape": "(1, -1, 4)"}, 
+      "inputs": [[551, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_ssdanchorgenerator5_reshape1", 
+      "attrs": {"shape": "(1, -1, 4)"}, 
+      "inputs": [[552, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_reshape5", 
+      "attrs": {"shape": "(1, -1)"}, 
+      "inputs": [[553, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat2", 
+      "attrs": {
+        "dim": "1", 
+        "num_args": "6"
+      }, 
+      "inputs": [[519, 0, 0], [526, 0, 0], [533, 0, 0], [540, 0, 0], [547, 0, 0], [554, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_reshape8", 
+      "attrs": {"shape": "(1, -1, 4)"}, 
+      "inputs": [[555, 0, 0]]
+    }, 
+    {
+      "op": "SliceChannel", 
+      "name": "ssd0_normalizedboxcenterdecoder0_split0", 
+      "attrs": {
+        "axis": "-1", 
+        "num_outputs": "4"
+      }, 
+      "inputs": [[556, 0, 0]]
+    }, 
+    {
+      "op": "broadcast_mul", 
+      "name": "ssd0_normalizedboxcenterdecoder0_broadcast_mul0", 
+      "inputs": [[512, 0, 0], [557, 2, 0]]
+    }, 
+    {
+      "op": "broadcast_add", 
+      "name": "ssd0_normalizedboxcenterdecoder0_broadcast_add0", 
+      "inputs": [[558, 0, 0], [557, 0, 0]]
+    }, 
+    {
+      "op": "_mul_scalar", 
+      "name": "ssd0_normalizedboxcenterdecoder0__mulscalar2", 
+      "attrs": {"scalar": "0.2"}, 
+      "inputs": [[510, 2, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_normalizedboxcenterdecoder0__plusscalar2", 
+      "attrs": {"scalar": "0.0"}, 
+      "inputs": [[560, 0, 0]]
+    }, 
+    {
+      "op": "exp", 
+      "name": "ssd0_normalizedboxcenterdecoder0_exp0", 
+      "inputs": [[561, 0, 0]]
+    }, 
+    {
+      "op": "broadcast_mul", 
+      "name": "ssd0_normalizedboxcenterdecoder0_broadcast_mul2", 
+      "inputs": [[562, 0, 0], [557, 2, 0]]
+    }, 
+    {
+      "op": "_div_scalar", 
+      "name": "ssd0_normalizedboxcenterdecoder0__divscalar0", 
+      "attrs": {"scalar": "2"}, 
+      "inputs": [[563, 0, 0]]
+    }, 
+    {
+      "op": "elemwise_sub", 
+      "name": "ssd0_normalizedboxcenterdecoder0__minus0", 
+      "inputs": [[559, 0, 0], [564, 0, 0]]
+    }, 
+    {
+      "op": "_mul_scalar", 
+      "name": "ssd0_normalizedboxcenterdecoder0__mulscalar1", 
+      "attrs": {"scalar": "0.1"}, 
+      "inputs": [[510, 1, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_normalizedboxcenterdecoder0__plusscalar1", 
+      "attrs": {"scalar": "0.0"}, 
+      "inputs": [[566, 0, 0]]
+    }, 
+    {
+      "op": "broadcast_mul", 
+      "name": "ssd0_normalizedboxcenterdecoder0_broadcast_mul1", 
+      "inputs": [[567, 0, 0], [557, 3, 0]]
+    }, 
+    {
+      "op": "broadcast_add", 
+      "name": "ssd0_normalizedboxcenterdecoder0_broadcast_add1", 
+      "inputs": [[568, 0, 0], [557, 1, 0]]
+    }, 
+    {
+      "op": "_mul_scalar", 
+      "name": "ssd0_normalizedboxcenterdecoder0__mulscalar3", 
+      "attrs": {"scalar": "0.2"}, 
+      "inputs": [[510, 3, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_normalizedboxcenterdecoder0__plusscalar3", 
+      "attrs": {"scalar": "0.0"}, 
+      "inputs": [[570, 0, 0]]
+    }, 
+    {
+      "op": "exp", 
+      "name": "ssd0_normalizedboxcenterdecoder0_exp1", 
+      "inputs": [[571, 0, 0]]
+    }, 
+    {
+      "op": "broadcast_mul", 
+      "name": "ssd0_normalizedboxcenterdecoder0_broadcast_mul3", 
+      "inputs": [[572, 0, 0], [557, 3, 0]]
+    }, 
+    {
+      "op": "_div_scalar", 
+      "name": "ssd0_normalizedboxcenterdecoder0__divscalar1", 
+      "attrs": {"scalar": "2"}, 
+      "inputs": [[573, 0, 0]]
+    }, 
+    {
+      "op": "elemwise_sub", 
+      "name": "ssd0_normalizedboxcenterdecoder0__minus1", 
+      "inputs": [[569, 0, 0], [574, 0, 0]]
+    }, 
+    {
+      "op": "elemwise_add", 
+      "name": "ssd0_normalizedboxcenterdecoder0__plus0", 
+      "inputs": [[559, 0, 0], [564, 0, 0]]
+    }, 
+    {
+      "op": "elemwise_add", 
+      "name": "ssd0_normalizedboxcenterdecoder0__plus1", 
+      "inputs": [[569, 0, 0], [574, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_normalizedboxcenterdecoder0_concat0", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "4"
+      }, 
+      "inputs": [[565, 0, 0], [575, 0, 0], [576, 0, 0], [577, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat3", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[468, 0, 0], [471, 0, 0], [578, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis2", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "1", 
+        "end": "2"
+      }, 
+      "inputs": [[467, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis3", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "1", 
+        "end": "2"
+      }, 
+      "inputs": [[470, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat4", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[580, 0, 0], [581, 0, 0], [578, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis4", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "2", 
+        "end": "3"
+      }, 
+      "inputs": [[467, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis5", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "2", 
+        "end": "3"
+      }, 
+      "inputs": [[470, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat5", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[583, 0, 0], [584, 0, 0], [578, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis6", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "3", 
+        "end": "4"
+      }, 
+      "inputs": [[467, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis7", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "3", 
+        "end": "4"
+      }, 
+      "inputs": [[470, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat6", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[586, 0, 0], [587, 0, 0], [578, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis8", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "4", 
+        "end": "5"
+      }, 
+      "inputs": [[467, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis9", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "4", 
+        "end": "5"
+      }, 
+      "inputs": [[470, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat7", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[589, 0, 0], [590, 0, 0], [578, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis10", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "5", 
+        "end": "6"
+      }, 
+      "inputs": [[467, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis11", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "5", 
+        "end": "6"
+      }, 
+      "inputs": [[470, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat8", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[592, 0, 0], [593, 0, 0], [578, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis12", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "6", 
+        "end": "7"
+      }, 
+      "inputs": [[467, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis13", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "6", 
+        "end": "7"
+      }, 
+      "inputs": [[470, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat9", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[595, 0, 0], [596, 0, 0], [578, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis14", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "7", 
+        "end": "8"
+      }, 
+      "inputs": [[467, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis15", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "7", 
+        "end": "8"
+      }, 
+      "inputs": [[470, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat10", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[598, 0, 0], [599, 0, 0], [578, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis16", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "8", 
+        "end": "9"
+      }, 
+      "inputs": [[467, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis17", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "8", 
+        "end": "9"
+      }, 
+      "inputs": [[470, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat11", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[601, 0, 0], [602, 0, 0], [578, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis18", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "9", 
+        "end": "10"
+      }, 
+      "inputs": [[467, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis19", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "9", 
+        "end": "10"
+      }, 
+      "inputs": [[470, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat12", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[604, 0, 0], [605, 0, 0], [578, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis20", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "10", 
+        "end": "11"
+      }, 
+      "inputs": [[467, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis21", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "10", 
+        "end": "11"
+      }, 
+      "inputs": [[470, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat13", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[607, 0, 0], [608, 0, 0], [578, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis22", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "11", 
+        "end": "12"
+      }, 
+      "inputs": [[467, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis23", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "11", 
+        "end": "12"
+      }, 
+      "inputs": [[470, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat14", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[610, 0, 0], [611, 0, 0], [578, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis24", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "12", 
+        "end": "13"
+      }, 
+      "inputs": [[467, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis25", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "12", 
+        "end": "13"
+      }, 
+      "inputs": [[470, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat15", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[613, 0, 0], [614, 0, 0], [578, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis26", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "13", 
+        "end": "14"
+      }, 
+      "inputs": [[467, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis27", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "13", 
+        "end": "14"
+      }, 
+      "inputs": [[470, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat16", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[616, 0, 0], [617, 0, 0], [578, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis28", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "14", 
+        "end": "15"
+      }, 
+      "inputs": [[467, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis29", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "14", 
+        "end": "15"
+      }, 
+      "inputs": [[470, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat17", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[619, 0, 0], [620, 0, 0], [578, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis30", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "15", 
+        "end": "16"
+      }, 
+      "inputs": [[467, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis31", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "15", 
+        "end": "16"
+      }, 
+      "inputs": [[470, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat18", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[622, 0, 0], [623, 0, 0], [578, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis32", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "16", 
+        "end": "17"
+      }, 
+      "inputs": [[467, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis33", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "16", 
+        "end": "17"
+      }, 
+      "inputs": [[470, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat19", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[625, 0, 0], [626, 0, 0], [578, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis34", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "17", 
+        "end": "18"
+      }, 
+      "inputs": [[467, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis35", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "17", 
+        "end": "18"
+      }, 
+      "inputs": [[470, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat20", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[628, 0, 0], [629, 0, 0], [578, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis36", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "18", 
+        "end": "19"
+      }, 
+      "inputs": [[467, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis37", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "18", 
+        "end": "19"
+      }, 
+      "inputs": [[470, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat21", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[631, 0, 0], [632, 0, 0], [578, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis38", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "19", 
+        "end": "20"
+      }, 
+      "inputs": [[467, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis39", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "19", 
+        "end": "20"
+      }, 
+      "inputs": [[470, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat22", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[634, 0, 0], [635, 0, 0], [578, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat23", 
+      "attrs": {
+        "dim": "1", 
+        "num_args": "20"
+      }, 
+      "inputs": [
+        [579, 0, 0], 
+        [582, 0, 0], 
+        [585, 0, 0], 
+        [588, 0, 0], 
+        [591, 0, 0], 
+        [594, 0, 0], 
+        [597, 0, 0], 
+        [600, 0, 0], 
+        [603, 0, 0], 
+        [606, 0, 0], 
+        [609, 0, 0], 
+        [612, 0, 0], 
+        [615, 0, 0], 
+        [618, 0, 0], 
+        [621, 0, 0], 
+        [624, 0, 0], 
+        [627, 0, 0], 
+        [630, 0, 0], 
+        [633, 0, 0], 
+        [636, 0, 0]
+      ]
+    }, 
+    {
+      "op": "_contrib_box_nms", 
+      "name": "ssd0_box_nms0", 
+      "attrs": {
+        "coord_start": "2", 
+        "force_suppress": "False", 
+        "id_index": "0", 
+        "overlap_thresh": "0.45", 
+        "score_index": "1", 
+        "topk": "200", 
+        "valid_thresh": "0.01"
+      }, 
+      "inputs": [[637, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis40", 
+      "attrs": {
+        "axis": "1", 
+        "begin": "0", 
+        "end": "100"
+      }, 
+      "inputs": [[638, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis41", 
+      "attrs": {
+        "axis": "2", 
+        "begin": "0", 
+        "end": "1"
+      }, 
+      "inputs": [[639, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis42", 
+      "attrs": {
+        "axis": "2", 
+        "begin": "1", 
+        "end": "2"
+      }, 
+      "inputs": [[639, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis43", 
+      "attrs": {
+        "axis": "2", 
+        "begin": "2", 
+        "end": "6"
+      }, 
+      "inputs": [[639, 0, 0]]
+    }
+  ], 
+  "arg_nodes": [
+    0, 
+    2, 
+    3, 
+    4, 
+    5, 
+    6, 
+    9, 
+    10, 
+    11, 
+    12, 
+    13, 
+    14, 
+    16, 
+    17, 
+    18, 
+    19, 
+    20, 
+    22, 
+    23, 
+    24, 
+    25, 
+    26, 
+    27, 
+    28, 
+    29, 
+    30, 
+    31, 
+    32, 
+    35, 
+    36, 
+    37, 
+    38, 
+    39, 
+    40, 
+    42, 
+    43, 
+    44, 
+    45, 
+    46, 
+    48, 
+    49, 
+    50, 
+    51, 
+    52, 
+    53, 
+    55, 
+    56, 
+    57, 
+    58, 
+    59, 
+    60, 
+    62, 
+    63, 
+    64, 
+    65, 
+    66, 
+    68, 
+    69, 
+    70, 
+    71, 
+    72, 
+    73, 
+    75, 
+    76, 
+    77, 
+    78, 
+    79, 
+    80, 
+    82, 
+    83, 
+    84, 
+    85, 
+    86, 
+    88, 
+    89, 
+    90, 
+    91, 
+    92, 
+    93, 
+    94, 
+    95, 
+    96, 
+    97, 
+    98, 
+    101, 
+    102, 
+    103, 
+    104, 
+    105, 
+    106, 
+    108, 
+    109, 
+    110, 
+    111, 
+    112, 
+    114, 
+    115, 
+    116, 
+    117, 
+    118, 
+    119, 
+    121, 
+    122, 
+    123, 
+    124, 
+    125, 
+    126, 
+    128, 
+    129, 
+    130, 
+    131, 
+    132, 
+    134, 
+    135, 
+    136, 
+    137, 
+    138, 
+    139, 
+    141, 
+    142, 
+    143, 
+    144, 
+    145, 
+    146, 
+    148, 
+    149, 
+    150, 
+    151, 
+    152, 
+    154, 
+    155, 
+    156, 
+    157, 
+    158, 
+    159, 
+    161, 
+    162, 
+    163, 
+    164, 
+    165, 
+    166, 
+    168, 
+    169, 
+    170, 
+    171, 
+    172, 
+    174, 
+    175, 
+    176, 
+    177, 
+    178, 
+    179, 
+    180, 
+    181, 
+    182, 
+    183, 
+    184, 
+    187, 
+    188, 
+    189, 
+    190, 
+    191, 
+    192, 
+    194, 
+    195, 
+    196, 
+    197, 
+    198, 
+    200, 
+    201, 
+    202, 
+    203, 
+    204, 
+    205, 
+    207, 
+    208, 
+    209, 
+    210, 
+    211, 
+    212, 
+    214, 
+    215, 
+    216, 
+    217, 
+    218, 
+    220, 
+    221, 
+    222, 
+    223, 
+    224, 
+    225, 
+    227, 
+    228, 
+    229, 
+    230, 
+    231, 
+    232, 
+    234, 
+    235, 
+    236, 
+    237, 
+    238, 
+    240, 
+    241, 
+    242, 
+    243, 
+    244, 
+    245, 
+    247, 
+    248, 
+    249, 
+    250, 
+    251, 
+    252, 
+    254, 
+    255, 
+    256, 
+    257, 
+    258, 
+    260, 
+    261, 
+    262, 
+    263, 
+    264, 
+    265, 
+    267, 
+    268, 
+    269, 
+    270, 
+    271, 
+    272, 
+    274, 
+    275, 
+    276, 
+    277, 
+    278, 
+    280, 
+    281, 
+    282, 
+    283, 
+    284, 
+    285, 
+    287, 
+    288, 
+    293, 
+    294, 
+    295, 
+    296, 
+    297, 
+    298, 
+    300, 
+    301, 
+    302, 
+    303, 
+    304, 
+    306, 
+    307, 
+    308, 
+    309, 
+    310, 
+    311, 
+    312, 
+    313, 
+    314, 
+    315, 
+    316, 
+    319, 
+    320, 
+    321, 
+    322, 
+    323, 
+    324, 
+    326, 
+    327, 
+    328, 
+    329, 
+    330, 
+    332, 
+    333, 
+    334, 
+    335, 
+    336, 
+    337, 
+    339, 
+    340, 
+    341, 
+    342, 
+    343, 
+    344, 
+    346, 
+    347, 
+    348, 
+    349, 
+    350, 
+    352, 
+    353, 
+    354, 
+    355, 
+    356, 
+    357, 
+    359, 
+    360, 
+    365, 
+    366, 
+    367, 
+    368, 
+    369, 
+    371, 
+    372, 
+    373, 
+    374, 
+    375, 
+    377, 
+    378, 
+    383, 
+    384, 
+    385, 
+    386, 
+    387, 
+    389, 
+    390, 
+    391, 
+    392, 
+    393, 
+    395, 
+    396, 
+    401, 
+    402, 
+    403, 
+    404, 
+    405, 
+    407, 
+    408, 
+    409, 
+    410, 
+    411, 
+    413, 
+    414, 
+    419, 
+    420, 
+    421, 
+    422, 
+    423, 
+    425, 
+    426, 
+    427, 
+    428, 
+    429, 
+    431, 
+    432, 
+    472, 
+    473, 
+    478, 
+    479, 
+    484, 
+    485, 
+    490, 
+    491, 
+    496, 
+    497, 
+    502, 
+    503, 
+    513, 
+    520, 
+    527, 
+    534, 
+    541, 
+    548
+  ], 
+  "node_row_ptr": [
+    0, 
+    1, 
+    4, 
+    5, 
+    6, 
+    7, 
+    8, 
+    9, 
+    12, 
+    15, 
+    16, 
+    17, 
+    18, 
+    19, 
+    20, 
+    21, 
+    24, 
+    25, 
+    26, 
+    27, 
+    28, 
+    29, 
+    32, 
+    33, 
+    34, 
+    35, 
+    36, 
+    37, 
+    38, 
+    39, 
+    40, 
+    41, 
+    42, 
+    43, 
+    46, 
+    49, 
+    50, 
+    51, 
+    52, 
+    53, 
+    54, 
+    55, 
+    58, 
+    59, 
+    60, 
+    61, 
+    62, 
+    63, 
+    66, 
+    67, 
+    68, 
+    69, 
+    70, 
+    71, 
+    72, 
+    75, 
+    76, 
+    77, 
+    78, 
+    79, 
+    80, 
+    81, 
+    84, 
+    85, 
+    86, 
+    87, 
+    88, 
+    89, 
+    92, 
+    93, 
+    94, 
+    95, 
+    96, 
+    97, 
+    98, 
+    101, 
+    102, 
+    103, 
+    104, 
+    105, 
+    106, 
+    107, 
+    110, 
+    111, 
+    112, 
+    113, 
+    114, 
+    115, 
+    118, 
+    119, 
+    120, 
+    121, 
+    122, 
+    123, 
+    124, 
+    125, 
+    126, 
+    127, 
+    128, 
+    129, 
+    132, 
+    135, 
+    136, 
+    137, 
+    138, 
+    139, 
+    140, 
+    141, 
+    144, 
+    145, 
+    146, 
+    147, 
+    148, 
+    149, 
+    152, 
+    153, 
+    154, 
+    155, 
+    156, 
+    157, 
+    158, 
+    161, 
+    162, 
+    163, 
+    164, 
+    165, 
+    166, 
+    167, 
+    170, 
+    171, 
+    172, 
+    173, 
+    174, 
+    175, 
+    178, 
+    179, 
+    180, 
+    181, 
+    182, 
+    183, 
+    184, 
+    187, 
+    188, 
+    189, 
+    190, 
+    191, 
+    192, 
+    193, 
+    196, 
+    197, 
+    198, 
+    199, 
+    200, 
+    201, 
+    204, 
+    205, 
+    206, 
+    207, 
+    208, 
+    209, 
+    210, 
+    213, 
+    214, 
+    215, 
+    216, 
+    217, 
+    218, 
+    219, 
+    222, 
+    223, 
+    224, 
+    225, 
+    226, 
+    227, 
+    230, 
+    231, 
+    232, 
+    233, 
+    234, 
+    235, 
+    236, 
+    237, 
+    238, 
+    239, 
+    240, 
+    241, 
+    244, 
+    247, 
+    248, 
+    249, 
+    250, 
+    251, 
+    252, 
+    253, 
+    256, 
+    257, 
+    258, 
+    259, 
+    260, 
+    261, 
+    264, 
+    265, 
+    266, 
+    267, 
+    268, 
+    269, 
+    270, 
+    273, 
+    274, 
+    275, 
+    276, 
+    277, 
+    278, 
+    279, 
+    282, 
+    283, 
+    284, 
+    285, 
+    286, 
+    287, 
+    290, 
+    291, 
+    292, 
+    293, 
+    294, 
+    295, 
+    296, 
+    299, 
+    300, 
+    301, 
+    302, 
+    303, 
+    304, 
+    305, 
+    308, 
+    309, 
+    310, 
+    311, 
+    312, 
+    313, 
+    316, 
+    317, 
+    318, 
+    319, 
+    320, 
+    321, 
+    322, 
+    325, 
+    326, 
+    327, 
+    328, 
+    329, 
+    330, 
+    331, 
+    334, 
+    335, 
+    336, 
+    337, 
+    338, 
+    339, 
+    342, 
+    343, 
+    344, 
+    345, 
+    346, 
+    347, 
+    348, 
+    351, 
+    352, 
+    353, 
+    354, 
+    355, 
+    356, 
+    357, 
+    360, 
+    361, 
+    362, 
+    363, 
+    364, 
+    365, 
+    368, 
+    369, 
+    370, 
+    371, 
+    372, 
+    373, 
+    374, 
+    377, 
+    378, 
+    379, 
+    382, 
+    383, 
+    384, 
+    385, 
+    386, 
+    387, 
+    388, 
+    389, 
+    390, 
+    391, 
+    394, 
+    395, 
+    396, 
+    397, 
+    398, 
+    399, 
+    402, 
+    403, 
+    404, 
+    405, 
+    406, 
+    407, 
+    408, 
+    409, 
+    410, 
+    411, 
+    412, 
+    413, 
+    416, 
+    419, 
+    420, 
+    421, 
+    422, 
+    423, 
+    424, 
+    425, 
+    428, 
+    429, 
+    430, 
+    431, 
+    432, 
+    433, 
+    436, 
+    437, 
+    438, 
+    439, 
+    440, 
+    441, 
+    442, 
+    445, 
+    446, 
+    447, 
+    448, 
+    449, 
+    450, 
+    451, 
+    454, 
+    455, 
+    456, 
+    457, 
+    458, 
+    459, 
+    462, 
+    463, 
+    464, 
+    465, 
+    466, 
+    467, 
+    468, 
+    471, 
+    472, 
+    473, 
+    476, 
+    477, 
+    478, 
+    479, 
+    480, 
+    481, 
+    482, 
+    483, 
+    484, 
+    487, 
+    488, 
+    489, 
+    490, 
+    491, 
+    492, 
+    495, 
+    496, 
+    497, 
+    500, 
+    501, 
+    502, 
+    503, 
+    504, 
+    505, 
+    506, 
+    507, 
+    508, 
+    511, 
+    512, 
+    513, 
+    514, 
+    515, 
+    516, 
+    519, 
+    520, 
+    521, 
+    524, 
+    525, 
+    526, 
+    527, 
+    528, 
+    529, 
+    530, 
+    531, 
+    532, 
+    535, 
+    536, 
+    537, 
+    538, 
+    539, 
+    540, 
+    543, 
+    544, 
+    545, 
+    548, 
+    549, 
+    550, 
+    551, 
+    552, 
+    553, 
+    554, 
+    555, 
+    556, 
+    559, 
+    560, 
+    561, 
+    562, 
+    563, 
+    564, 
+    567, 
+    568, 
+    569, 
+    572, 
+    573, 
+    574, 
+    575, 
+    576, 
+    577, 
+    578, 
+    579, 
+    580, 
+    581, 
+    582, 
+    583, 
+    584, 
+    585, 
+    586, 
+    587, 
+    588, 
+    589, 
+    590, 
+    591, 
+    592, 
+    593, 
+    594, 
+    595, 
+    596, 
+    597, 
+    598, 
+    599, 
+    600, 
+    601, 
+    602, 
+    603, 
+    604, 
+    605, 
+    606, 
+    607, 
+    608, 
+    609, 
+    610, 
+    611, 
+    612, 
+    615, 
+    616, 
+    617, 
+    618, 
+    619, 
+    620, 
+    623, 
+    624, 
+    625, 
+    626, 
+    627, 
+    628, 
+    631, 
+    632, 
+    633, 
+    634, 
+    635, 
+    636, 
+    639, 
+    640, 
+    641, 
+    642, 
+    643, 
+    644, 
+    647, 
+    648, 
+    649, 
+    650, 
+    651, 
+    652, 
+    655, 
+    656, 
+    657, 
+    658, 
+    659, 
+    660, 
+    664, 
+    665, 
+    666, 
+    667, 
+    668, 
+    669, 
+    670, 
+    671, 
+    672, 
+    673, 
+    674, 
+    675, 
+    676, 
+    677, 
+    678, 
+    679, 
+    680, 
+    681, 
+    682, 
+    683, 
+    684, 
+    685, 
+    686, 
+    687, 
+    688, 
+    689, 
+    690, 
+    691, 
+    692, 
+    693, 
+    694, 
+    695, 
+    696, 
+    697, 
+    698, 
+    699, 
+    700, 
+    701, 
+    702, 
+    703, 
+    704, 
+    705, 
+    706, 
+    707, 
+    708, 
+    709, 
+    710, 
+    714, 
+    715, 
+    716, 
+    717, 
+    718, 
+    719, 
+    720, 
+    721, 
+    722, 
+    723, 
+    724, 
+    725, 
+    726, 
+    727, 
+    728, 
+    729, 
+    730, 
+    731, 
+    732, 
+    733, 
+    734, 
+    735, 
+    736, 
+    737, 
+    738, 
+    739, 
+    740, 
+    741, 
+    742, 
+    743, 
+    744, 
+    745, 
+    746, 
+    747, 
+    748, 
+    749, 
+    750, 
+    751, 
+    752, 
+    753, 
+    754, 
+    755, 
+    756, 
+    757, 
+    758, 
+    759, 
+    760, 
+    761, 
+    762, 
+    763, 
+    764, 
+    765, 
+    766, 
+    767, 
+    768, 
+    769, 
+    770, 
+    771, 
+    772, 
+    773, 
+    774, 
+    775, 
+    776, 
+    777, 
+    778, 
+    779, 
+    780, 
+    781, 
+    782, 
+    783, 
+    784, 
+    785, 
+    786, 
+    787, 
+    788, 
+    789, 
+    790, 
+    791, 
+    792, 
+    793, 
+    794, 
+    796, 
+    797, 
+    798, 
+    799, 
+    800
+  ], 
+  "heads": [[640, 0, 0], [641, 0, 0], [642, 0, 0]], 
+  "attrs": {"mxnet_version": ["int", 10500]}
+}

--- a/gluoncv/model_zoo/quantized/ssd_512_vgg16_atrous_voc_int8-symbol.json
+++ b/gluoncv/model_zoo/quantized/ssd_512_vgg16_atrous_voc_int8-symbol.json
@@ -1,0 +1,5295 @@
+{
+  "nodes": [
+    {
+      "op": "null", 
+      "name": "data", 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_init_scale", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "Constant_ssd0_vggatrousextractor0_init_scale_139783361597960", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1, 3, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "broadcast_mul", 
+      "name": "ssd0_vggatrousextractor0_broadcast_mul0", 
+      "inputs": [[0, 0, 0], [1, 0, 0]]
+    }, 
+    {
+      "op": "_contrib_quantize_v2", 
+      "name": "ssd0_vggatrousextractor0_broadcast_mul0_0_quantize", 
+      "attrs": {"out_type": "auto"}, 
+      "inputs": [[2, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"gaussian\", \"factor_type\": \"out\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64, 3, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_relu_0", 
+      "attrs": {
+        "max_calib_range": "832.222168", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[3, 0, 0], [4, 0, 0], [5, 0, 0], [3, 1, 0], [3, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_broadcast_mul0_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_vggatrousextractor0_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "64", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_vggatrousextractor0_relu0_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[3, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5], 
+          "heads": [[4, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_conv1_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"gaussian\", \"factor_type\": \"out\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64, 64, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_conv1_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(64,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_relu_1", 
+      "attrs": {
+        "max_calib_range": "3649.146973", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[6, 0, 0], [7, 0, 0], [8, 0, 0], [6, 1, 0], [6, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_0_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_conv1_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_conv1_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_vggatrousextractor0_conv1_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "64", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_vggatrousextractor0_relu1_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[3, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5], 
+          "heads": [[4, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_quantized_pooling", 
+      "name": "quantized_ssd0_vggatrousextractor0_pooling0", 
+      "attrs": {
+        "kernel": "(2, 2)", 
+        "pool_type": "max", 
+        "pooling_convention": "full", 
+        "stride": "(2, 2)"
+      }, 
+      "inputs": [[9, 0, 0], [9, 1, 0], [9, 2, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_conv2_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"gaussian\", \"factor_type\": \"out\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128, 64, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_conv2_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_relu_2", 
+      "attrs": {
+        "max_calib_range": "5728.440918", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[10, 0, 0], [11, 0, 0], [12, 0, 0], [10, 1, 0], [10, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_pooling0_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_conv2_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_conv2_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_vggatrousextractor0_conv2_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "128", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_vggatrousextractor0_relu2_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[3, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5], 
+          "heads": [[4, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_conv3_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"gaussian\", \"factor_type\": \"out\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128, 128, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_conv3_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_relu_3", 
+      "attrs": {
+        "max_calib_range": "8342.140625", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[13, 0, 0], [14, 0, 0], [15, 0, 0], [13, 1, 0], [13, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_2_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_conv3_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_conv3_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_vggatrousextractor0_conv3_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "128", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_vggatrousextractor0_relu3_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[3, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5], 
+          "heads": [[4, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_quantized_pooling", 
+      "name": "quantized_ssd0_vggatrousextractor0_pooling1", 
+      "attrs": {
+        "kernel": "(2, 2)", 
+        "pool_type": "max", 
+        "pooling_convention": "full", 
+        "stride": "(2, 2)"
+      }, 
+      "inputs": [[16, 0, 0], [16, 1, 0], [16, 2, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_conv4_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"gaussian\", \"factor_type\": \"out\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256, 128, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_conv4_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_relu_4", 
+      "attrs": {
+        "max_calib_range": "9537.661133", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[17, 0, 0], [18, 0, 0], [19, 0, 0], [17, 1, 0], [17, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_pooling1_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_conv4_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_conv4_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_vggatrousextractor0_conv4_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "256", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_vggatrousextractor0_relu4_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[3, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5], 
+          "heads": [[4, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_conv5_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"gaussian\", \"factor_type\": \"out\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256, 256, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_conv5_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_relu_5", 
+      "attrs": {
+        "max_calib_range": "8158.472168", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[20, 0, 0], [21, 0, 0], [22, 0, 0], [20, 1, 0], [20, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_4_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_conv5_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_conv5_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_vggatrousextractor0_conv5_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "256", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_vggatrousextractor0_relu5_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[3, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5], 
+          "heads": [[4, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_conv6_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"gaussian\", \"factor_type\": \"out\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256, 256, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_conv6_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_relu_6", 
+      "attrs": {
+        "max_calib_range": "7653.954102", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[23, 0, 0], [24, 0, 0], [25, 0, 0], [23, 1, 0], [23, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_5_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_conv6_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_conv6_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_vggatrousextractor0_conv6_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "256", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_vggatrousextractor0_relu6_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[3, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5], 
+          "heads": [[4, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_quantized_pooling", 
+      "name": "quantized_ssd0_vggatrousextractor0_pooling2", 
+      "attrs": {
+        "kernel": "(2, 2)", 
+        "pool_type": "max", 
+        "pooling_convention": "full", 
+        "stride": "(2, 2)"
+      }, 
+      "inputs": [[26, 0, 0], [26, 1, 0], [26, 2, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_conv7_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"gaussian\", \"factor_type\": \"out\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 256, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_conv7_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_relu_7", 
+      "attrs": {
+        "max_calib_range": "4286.884766", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[27, 0, 0], [28, 0, 0], [29, 0, 0], [27, 1, 0], [27, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_pooling2_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_conv7_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_conv7_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_vggatrousextractor0_conv7_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "512", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_vggatrousextractor0_relu7_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[3, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5], 
+          "heads": [[4, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_conv8_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"gaussian\", \"factor_type\": \"out\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 512, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_conv8_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_relu_8", 
+      "attrs": {
+        "max_calib_range": "1701.747681", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[30, 0, 0], [31, 0, 0], [32, 0, 0], [30, 1, 0], [30, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_7_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_conv8_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_conv8_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_vggatrousextractor0_conv8_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "512", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_vggatrousextractor0_relu8_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[3, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5], 
+          "heads": [[4, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_conv9_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"gaussian\", \"factor_type\": \"out\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 512, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_conv9_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_relu_9", 
+      "attrs": {
+        "max_calib_range": "823.329224", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[33, 0, 0], [34, 0, 0], [35, 0, 0], [33, 1, 0], [33, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_8_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_conv9_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_conv9_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_vggatrousextractor0_conv9_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "512", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_vggatrousextractor0_relu9_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[3, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5], 
+          "heads": [[4, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_relu_9_dequantize", 
+      "inputs": [[36, 0, 0], [36, 1, 0], [36, 2, 0]]
+    }, 
+    {
+      "op": "L2Normalization", 
+      "name": "ssd0_vggatrousextractor0_normalize0_l2normalization0", 
+      "attrs": {
+        "eps": "1e-05", 
+        "mode": "channel"
+      }, 
+      "inputs": [[37, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_normalize0_normalize_scale", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"constant\", {\"value\": 20}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1, 512, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "broadcast_mul", 
+      "name": "ssd0_vggatrousextractor0_normalize0_broadcast_mul0", 
+      "inputs": [[38, 0, 0], [39, 0, 0]]
+    }, 
+    {
+      "op": "_contrib_quantize_v2", 
+      "name": "ssd0_vggatrousextractor0_normalize0_broadcast_mul0_0_quantize", 
+      "attrs": {"out_type": "auto"}, 
+      "inputs": [[40, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor0_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"uniform\", \"factor_type\": \"avg\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(84, 512, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor0_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(84,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_10", 
+      "attrs": {
+        "max_calib_range": "15.165039", 
+        "min_calib_range": "-6.742505", 
+        "quantized": "true"
+      }, 
+      "inputs": [[41, 0, 0], [42, 0, 0], [43, 0, 0], [41, 1, 0], [41, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_normalize0_broadcast_mul0_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor0_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor0_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_convpredictor0_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "84", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4], 
+          "heads": [[3, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_10_dequantize", 
+      "inputs": [[44, 0, 0], [44, 1, 0], [44, 2, 0]]
+    }, 
+    {
+      "op": "transpose", 
+      "name": "ssd0_transpose0", 
+      "attrs": {"axes": "(0, 2, 3, 1)"}, 
+      "inputs": [[45, 0, 0]]
+    }, 
+    {
+      "op": "Flatten", 
+      "name": "ssd0_flatten0", 
+      "inputs": [[46, 0, 0]]
+    }, 
+    {
+      "op": "_contrib_quantized_pooling", 
+      "name": "quantized_ssd0_vggatrousextractor0_pooling3", 
+      "attrs": {
+        "kernel": "(2, 2)", 
+        "pool_type": "max", 
+        "pooling_convention": "full", 
+        "stride": "(2, 2)"
+      }, 
+      "inputs": [[36, 0, 0], [36, 1, 0], [36, 2, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_conv10_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"gaussian\", \"factor_type\": \"out\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 512, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_conv10_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_relu_11", 
+      "attrs": {
+        "max_calib_range": "550.796570", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[48, 0, 0], [49, 0, 0], [50, 0, 0], [48, 1, 0], [48, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_pooling3_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_conv10_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_conv10_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_vggatrousextractor0_conv10_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "512", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_vggatrousextractor0_relu10_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[3, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5], 
+          "heads": [[4, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_conv11_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"gaussian\", \"factor_type\": \"out\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 512, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_conv11_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_relu_12", 
+      "attrs": {
+        "max_calib_range": "262.895081", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[51, 0, 0], [52, 0, 0], [53, 0, 0], [51, 1, 0], [51, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_11_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_conv11_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_conv11_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_vggatrousextractor0_conv11_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "512", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_vggatrousextractor0_relu11_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[3, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5], 
+          "heads": [[4, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_conv12_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"gaussian\", \"factor_type\": \"out\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 512, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_conv12_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_relu_13", 
+      "attrs": {
+        "max_calib_range": "169.532410", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[54, 0, 0], [55, 0, 0], [56, 0, 0], [54, 1, 0], [54, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_12_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_conv12_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_conv12_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_vggatrousextractor0_conv12_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "512", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_vggatrousextractor0_relu12_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[3, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5], 
+          "heads": [[4, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_quantized_pooling", 
+      "name": "quantized_ssd0_vggatrousextractor0_pooling4", 
+      "attrs": {
+        "kernel": "(3, 3)", 
+        "pad": "(1, 1)", 
+        "pool_type": "max", 
+        "pooling_convention": "full", 
+        "stride": "(1, 1)"
+      }, 
+      "inputs": [[57, 0, 0], [57, 1, 0], [57, 2, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_dilated_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"gaussian\", \"factor_type\": \"out\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024, 512, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_dilated_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_relu_14", 
+      "attrs": {
+        "max_calib_range": "49.372860", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[58, 0, 0], [59, 0, 0], [60, 0, 0], [58, 1, 0], [58, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_pooling4_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_dilated_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_dilated_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_vggatrousextractor0_dilated_conv0_fwd", 
+              "attrs": {
+                "dilate": "(6, 6)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "1024", 
+                "num_group": "1", 
+                "pad": "(6, 6)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_vggatrousextractor0_dilated_relu0_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[3, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5], 
+          "heads": [[4, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_dilated_conv1_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"gaussian\", \"factor_type\": \"out\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024, 1024, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_dilated_conv1_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1024,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_relu_15", 
+      "attrs": {
+        "max_calib_range": "12.387590", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[61, 0, 0], [62, 0, 0], [63, 0, 0], [61, 1, 0], [61, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_14_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_dilated_conv1_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_dilated_conv1_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_vggatrousextractor0_dilated_conv1_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "1024", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_vggatrousextractor0_dilated_relu1_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[3, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5], 
+          "heads": [[4, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor2_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"uniform\", \"factor_type\": \"avg\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(126, 1024, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor2_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(126,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_16", 
+      "attrs": {
+        "max_calib_range": "35.013943", 
+        "min_calib_range": "-14.424582", 
+        "quantized": "true"
+      }, 
+      "inputs": [[64, 0, 0], [65, 0, 0], [66, 0, 0], [64, 1, 0], [64, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_15_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor2_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor2_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_convpredictor2_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "126", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4], 
+          "heads": [[3, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_16_dequantize", 
+      "inputs": [[67, 0, 0], [67, 1, 0], [67, 2, 0]]
+    }, 
+    {
+      "op": "transpose", 
+      "name": "ssd0_transpose1", 
+      "attrs": {"axes": "(0, 2, 3, 1)"}, 
+      "inputs": [[68, 0, 0]]
+    }, 
+    {
+      "op": "Flatten", 
+      "name": "ssd0_flatten1", 
+      "inputs": [[69, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_extra0_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"gaussian\", \"factor_type\": \"out\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256, 1024, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_extra0_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_relu_17", 
+      "attrs": {
+        "max_calib_range": "10.076336", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[64, 0, 0], [71, 0, 0], [72, 0, 0], [64, 1, 0], [64, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_15_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_extra0_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_extra0_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_vggatrousextractor0_extra0_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "256", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_vggatrousextractor0_extra0_relu0_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[3, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5], 
+          "heads": [[4, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_extra0_conv1_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"gaussian\", \"factor_type\": \"out\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512, 256, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_extra0_conv1_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(512,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_relu_18", 
+      "attrs": {
+        "max_calib_range": "10.388749", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[73, 0, 0], [74, 0, 0], [75, 0, 0], [73, 1, 0], [73, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_17_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_extra0_conv1_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_extra0_conv1_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_vggatrousextractor0_extra0_conv1_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "512", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(2, 2)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_vggatrousextractor0_extra0_relu1_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[3, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5], 
+          "heads": [[4, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor4_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"uniform\", \"factor_type\": \"avg\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(126, 512, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor4_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(126,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_19", 
+      "attrs": {
+        "max_calib_range": "31.706652", 
+        "min_calib_range": "-12.462226", 
+        "quantized": "true"
+      }, 
+      "inputs": [[76, 0, 0], [77, 0, 0], [78, 0, 0], [76, 1, 0], [76, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_18_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor4_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor4_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_convpredictor4_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "126", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4], 
+          "heads": [[3, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_19_dequantize", 
+      "inputs": [[79, 0, 0], [79, 1, 0], [79, 2, 0]]
+    }, 
+    {
+      "op": "transpose", 
+      "name": "ssd0_transpose2", 
+      "attrs": {"axes": "(0, 2, 3, 1)"}, 
+      "inputs": [[80, 0, 0]]
+    }, 
+    {
+      "op": "Flatten", 
+      "name": "ssd0_flatten2", 
+      "inputs": [[81, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_extra1_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"gaussian\", \"factor_type\": \"out\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128, 512, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_extra1_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_relu_20", 
+      "attrs": {
+        "max_calib_range": "17.176729", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[76, 0, 0], [83, 0, 0], [84, 0, 0], [76, 1, 0], [76, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_18_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_extra1_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_extra1_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_vggatrousextractor0_extra1_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "128", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_vggatrousextractor0_extra1_relu0_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[3, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5], 
+          "heads": [[4, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_extra1_conv1_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"gaussian\", \"factor_type\": \"out\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256, 128, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_extra1_conv1_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_relu_21", 
+      "attrs": {
+        "max_calib_range": "16.528648", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[85, 0, 0], [86, 0, 0], [87, 0, 0], [85, 1, 0], [85, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_20_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_extra1_conv1_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_extra1_conv1_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_vggatrousextractor0_extra1_conv1_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "256", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(2, 2)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_vggatrousextractor0_extra1_relu1_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[3, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5], 
+          "heads": [[4, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor6_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"uniform\", \"factor_type\": \"avg\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(126, 256, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor6_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(126,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_22", 
+      "attrs": {
+        "max_calib_range": "31.651865", 
+        "min_calib_range": "-14.558433", 
+        "quantized": "true"
+      }, 
+      "inputs": [[88, 0, 0], [89, 0, 0], [90, 0, 0], [88, 1, 0], [88, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_21_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor6_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor6_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_convpredictor6_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "126", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4], 
+          "heads": [[3, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_22_dequantize", 
+      "inputs": [[91, 0, 0], [91, 1, 0], [91, 2, 0]]
+    }, 
+    {
+      "op": "transpose", 
+      "name": "ssd0_transpose3", 
+      "attrs": {"axes": "(0, 2, 3, 1)"}, 
+      "inputs": [[92, 0, 0]]
+    }, 
+    {
+      "op": "Flatten", 
+      "name": "ssd0_flatten3", 
+      "inputs": [[93, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_extra2_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"gaussian\", \"factor_type\": \"out\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128, 256, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_extra2_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_relu_23", 
+      "attrs": {
+        "max_calib_range": "21.921522", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[88, 0, 0], [95, 0, 0], [96, 0, 0], [88, 1, 0], [88, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_21_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_extra2_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_extra2_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_vggatrousextractor0_extra2_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "128", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_vggatrousextractor0_extra2_relu0_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[3, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5], 
+          "heads": [[4, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_extra2_conv1_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"gaussian\", \"factor_type\": \"out\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256, 128, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_extra2_conv1_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_relu_24", 
+      "attrs": {
+        "max_calib_range": "22.233150", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[97, 0, 0], [98, 0, 0], [99, 0, 0], [97, 1, 0], [97, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_23_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_extra2_conv1_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_extra2_conv1_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_vggatrousextractor0_extra2_conv1_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "256", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(2, 2)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_vggatrousextractor0_extra2_relu1_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[3, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5], 
+          "heads": [[4, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor8_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"uniform\", \"factor_type\": \"avg\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(126, 256, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor8_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(126,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_25", 
+      "attrs": {
+        "max_calib_range": "25.814215", 
+        "min_calib_range": "-16.012779", 
+        "quantized": "true"
+      }, 
+      "inputs": [[100, 0, 0], [101, 0, 0], [102, 0, 0], [100, 1, 0], [100, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_24_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor8_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor8_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_convpredictor8_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "126", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4], 
+          "heads": [[3, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_25_dequantize", 
+      "inputs": [[103, 0, 0], [103, 1, 0], [103, 2, 0]]
+    }, 
+    {
+      "op": "transpose", 
+      "name": "ssd0_transpose4", 
+      "attrs": {"axes": "(0, 2, 3, 1)"}, 
+      "inputs": [[104, 0, 0]]
+    }, 
+    {
+      "op": "Flatten", 
+      "name": "ssd0_flatten4", 
+      "inputs": [[105, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_extra3_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"gaussian\", \"factor_type\": \"out\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128, 256, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_extra3_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_relu_26", 
+      "attrs": {
+        "max_calib_range": "31.320433", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[100, 0, 0], [107, 0, 0], [108, 0, 0], [100, 1, 0], [100, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_24_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_extra3_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_extra3_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_vggatrousextractor0_extra3_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "128", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_vggatrousextractor0_extra3_relu0_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[3, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5], 
+          "heads": [[4, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_extra3_conv1_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"gaussian\", \"factor_type\": \"out\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256, 128, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_extra3_conv1_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_relu_27", 
+      "attrs": {
+        "max_calib_range": "33.492085", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[109, 0, 0], [110, 0, 0], [111, 0, 0], [109, 1, 0], [109, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_26_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_extra3_conv1_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_extra3_conv1_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_vggatrousextractor0_extra3_conv1_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "256", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(2, 2)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_vggatrousextractor0_extra3_relu1_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[3, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5], 
+          "heads": [[4, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor10_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"uniform\", \"factor_type\": \"avg\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(84, 256, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor10_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(84,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_28", 
+      "attrs": {
+        "max_calib_range": "20.189611", 
+        "min_calib_range": "-14.922727", 
+        "quantized": "true"
+      }, 
+      "inputs": [[112, 0, 0], [113, 0, 0], [114, 0, 0], [112, 1, 0], [112, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_27_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor10_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor10_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_convpredictor10_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "84", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4], 
+          "heads": [[3, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_28_dequantize", 
+      "inputs": [[115, 0, 0], [115, 1, 0], [115, 2, 0]]
+    }, 
+    {
+      "op": "transpose", 
+      "name": "ssd0_transpose5", 
+      "attrs": {"axes": "(0, 2, 3, 1)"}, 
+      "inputs": [[116, 0, 0]]
+    }, 
+    {
+      "op": "Flatten", 
+      "name": "ssd0_flatten5", 
+      "inputs": [[117, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_extra4_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"gaussian\", \"factor_type\": \"out\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128, 256, 1, 1)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_extra4_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(128,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_relu_29", 
+      "attrs": {
+        "max_calib_range": "41.716820", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[112, 0, 0], [119, 0, 0], [120, 0, 0], [112, 1, 0], [112, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_27_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_extra4_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_extra4_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_vggatrousextractor0_extra4_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(1, 1)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "128", 
+                "num_group": "1", 
+                "pad": "(0, 0)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_vggatrousextractor0_extra4_relu0_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[3, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5], 
+          "heads": [[4, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_extra4_conv1_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"gaussian\", \"factor_type\": \"out\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256, 128, 4, 4)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_vggatrousextractor0_extra4_conv1_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(256,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_relu_30", 
+      "attrs": {
+        "max_calib_range": "27.027159", 
+        "min_calib_range": "-0.000000", 
+        "quantized": "true", 
+        "with_relu": "true"
+      }, 
+      "inputs": [[121, 0, 0], [122, 0, 0], [123, 0, 0], [121, 1, 0], [121, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_29_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_extra4_conv1_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_extra4_conv1_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_vggatrousextractor0_extra4_conv1_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(4, 4)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "256", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }, 
+            {
+              "op": "Activation", 
+              "name": "ssd0_vggatrousextractor0_extra4_relu1_fwd", 
+              "attrs": {"act_type": "relu"}, 
+              "inputs": [[3, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4, 5], 
+          "heads": [[4, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor12_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"uniform\", \"factor_type\": \"avg\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(84, 256, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor12_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(84,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_31", 
+      "attrs": {
+        "max_calib_range": "18.919998", 
+        "min_calib_range": "-15.738542", 
+        "quantized": "true"
+      }, 
+      "inputs": [[124, 0, 0], [125, 0, 0], [126, 0, 0], [124, 1, 0], [124, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_30_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor12_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor12_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_convpredictor12_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "84", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4], 
+          "heads": [[3, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_31_dequantize", 
+      "inputs": [[127, 0, 0], [127, 1, 0], [127, 2, 0]]
+    }, 
+    {
+      "op": "transpose", 
+      "name": "ssd0_transpose6", 
+      "attrs": {"axes": "(0, 2, 3, 1)"}, 
+      "inputs": [[128, 0, 0]]
+    }, 
+    {
+      "op": "Flatten", 
+      "name": "ssd0_flatten6", 
+      "inputs": [[129, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat0", 
+      "attrs": {
+        "dim": "1", 
+        "num_args": "7"
+      }, 
+      "inputs": [[47, 0, 0], [70, 0, 0], [82, 0, 0], [94, 0, 0], [106, 0, 0], [118, 0, 0], [130, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_reshape7", 
+      "attrs": {"shape": "(0, -1, 21)"}, 
+      "inputs": [[131, 0, 0]]
+    }, 
+    {
+      "op": "softmax", 
+      "name": "ssd0_softmax0", 
+      "attrs": {"axis": "-1"}, 
+      "inputs": [[132, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_multiperclassdecoder0_slice_axis0", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "1", 
+        "end": "None"
+      }, 
+      "inputs": [[133, 0, 0]]
+    }, 
+    {
+      "op": "_greater_scalar", 
+      "name": "ssd0_multiperclassdecoder0__greater_scalar0", 
+      "attrs": {"scalar": "0.01"}, 
+      "inputs": [[134, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_multiperclassdecoder0_slice_axis1", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "0", 
+        "end": "1"
+      }, 
+      "inputs": [[133, 0, 0]]
+    }, 
+    {
+      "op": "zeros_like", 
+      "name": "ssd0_multiperclassdecoder0_zeros_like0", 
+      "inputs": [[136, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar0", 
+      "attrs": {"scalar": "0"}, 
+      "inputs": [[137, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar1", 
+      "attrs": {"scalar": "1"}, 
+      "inputs": [[137, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar2", 
+      "attrs": {"scalar": "2"}, 
+      "inputs": [[137, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar3", 
+      "attrs": {"scalar": "3"}, 
+      "inputs": [[137, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar4", 
+      "attrs": {"scalar": "4"}, 
+      "inputs": [[137, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar5", 
+      "attrs": {"scalar": "5"}, 
+      "inputs": [[137, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar6", 
+      "attrs": {"scalar": "6"}, 
+      "inputs": [[137, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar7", 
+      "attrs": {"scalar": "7"}, 
+      "inputs": [[137, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar8", 
+      "attrs": {"scalar": "8"}, 
+      "inputs": [[137, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar9", 
+      "attrs": {"scalar": "9"}, 
+      "inputs": [[137, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar10", 
+      "attrs": {"scalar": "10"}, 
+      "inputs": [[137, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar11", 
+      "attrs": {"scalar": "11"}, 
+      "inputs": [[137, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar12", 
+      "attrs": {"scalar": "12"}, 
+      "inputs": [[137, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar13", 
+      "attrs": {"scalar": "13"}, 
+      "inputs": [[137, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar14", 
+      "attrs": {"scalar": "14"}, 
+      "inputs": [[137, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar15", 
+      "attrs": {"scalar": "15"}, 
+      "inputs": [[137, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar16", 
+      "attrs": {"scalar": "16"}, 
+      "inputs": [[137, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar17", 
+      "attrs": {"scalar": "17"}, 
+      "inputs": [[137, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar18", 
+      "attrs": {"scalar": "18"}, 
+      "inputs": [[137, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_multiperclassdecoder0__plusscalar19", 
+      "attrs": {"scalar": "19"}, 
+      "inputs": [[137, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_multiperclassdecoder0_concat0", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "20"
+      }, 
+      "inputs": [
+        [138, 0, 0], 
+        [139, 0, 0], 
+        [140, 0, 0], 
+        [141, 0, 0], 
+        [142, 0, 0], 
+        [143, 0, 0], 
+        [144, 0, 0], 
+        [145, 0, 0], 
+        [146, 0, 0], 
+        [147, 0, 0], 
+        [148, 0, 0], 
+        [149, 0, 0], 
+        [150, 0, 0], 
+        [151, 0, 0], 
+        [152, 0, 0], 
+        [153, 0, 0], 
+        [154, 0, 0], 
+        [155, 0, 0], 
+        [156, 0, 0], 
+        [157, 0, 0]
+      ]
+    }, 
+    {
+      "op": "ones_like", 
+      "name": "ssd0_multiperclassdecoder0_ones_like0", 
+      "inputs": [[158, 0, 0]]
+    }, 
+    {
+      "op": "_mul_scalar", 
+      "name": "ssd0_multiperclassdecoder0__mulscalar0", 
+      "attrs": {"scalar": "-1"}, 
+      "inputs": [[159, 0, 0]]
+    }, 
+    {
+      "op": "where", 
+      "name": "ssd0_multiperclassdecoder0_where0", 
+      "inputs": [[135, 0, 0], [158, 0, 0], [160, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis0", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "0", 
+        "end": "1"
+      }, 
+      "inputs": [[161, 0, 0]]
+    }, 
+    {
+      "op": "zeros_like", 
+      "name": "ssd0_multiperclassdecoder0_zeros_like1", 
+      "inputs": [[134, 0, 0]]
+    }, 
+    {
+      "op": "where", 
+      "name": "ssd0_multiperclassdecoder0_where1", 
+      "inputs": [[135, 0, 0], [134, 0, 0], [163, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis1", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "0", 
+        "end": "1"
+      }, 
+      "inputs": [[164, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor1_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"uniform\", \"factor_type\": \"avg\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(16, 512, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor1_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(16,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_32", 
+      "attrs": {
+        "max_calib_range": "5.037223", 
+        "min_calib_range": "-13.463578", 
+        "quantized": "true"
+      }, 
+      "inputs": [[41, 0, 0], [166, 0, 0], [167, 0, 0], [41, 1, 0], [41, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "ssd0_vggatrousextractor0_normalize0_broadcast_mul0_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor1_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor1_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_convpredictor1_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "16", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4], 
+          "heads": [[3, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_32_dequantize", 
+      "inputs": [[168, 0, 0], [168, 1, 0], [168, 2, 0]]
+    }, 
+    {
+      "op": "transpose", 
+      "name": "ssd0_transpose7", 
+      "attrs": {"axes": "(0, 2, 3, 1)"}, 
+      "inputs": [[169, 0, 0]]
+    }, 
+    {
+      "op": "Flatten", 
+      "name": "ssd0_flatten7", 
+      "inputs": [[170, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor3_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"uniform\", \"factor_type\": \"avg\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(24, 1024, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor3_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(24,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_33", 
+      "attrs": {
+        "max_calib_range": "4.927182", 
+        "min_calib_range": "-5.132103", 
+        "quantized": "true"
+      }, 
+      "inputs": [[64, 0, 0], [172, 0, 0], [173, 0, 0], [64, 1, 0], [64, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_15_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor3_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor3_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_convpredictor3_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "24", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4], 
+          "heads": [[3, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_33_dequantize", 
+      "inputs": [[174, 0, 0], [174, 1, 0], [174, 2, 0]]
+    }, 
+    {
+      "op": "transpose", 
+      "name": "ssd0_transpose8", 
+      "attrs": {"axes": "(0, 2, 3, 1)"}, 
+      "inputs": [[175, 0, 0]]
+    }, 
+    {
+      "op": "Flatten", 
+      "name": "ssd0_flatten8", 
+      "inputs": [[176, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor5_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"uniform\", \"factor_type\": \"avg\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(24, 512, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor5_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(24,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_34", 
+      "attrs": {
+        "max_calib_range": "4.420295", 
+        "min_calib_range": "-4.391596", 
+        "quantized": "true"
+      }, 
+      "inputs": [[76, 0, 0], [178, 0, 0], [179, 0, 0], [76, 1, 0], [76, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_18_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor5_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor5_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_convpredictor5_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "24", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4], 
+          "heads": [[3, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_34_dequantize", 
+      "inputs": [[180, 0, 0], [180, 1, 0], [180, 2, 0]]
+    }, 
+    {
+      "op": "transpose", 
+      "name": "ssd0_transpose9", 
+      "attrs": {"axes": "(0, 2, 3, 1)"}, 
+      "inputs": [[181, 0, 0]]
+    }, 
+    {
+      "op": "Flatten", 
+      "name": "ssd0_flatten9", 
+      "inputs": [[182, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor7_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"uniform\", \"factor_type\": \"avg\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(24, 256, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor7_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(24,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_35", 
+      "attrs": {
+        "max_calib_range": "4.537238", 
+        "min_calib_range": "-4.054255", 
+        "quantized": "true"
+      }, 
+      "inputs": [[88, 0, 0], [184, 0, 0], [185, 0, 0], [88, 1, 0], [88, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_21_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor7_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor7_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_convpredictor7_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "24", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4], 
+          "heads": [[3, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_35_dequantize", 
+      "inputs": [[186, 0, 0], [186, 1, 0], [186, 2, 0]]
+    }, 
+    {
+      "op": "transpose", 
+      "name": "ssd0_transpose10", 
+      "attrs": {"axes": "(0, 2, 3, 1)"}, 
+      "inputs": [[187, 0, 0]]
+    }, 
+    {
+      "op": "Flatten", 
+      "name": "ssd0_flatten10", 
+      "inputs": [[188, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor9_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"uniform\", \"factor_type\": \"avg\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(24, 256, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor9_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(24,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_36", 
+      "attrs": {
+        "max_calib_range": "4.179194", 
+        "min_calib_range": "-4.483447", 
+        "quantized": "true"
+      }, 
+      "inputs": [[100, 0, 0], [190, 0, 0], [191, 0, 0], [100, 1, 0], [100, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_24_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor9_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor9_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_convpredictor9_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "24", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4], 
+          "heads": [[3, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_36_dequantize", 
+      "inputs": [[192, 0, 0], [192, 1, 0], [192, 2, 0]]
+    }, 
+    {
+      "op": "transpose", 
+      "name": "ssd0_transpose11", 
+      "attrs": {"axes": "(0, 2, 3, 1)"}, 
+      "inputs": [[193, 0, 0]]
+    }, 
+    {
+      "op": "Flatten", 
+      "name": "ssd0_flatten11", 
+      "inputs": [[194, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor11_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"uniform\", \"factor_type\": \"avg\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(16, 256, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor11_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(16,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_37", 
+      "attrs": {
+        "max_calib_range": "2.919856", 
+        "min_calib_range": "-3.472292", 
+        "quantized": "true"
+      }, 
+      "inputs": [[112, 0, 0], [196, 0, 0], [197, 0, 0], [112, 1, 0], [112, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_27_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor11_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor11_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_convpredictor11_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "16", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4], 
+          "heads": [[3, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_37_dequantize", 
+      "inputs": [[198, 0, 0], [198, 1, 0], [198, 2, 0]]
+    }, 
+    {
+      "op": "transpose", 
+      "name": "ssd0_transpose12", 
+      "attrs": {"axes": "(0, 2, 3, 1)"}, 
+      "inputs": [[199, 0, 0]]
+    }, 
+    {
+      "op": "Flatten", 
+      "name": "ssd0_flatten12", 
+      "inputs": [[200, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor13_conv0_weight", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "[\"xavier\", {\"rnd_type\": \"uniform\", \"factor_type\": \"avg\", \"magnitude\": 2}]", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(16, 256, 3, 3)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_convpredictor13_conv0_bias", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "zeros", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(16,)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_sg_mkldnn_conv", 
+      "name": "quantized_sg_mkldnn_conv_38", 
+      "attrs": {
+        "max_calib_range": "2.413904", 
+        "min_calib_range": "-3.667528", 
+        "quantized": "true"
+      }, 
+      "inputs": [[124, 0, 0], [202, 0, 0], [203, 0, 0], [124, 1, 0], [124, 2, 0]], 
+      "subgraphs": [
+        {
+          "nodes": [
+            {
+              "op": "null", 
+              "name": "sg_mkldnn_conv_relu_30_output0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor13_conv0_weight0", 
+              "inputs": []
+            }, 
+            {
+              "op": "null", 
+              "name": "ssd0_convpredictor13_conv0_bias0", 
+              "inputs": []
+            }, 
+            {
+              "op": "Convolution", 
+              "name": "ssd0_convpredictor13_conv0_fwd", 
+              "attrs": {
+                "dilate": "(1, 1)", 
+                "kernel": "(3, 3)", 
+                "layout": "NCHW", 
+                "no_bias": "False", 
+                "num_filter": "16", 
+                "num_group": "1", 
+                "pad": "(1, 1)", 
+                "stride": "(1, 1)"
+              }, 
+              "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+            }
+          ], 
+          "arg_nodes": [0, 1, 2], 
+          "node_row_ptr": [0, 1, 2, 3, 4], 
+          "heads": [[3, 0, 0]]
+        }
+      ]
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_38_dequantize", 
+      "inputs": [[204, 0, 0], [204, 1, 0], [204, 2, 0]]
+    }, 
+    {
+      "op": "transpose", 
+      "name": "ssd0_transpose13", 
+      "attrs": {"axes": "(0, 2, 3, 1)"}, 
+      "inputs": [[205, 0, 0]]
+    }, 
+    {
+      "op": "Flatten", 
+      "name": "ssd0_flatten13", 
+      "inputs": [[206, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat1", 
+      "attrs": {
+        "dim": "1", 
+        "num_args": "7"
+      }, 
+      "inputs": [[171, 0, 0], [177, 0, 0], [183, 0, 0], [189, 0, 0], [195, 0, 0], [201, 0, 0], [207, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_reshape8", 
+      "attrs": {"shape": "(0, -1, 4)"}, 
+      "inputs": [[208, 0, 0]]
+    }, 
+    {
+      "op": "SliceChannel", 
+      "name": "ssd0_normalizedboxcenterdecoder0_split1", 
+      "attrs": {
+        "axis": "-1", 
+        "num_outputs": "4"
+      }, 
+      "inputs": [[209, 0, 0]]
+    }, 
+    {
+      "op": "_mul_scalar", 
+      "name": "ssd0_normalizedboxcenterdecoder0__mulscalar0", 
+      "attrs": {"scalar": "0.1"}, 
+      "inputs": [[210, 0, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_normalizedboxcenterdecoder0__plusscalar0", 
+      "attrs": {"scalar": "0.0"}, 
+      "inputs": [[211, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_ssdanchorgenerator0_anchor_0", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "Constant_ssd0_ssdanchorgenerator0_anchor_0_139783361597904", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1, 1, 128, 128, 16)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_mul_scalar", 
+      "name": "ssd0_ssdanchorgenerator0__mulscalar0", 
+      "attrs": {"scalar": "0"}, 
+      "inputs": [[40, 0, 0]]
+    }, 
+    {
+      "op": "slice_like", 
+      "name": "ssd0_ssdanchorgenerator0_slice_like0", 
+      "attrs": {"axes": "(2, 3)"}, 
+      "inputs": [[213, 0, 0], [214, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_ssdanchorgenerator0_reshape0", 
+      "attrs": {"shape": "(1, -1, 4)"}, 
+      "inputs": [[215, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_ssdanchorgenerator0_reshape1", 
+      "attrs": {"shape": "(1, -1, 4)"}, 
+      "inputs": [[216, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_reshape0", 
+      "attrs": {"shape": "(1, -1)"}, 
+      "inputs": [[217, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_ssdanchorgenerator1_anchor_1", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "Constant_ssd0_ssdanchorgenerator1_anchor_1_139788581476784", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1, 1, 64, 64, 24)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_relu_15_dequantize", 
+      "inputs": [[64, 0, 0], [64, 1, 0], [64, 2, 0]]
+    }, 
+    {
+      "op": "_mul_scalar", 
+      "name": "ssd0_ssdanchorgenerator1__mulscalar0", 
+      "attrs": {"scalar": "0"}, 
+      "inputs": [[220, 0, 0]]
+    }, 
+    {
+      "op": "slice_like", 
+      "name": "ssd0_ssdanchorgenerator1_slice_like0", 
+      "attrs": {"axes": "(2, 3)"}, 
+      "inputs": [[219, 0, 0], [221, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_ssdanchorgenerator1_reshape0", 
+      "attrs": {"shape": "(1, -1, 4)"}, 
+      "inputs": [[222, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_ssdanchorgenerator1_reshape1", 
+      "attrs": {"shape": "(1, -1, 4)"}, 
+      "inputs": [[223, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_reshape1", 
+      "attrs": {"shape": "(1, -1)"}, 
+      "inputs": [[224, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_ssdanchorgenerator2_anchor_2", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "Constant_ssd0_ssdanchorgenerator2_anchor_2_139783352913480", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1, 1, 32, 32, 24)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_relu_18_dequantize", 
+      "inputs": [[76, 0, 0], [76, 1, 0], [76, 2, 0]]
+    }, 
+    {
+      "op": "_mul_scalar", 
+      "name": "ssd0_ssdanchorgenerator2__mulscalar0", 
+      "attrs": {"scalar": "0"}, 
+      "inputs": [[227, 0, 0]]
+    }, 
+    {
+      "op": "slice_like", 
+      "name": "ssd0_ssdanchorgenerator2_slice_like0", 
+      "attrs": {"axes": "(2, 3)"}, 
+      "inputs": [[226, 0, 0], [228, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_ssdanchorgenerator2_reshape0", 
+      "attrs": {"shape": "(1, -1, 4)"}, 
+      "inputs": [[229, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_ssdanchorgenerator2_reshape1", 
+      "attrs": {"shape": "(1, -1, 4)"}, 
+      "inputs": [[230, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_reshape2", 
+      "attrs": {"shape": "(1, -1)"}, 
+      "inputs": [[231, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_ssdanchorgenerator3_anchor_3", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "Constant_ssd0_ssdanchorgenerator3_anchor_3_139783352913816", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1, 1, 16, 16, 24)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_relu_21_dequantize", 
+      "inputs": [[88, 0, 0], [88, 1, 0], [88, 2, 0]]
+    }, 
+    {
+      "op": "_mul_scalar", 
+      "name": "ssd0_ssdanchorgenerator3__mulscalar0", 
+      "attrs": {"scalar": "0"}, 
+      "inputs": [[234, 0, 0]]
+    }, 
+    {
+      "op": "slice_like", 
+      "name": "ssd0_ssdanchorgenerator3_slice_like0", 
+      "attrs": {"axes": "(2, 3)"}, 
+      "inputs": [[233, 0, 0], [235, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_ssdanchorgenerator3_reshape0", 
+      "attrs": {"shape": "(1, -1, 4)"}, 
+      "inputs": [[236, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_ssdanchorgenerator3_reshape1", 
+      "attrs": {"shape": "(1, -1, 4)"}, 
+      "inputs": [[237, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_reshape3", 
+      "attrs": {"shape": "(1, -1)"}, 
+      "inputs": [[238, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_ssdanchorgenerator4_anchor_4", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "Constant_ssd0_ssdanchorgenerator4_anchor_4_139783361523160", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1, 1, 16, 16, 24)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_relu_24_dequantize", 
+      "inputs": [[100, 0, 0], [100, 1, 0], [100, 2, 0]]
+    }, 
+    {
+      "op": "_mul_scalar", 
+      "name": "ssd0_ssdanchorgenerator4__mulscalar0", 
+      "attrs": {"scalar": "0"}, 
+      "inputs": [[241, 0, 0]]
+    }, 
+    {
+      "op": "slice_like", 
+      "name": "ssd0_ssdanchorgenerator4_slice_like0", 
+      "attrs": {"axes": "(2, 3)"}, 
+      "inputs": [[240, 0, 0], [242, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_ssdanchorgenerator4_reshape0", 
+      "attrs": {"shape": "(1, -1, 4)"}, 
+      "inputs": [[243, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_ssdanchorgenerator4_reshape1", 
+      "attrs": {"shape": "(1, -1, 4)"}, 
+      "inputs": [[244, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_reshape4", 
+      "attrs": {"shape": "(1, -1)"}, 
+      "inputs": [[245, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_ssdanchorgenerator5_anchor_5", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "Constant_ssd0_ssdanchorgenerator5_anchor_5_139783361523048", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1, 1, 16, 16, 16)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_relu_27_dequantize", 
+      "inputs": [[112, 0, 0], [112, 1, 0], [112, 2, 0]]
+    }, 
+    {
+      "op": "_mul_scalar", 
+      "name": "ssd0_ssdanchorgenerator5__mulscalar0", 
+      "attrs": {"scalar": "0"}, 
+      "inputs": [[248, 0, 0]]
+    }, 
+    {
+      "op": "slice_like", 
+      "name": "ssd0_ssdanchorgenerator5_slice_like0", 
+      "attrs": {"axes": "(2, 3)"}, 
+      "inputs": [[247, 0, 0], [249, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_ssdanchorgenerator5_reshape0", 
+      "attrs": {"shape": "(1, -1, 4)"}, 
+      "inputs": [[250, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_ssdanchorgenerator5_reshape1", 
+      "attrs": {"shape": "(1, -1, 4)"}, 
+      "inputs": [[251, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_reshape5", 
+      "attrs": {"shape": "(1, -1)"}, 
+      "inputs": [[252, 0, 0]]
+    }, 
+    {
+      "op": "null", 
+      "name": "ssd0_ssdanchorgenerator6_anchor_6", 
+      "attrs": {
+        "__dtype__": "0", 
+        "__init__": "Constant_ssd0_ssdanchorgenerator6_anchor_6_139783352474424", 
+        "__lr_mult__": "1.0", 
+        "__shape__": "(1, 1, 16, 16, 16)", 
+        "__storage_type__": "0", 
+        "__wd_mult__": "1.0"
+      }, 
+      "inputs": []
+    }, 
+    {
+      "op": "_contrib_dequantize", 
+      "name": "sg_mkldnn_conv_relu_30_dequantize", 
+      "inputs": [[124, 0, 0], [124, 1, 0], [124, 2, 0]]
+    }, 
+    {
+      "op": "_mul_scalar", 
+      "name": "ssd0_ssdanchorgenerator6__mulscalar0", 
+      "attrs": {"scalar": "0"}, 
+      "inputs": [[255, 0, 0]]
+    }, 
+    {
+      "op": "slice_like", 
+      "name": "ssd0_ssdanchorgenerator6_slice_like0", 
+      "attrs": {"axes": "(2, 3)"}, 
+      "inputs": [[254, 0, 0], [256, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_ssdanchorgenerator6_reshape0", 
+      "attrs": {"shape": "(1, -1, 4)"}, 
+      "inputs": [[257, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_ssdanchorgenerator6_reshape1", 
+      "attrs": {"shape": "(1, -1, 4)"}, 
+      "inputs": [[258, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_reshape6", 
+      "attrs": {"shape": "(1, -1)"}, 
+      "inputs": [[259, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat2", 
+      "attrs": {
+        "dim": "1", 
+        "num_args": "7"
+      }, 
+      "inputs": [[218, 0, 0], [225, 0, 0], [232, 0, 0], [239, 0, 0], [246, 0, 0], [253, 0, 0], [260, 0, 0]]
+    }, 
+    {
+      "op": "Reshape", 
+      "name": "ssd0_reshape9", 
+      "attrs": {"shape": "(1, -1, 4)"}, 
+      "inputs": [[261, 0, 0]]
+    }, 
+    {
+      "op": "SliceChannel", 
+      "name": "ssd0_normalizedboxcenterdecoder0_split0", 
+      "attrs": {
+        "axis": "-1", 
+        "num_outputs": "4"
+      }, 
+      "inputs": [[262, 0, 0]]
+    }, 
+    {
+      "op": "broadcast_mul", 
+      "name": "ssd0_normalizedboxcenterdecoder0_broadcast_mul0", 
+      "inputs": [[212, 0, 0], [263, 2, 0]]
+    }, 
+    {
+      "op": "broadcast_add", 
+      "name": "ssd0_normalizedboxcenterdecoder0_broadcast_add0", 
+      "inputs": [[264, 0, 0], [263, 0, 0]]
+    }, 
+    {
+      "op": "_mul_scalar", 
+      "name": "ssd0_normalizedboxcenterdecoder0__mulscalar2", 
+      "attrs": {"scalar": "0.2"}, 
+      "inputs": [[210, 2, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_normalizedboxcenterdecoder0__plusscalar2", 
+      "attrs": {"scalar": "0.0"}, 
+      "inputs": [[266, 0, 0]]
+    }, 
+    {
+      "op": "exp", 
+      "name": "ssd0_normalizedboxcenterdecoder0_exp0", 
+      "inputs": [[267, 0, 0]]
+    }, 
+    {
+      "op": "broadcast_mul", 
+      "name": "ssd0_normalizedboxcenterdecoder0_broadcast_mul2", 
+      "inputs": [[268, 0, 0], [263, 2, 0]]
+    }, 
+    {
+      "op": "_div_scalar", 
+      "name": "ssd0_normalizedboxcenterdecoder0__divscalar0", 
+      "attrs": {"scalar": "2"}, 
+      "inputs": [[269, 0, 0]]
+    }, 
+    {
+      "op": "elemwise_sub", 
+      "name": "ssd0_normalizedboxcenterdecoder0__minus0", 
+      "inputs": [[265, 0, 0], [270, 0, 0]]
+    }, 
+    {
+      "op": "_mul_scalar", 
+      "name": "ssd0_normalizedboxcenterdecoder0__mulscalar1", 
+      "attrs": {"scalar": "0.1"}, 
+      "inputs": [[210, 1, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_normalizedboxcenterdecoder0__plusscalar1", 
+      "attrs": {"scalar": "0.0"}, 
+      "inputs": [[272, 0, 0]]
+    }, 
+    {
+      "op": "broadcast_mul", 
+      "name": "ssd0_normalizedboxcenterdecoder0_broadcast_mul1", 
+      "inputs": [[273, 0, 0], [263, 3, 0]]
+    }, 
+    {
+      "op": "broadcast_add", 
+      "name": "ssd0_normalizedboxcenterdecoder0_broadcast_add1", 
+      "inputs": [[274, 0, 0], [263, 1, 0]]
+    }, 
+    {
+      "op": "_mul_scalar", 
+      "name": "ssd0_normalizedboxcenterdecoder0__mulscalar3", 
+      "attrs": {"scalar": "0.2"}, 
+      "inputs": [[210, 3, 0]]
+    }, 
+    {
+      "op": "_plus_scalar", 
+      "name": "ssd0_normalizedboxcenterdecoder0__plusscalar3", 
+      "attrs": {"scalar": "0.0"}, 
+      "inputs": [[276, 0, 0]]
+    }, 
+    {
+      "op": "exp", 
+      "name": "ssd0_normalizedboxcenterdecoder0_exp1", 
+      "inputs": [[277, 0, 0]]
+    }, 
+    {
+      "op": "broadcast_mul", 
+      "name": "ssd0_normalizedboxcenterdecoder0_broadcast_mul3", 
+      "inputs": [[278, 0, 0], [263, 3, 0]]
+    }, 
+    {
+      "op": "_div_scalar", 
+      "name": "ssd0_normalizedboxcenterdecoder0__divscalar1", 
+      "attrs": {"scalar": "2"}, 
+      "inputs": [[279, 0, 0]]
+    }, 
+    {
+      "op": "elemwise_sub", 
+      "name": "ssd0_normalizedboxcenterdecoder0__minus1", 
+      "inputs": [[275, 0, 0], [280, 0, 0]]
+    }, 
+    {
+      "op": "elemwise_add", 
+      "name": "ssd0_normalizedboxcenterdecoder0__plus0", 
+      "inputs": [[265, 0, 0], [270, 0, 0]]
+    }, 
+    {
+      "op": "elemwise_add", 
+      "name": "ssd0_normalizedboxcenterdecoder0__plus1", 
+      "inputs": [[275, 0, 0], [280, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_normalizedboxcenterdecoder0_concat0", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "4"
+      }, 
+      "inputs": [[271, 0, 0], [281, 0, 0], [282, 0, 0], [283, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat3", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[162, 0, 0], [165, 0, 0], [284, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis2", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "1", 
+        "end": "2"
+      }, 
+      "inputs": [[161, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis3", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "1", 
+        "end": "2"
+      }, 
+      "inputs": [[164, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat4", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[286, 0, 0], [287, 0, 0], [284, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis4", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "2", 
+        "end": "3"
+      }, 
+      "inputs": [[161, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis5", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "2", 
+        "end": "3"
+      }, 
+      "inputs": [[164, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat5", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[289, 0, 0], [290, 0, 0], [284, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis6", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "3", 
+        "end": "4"
+      }, 
+      "inputs": [[161, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis7", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "3", 
+        "end": "4"
+      }, 
+      "inputs": [[164, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat6", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[292, 0, 0], [293, 0, 0], [284, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis8", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "4", 
+        "end": "5"
+      }, 
+      "inputs": [[161, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis9", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "4", 
+        "end": "5"
+      }, 
+      "inputs": [[164, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat7", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[295, 0, 0], [296, 0, 0], [284, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis10", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "5", 
+        "end": "6"
+      }, 
+      "inputs": [[161, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis11", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "5", 
+        "end": "6"
+      }, 
+      "inputs": [[164, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat8", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[298, 0, 0], [299, 0, 0], [284, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis12", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "6", 
+        "end": "7"
+      }, 
+      "inputs": [[161, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis13", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "6", 
+        "end": "7"
+      }, 
+      "inputs": [[164, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat9", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[301, 0, 0], [302, 0, 0], [284, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis14", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "7", 
+        "end": "8"
+      }, 
+      "inputs": [[161, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis15", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "7", 
+        "end": "8"
+      }, 
+      "inputs": [[164, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat10", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[304, 0, 0], [305, 0, 0], [284, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis16", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "8", 
+        "end": "9"
+      }, 
+      "inputs": [[161, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis17", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "8", 
+        "end": "9"
+      }, 
+      "inputs": [[164, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat11", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[307, 0, 0], [308, 0, 0], [284, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis18", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "9", 
+        "end": "10"
+      }, 
+      "inputs": [[161, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis19", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "9", 
+        "end": "10"
+      }, 
+      "inputs": [[164, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat12", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[310, 0, 0], [311, 0, 0], [284, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis20", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "10", 
+        "end": "11"
+      }, 
+      "inputs": [[161, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis21", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "10", 
+        "end": "11"
+      }, 
+      "inputs": [[164, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat13", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[313, 0, 0], [314, 0, 0], [284, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis22", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "11", 
+        "end": "12"
+      }, 
+      "inputs": [[161, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis23", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "11", 
+        "end": "12"
+      }, 
+      "inputs": [[164, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat14", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[316, 0, 0], [317, 0, 0], [284, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis24", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "12", 
+        "end": "13"
+      }, 
+      "inputs": [[161, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis25", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "12", 
+        "end": "13"
+      }, 
+      "inputs": [[164, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat15", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[319, 0, 0], [320, 0, 0], [284, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis26", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "13", 
+        "end": "14"
+      }, 
+      "inputs": [[161, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis27", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "13", 
+        "end": "14"
+      }, 
+      "inputs": [[164, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat16", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[322, 0, 0], [323, 0, 0], [284, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis28", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "14", 
+        "end": "15"
+      }, 
+      "inputs": [[161, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis29", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "14", 
+        "end": "15"
+      }, 
+      "inputs": [[164, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat17", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[325, 0, 0], [326, 0, 0], [284, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis30", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "15", 
+        "end": "16"
+      }, 
+      "inputs": [[161, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis31", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "15", 
+        "end": "16"
+      }, 
+      "inputs": [[164, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat18", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[328, 0, 0], [329, 0, 0], [284, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis32", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "16", 
+        "end": "17"
+      }, 
+      "inputs": [[161, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis33", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "16", 
+        "end": "17"
+      }, 
+      "inputs": [[164, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat19", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[331, 0, 0], [332, 0, 0], [284, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis34", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "17", 
+        "end": "18"
+      }, 
+      "inputs": [[161, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis35", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "17", 
+        "end": "18"
+      }, 
+      "inputs": [[164, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat20", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[334, 0, 0], [335, 0, 0], [284, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis36", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "18", 
+        "end": "19"
+      }, 
+      "inputs": [[161, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis37", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "18", 
+        "end": "19"
+      }, 
+      "inputs": [[164, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat21", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[337, 0, 0], [338, 0, 0], [284, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis38", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "19", 
+        "end": "20"
+      }, 
+      "inputs": [[161, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis39", 
+      "attrs": {
+        "axis": "-1", 
+        "begin": "19", 
+        "end": "20"
+      }, 
+      "inputs": [[164, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat22", 
+      "attrs": {
+        "dim": "-1", 
+        "num_args": "3"
+      }, 
+      "inputs": [[340, 0, 0], [341, 0, 0], [284, 0, 0]]
+    }, 
+    {
+      "op": "Concat", 
+      "name": "ssd0_concat23", 
+      "attrs": {
+        "dim": "1", 
+        "num_args": "20"
+      }, 
+      "inputs": [
+        [285, 0, 0], 
+        [288, 0, 0], 
+        [291, 0, 0], 
+        [294, 0, 0], 
+        [297, 0, 0], 
+        [300, 0, 0], 
+        [303, 0, 0], 
+        [306, 0, 0], 
+        [309, 0, 0], 
+        [312, 0, 0], 
+        [315, 0, 0], 
+        [318, 0, 0], 
+        [321, 0, 0], 
+        [324, 0, 0], 
+        [327, 0, 0], 
+        [330, 0, 0], 
+        [333, 0, 0], 
+        [336, 0, 0], 
+        [339, 0, 0], 
+        [342, 0, 0]
+      ]
+    }, 
+    {
+      "op": "_contrib_box_nms", 
+      "name": "ssd0_box_nms0", 
+      "attrs": {
+        "coord_start": "2", 
+        "force_suppress": "False", 
+        "id_index": "0", 
+        "overlap_thresh": "0.45", 
+        "score_index": "1", 
+        "topk": "200", 
+        "valid_thresh": "0.01"
+      }, 
+      "inputs": [[343, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis40", 
+      "attrs": {
+        "axis": "1", 
+        "begin": "0", 
+        "end": "100"
+      }, 
+      "inputs": [[344, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis41", 
+      "attrs": {
+        "axis": "2", 
+        "begin": "0", 
+        "end": "1"
+      }, 
+      "inputs": [[345, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis42", 
+      "attrs": {
+        "axis": "2", 
+        "begin": "1", 
+        "end": "2"
+      }, 
+      "inputs": [[345, 0, 0]]
+    }, 
+    {
+      "op": "slice_axis", 
+      "name": "ssd0_slice_axis43", 
+      "attrs": {
+        "axis": "2", 
+        "begin": "2", 
+        "end": "6"
+      }, 
+      "inputs": [[345, 0, 0]]
+    }
+  ], 
+  "arg_nodes": [
+    0, 
+    1, 
+    4, 
+    5, 
+    7, 
+    8, 
+    11, 
+    12, 
+    14, 
+    15, 
+    18, 
+    19, 
+    21, 
+    22, 
+    24, 
+    25, 
+    28, 
+    29, 
+    31, 
+    32, 
+    34, 
+    35, 
+    39, 
+    42, 
+    43, 
+    49, 
+    50, 
+    52, 
+    53, 
+    55, 
+    56, 
+    59, 
+    60, 
+    62, 
+    63, 
+    65, 
+    66, 
+    71, 
+    72, 
+    74, 
+    75, 
+    77, 
+    78, 
+    83, 
+    84, 
+    86, 
+    87, 
+    89, 
+    90, 
+    95, 
+    96, 
+    98, 
+    99, 
+    101, 
+    102, 
+    107, 
+    108, 
+    110, 
+    111, 
+    113, 
+    114, 
+    119, 
+    120, 
+    122, 
+    123, 
+    125, 
+    126, 
+    166, 
+    167, 
+    172, 
+    173, 
+    178, 
+    179, 
+    184, 
+    185, 
+    190, 
+    191, 
+    196, 
+    197, 
+    202, 
+    203, 
+    213, 
+    219, 
+    226, 
+    233, 
+    240, 
+    247, 
+    254
+  ], 
+  "node_row_ptr": [
+    0, 
+    1, 
+    2, 
+    3, 
+    6, 
+    7, 
+    8, 
+    11, 
+    12, 
+    13, 
+    16, 
+    19, 
+    20, 
+    21, 
+    24, 
+    25, 
+    26, 
+    29, 
+    32, 
+    33, 
+    34, 
+    37, 
+    38, 
+    39, 
+    42, 
+    43, 
+    44, 
+    47, 
+    50, 
+    51, 
+    52, 
+    55, 
+    56, 
+    57, 
+    60, 
+    61, 
+    62, 
+    65, 
+    66, 
+    68, 
+    69, 
+    70, 
+    73, 
+    74, 
+    75, 
+    78, 
+    79, 
+    80, 
+    81, 
+    84, 
+    85, 
+    86, 
+    89, 
+    90, 
+    91, 
+    94, 
+    95, 
+    96, 
+    99, 
+    102, 
+    103, 
+    104, 
+    107, 
+    108, 
+    109, 
+    112, 
+    113, 
+    114, 
+    117, 
+    118, 
+    119, 
+    120, 
+    121, 
+    122, 
+    125, 
+    126, 
+    127, 
+    130, 
+    131, 
+    132, 
+    135, 
+    136, 
+    137, 
+    138, 
+    139, 
+    140, 
+    143, 
+    144, 
+    145, 
+    148, 
+    149, 
+    150, 
+    153, 
+    154, 
+    155, 
+    156, 
+    157, 
+    158, 
+    161, 
+    162, 
+    163, 
+    166, 
+    167, 
+    168, 
+    171, 
+    172, 
+    173, 
+    174, 
+    175, 
+    176, 
+    179, 
+    180, 
+    181, 
+    184, 
+    185, 
+    186, 
+    189, 
+    190, 
+    191, 
+    192, 
+    193, 
+    194, 
+    197, 
+    198, 
+    199, 
+    202, 
+    203, 
+    204, 
+    207, 
+    208, 
+    209, 
+    210, 
+    211, 
+    212, 
+    213, 
+    214, 
+    215, 
+    216, 
+    217, 
+    218, 
+    219, 
+    220, 
+    221, 
+    222, 
+    223, 
+    224, 
+    225, 
+    226, 
+    227, 
+    228, 
+    229, 
+    230, 
+    231, 
+    232, 
+    233, 
+    234, 
+    235, 
+    236, 
+    237, 
+    238, 
+    239, 
+    240, 
+    241, 
+    242, 
+    243, 
+    244, 
+    245, 
+    246, 
+    247, 
+    250, 
+    251, 
+    252, 
+    253, 
+    254, 
+    255, 
+    258, 
+    259, 
+    260, 
+    261, 
+    262, 
+    263, 
+    266, 
+    267, 
+    268, 
+    269, 
+    270, 
+    271, 
+    274, 
+    275, 
+    276, 
+    277, 
+    278, 
+    279, 
+    282, 
+    283, 
+    284, 
+    285, 
+    286, 
+    287, 
+    290, 
+    291, 
+    292, 
+    293, 
+    294, 
+    295, 
+    298, 
+    299, 
+    300, 
+    301, 
+    302, 
+    303, 
+    307, 
+    308, 
+    309, 
+    310, 
+    311, 
+    312, 
+    313, 
+    314, 
+    315, 
+    316, 
+    317, 
+    318, 
+    319, 
+    320, 
+    321, 
+    322, 
+    323, 
+    324, 
+    325, 
+    326, 
+    327, 
+    328, 
+    329, 
+    330, 
+    331, 
+    332, 
+    333, 
+    334, 
+    335, 
+    336, 
+    337, 
+    338, 
+    339, 
+    340, 
+    341, 
+    342, 
+    343, 
+    344, 
+    345, 
+    346, 
+    347, 
+    348, 
+    349, 
+    350, 
+    351, 
+    352, 
+    353, 
+    354, 
+    355, 
+    356, 
+    357, 
+    358, 
+    359, 
+    363, 
+    364, 
+    365, 
+    366, 
+    367, 
+    368, 
+    369, 
+    370, 
+    371, 
+    372, 
+    373, 
+    374, 
+    375, 
+    376, 
+    377, 
+    378, 
+    379, 
+    380, 
+    381, 
+    382, 
+    383, 
+    384, 
+    385, 
+    386, 
+    387, 
+    388, 
+    389, 
+    390, 
+    391, 
+    392, 
+    393, 
+    394, 
+    395, 
+    396, 
+    397, 
+    398, 
+    399, 
+    400, 
+    401, 
+    402, 
+    403, 
+    404, 
+    405, 
+    406, 
+    407, 
+    408, 
+    409, 
+    410, 
+    411, 
+    412, 
+    413, 
+    414, 
+    415, 
+    416, 
+    417, 
+    418, 
+    419, 
+    420, 
+    421, 
+    422, 
+    423, 
+    424, 
+    425, 
+    426, 
+    427, 
+    428, 
+    429, 
+    430, 
+    431, 
+    432, 
+    433, 
+    434, 
+    435, 
+    436, 
+    437, 
+    438, 
+    439, 
+    440, 
+    441, 
+    442, 
+    443, 
+    445, 
+    446, 
+    447, 
+    448, 
+    449
+  ], 
+  "heads": [[346, 0, 0], [347, 0, 0], [348, 0, 0]], 
+  "attrs": {"mxnet_version": ["int", 10500]}
+}

--- a/scripts/detection/ssd/eval_ssd.py
+++ b/scripts/detection/ssd/eval_ssd.py
@@ -21,16 +21,18 @@ def parse_args():
     parser = argparse.ArgumentParser(description='Eval SSD networks.')
     parser.add_argument('--network', type=str, default='vgg16_atrous',
                         help="Base network name")
+    parser.add_argument('--quantized', action='store_true',
+                        help='use int8 pretrained model')
     parser.add_argument('--data-shape', type=int, default=300,
                         help="Input data shape")
     parser.add_argument('--batch-size', type=int, default=64,
-                        help='Training mini-batch size')
+                        help='eval mini-batch size')
     parser.add_argument('--dataset', type=str, default='voc',
-                        help='Training dataset.')
+                        help='eval dataset.')
     parser.add_argument('--num-workers', '-j', dest='num_workers', type=int,
                         default=4, help='Number of data workers')
-    parser.add_argument('--gpus', type=str, default='0',
-                        help='Training with GPUs, you can specify 1,3 for example.')
+    parser.add_argument('--num-gpus', type=int, default=0,
+                        help='number of gpus to use.')
     parser.add_argument('--pretrained', type=str, default='True',
                         help='Load weights from previously saved parameters.')
     parser.add_argument('--save-prefix', type=str, default='',
@@ -64,9 +66,11 @@ def validate(net, val_data, ctx, classes, size, metric):
     """Test on validation dataset."""
     net.collect_params().reset_ctx(ctx)
     metric.reset()
-    net.set_nms(nms_thresh=0.45, nms_topk=400)
+    if not args.quantized:
+        net.set_nms(nms_thresh=0.45, nms_topk=400)
     net.hybridize()
     with tqdm(total=size) as pbar:
+        start = time.time()
         for ib, batch in enumerate(val_data):
             data = gluon.utils.split_and_load(batch[0], ctx_list=ctx, batch_axis=0, even_split=False)
             label = gluon.utils.split_and_load(batch[1], ctx_list=ctx, batch_axis=0, even_split=False)
@@ -89,17 +93,24 @@ def validate(net, val_data, ctx, classes, size, metric):
 
             metric.update(det_bboxes, det_ids, det_scores, gt_bboxes, gt_ids, gt_difficults)
             pbar.update(batch[0].shape[0])
+        end = time.time()
+        speed = size / (end - start)
+        print('Throughput is %f img/sec.'% speed)
     return metric.get()
 
 if __name__ == '__main__':
     args = parse_args()
 
-    # training contexts
-    ctx = [mx.gpu(int(i)) for i in args.gpus.split(',') if i.strip()]
-    ctx = ctx if ctx else [mx.cpu()]
+    # eval contexts
+    num_gpus = args.num_gpus
+    if num_gpus > 0:
+        args.batch_size *= num_gpus
+    ctx = [mx.gpu(i) for i in range(num_gpus)] if num_gpus > 0 else [mx.cpu()]
 
     # network
     net_name = '_'.join(('ssd', str(args.data_shape), args.network, args.dataset))
+    if args.quantized:
+        net_name = '_'.join((net_name, 'int8'))
     args.save_prefix += net_name
     if args.pretrained.lower() in ['true', '1', 'yes', 't']:
         net = gcv.model_zoo.get_model(net_name, pretrained=True)
@@ -107,13 +118,13 @@ if __name__ == '__main__':
         net = gcv.model_zoo.get_model(net_name, pretrained=False)
         net.load_parameters(args.pretrained.strip())
 
-    # training data
+    # eval data
     val_dataset, val_metric = get_dataset(args.dataset, args.data_shape)
     val_data = get_dataloader(
         val_dataset, args.data_shape, args.batch_size, args.num_workers)
     classes = val_dataset.classes  # class names
 
-    # training
+    # eval
     names, values = validate(net, val_data, ctx, classes, len(val_dataset), val_metric)
     for k, v in zip(names, values):
         print(k, v)

--- a/tests/py2.yml
+++ b/tests/py2.yml
@@ -11,7 +11,7 @@ dependencies:
   - scipy
   - pip=9.0.3
   - pip:
-    - mxnet-cu92mkl==1.5.0b20190115
+    - mxnet-cu92mkl==1.5.0b20190314
     - coverage-badge
     - awscli
     - nose-timer

--- a/tests/py3.yml
+++ b/tests/py3.yml
@@ -11,7 +11,7 @@ dependencies:
   - scipy
   - pip=9.0.3
   - pip:
-    - mxnet-cu92mkl==1.5.0b20190115
+    - mxnet-cu92mkl==1.5.0b20190314
     - coverage-badge
     - awscli
     - nose-timer

--- a/tests/unittests/test_model_zoo.py
+++ b/tests/unittests/test_model_zoo.py
@@ -315,7 +315,7 @@ def test_segmentation_models():
     _test_model_list(models, ctx, x, pretrained=False, pretrained_base=False)
     _test_model_list(models, ctx, x, pretrained=False, pretrained_base=True)
 
-
+@with_cpu(0)
 def test_mobilenet_sync_bn():
     model_name = "mobilenet1.0"
     net = gcv.model_zoo.get_model(model_name, pretrained=True)
@@ -324,6 +324,20 @@ def test_mobilenet_sync_bn():
                                   norm_layer=mx.gluon.contrib.nn.SyncBatchNorm, norm_kwargs={'num_devices': 2})
     net.load_parameters(model_name + '.params')
 
+@with_cpu(0)
+def test_quantized_imagenet_models():
+    model_list = ['mobilenet1.0_int8', 'resnet50_v1_int8']
+    ctx = mx.context.current_context()
+    x = mx.random.uniform(shape=(1, 3, 224, 224), ctx=ctx)
+    _test_model_list(model_list, ctx, x)
+
+@with_cpu(0)
+def test_quantized_ssd_models():
+    model_list = ['ssd_300_vgg16_atrous_voc_int8', 'ssd_512_mobilenet1.0_voc_int8',
+    'ssd_512_resnet50_v1_voc_int8', 'ssd_512_vgg16_atrous_voc_int8']
+    ctx = mx.context.current_context()
+    x = mx.random.uniform(shape=(1, 3, 512, 544), ctx=ctx)
+    _test_model_list(model_list, ctx, x)
 
 if __name__ == '__main__':
     import nose


### PR DESCRIPTION
Add two quantized classification models and four quantized detection models to GluonCV modelzoo for inference. Below is the performance on AWS EC2 c5.18xlarge instance and accuracy of these models:


Model | Dataset | Batch Size | C5.18xlargeFP32 | C5.18xlargeINT8 | Speedup | FP32 Accuracy | INT8 Accuracy
-- | -- | -- | -- | -- | -- | -- | --
ResNet50 V1 | ImageNet | 128 | 122.02 | 276.72 | 2.27 | 77.21%93.55% | 76.86%/93.46
MobileNet 1.0 | ImageNet | 128 | 375.33 | 1016.39 | 2.71 | 73.28%/91.22% | 72.85%/90.99%
SSD VGG 300* | VOC | 224 | 21.55 | 31.47 | 1.46 | 77.4 | 77.46
SSD VGG 512* | VOC | 224 | 7.63 | 11.69 | 1.53 | 78.41 | 78.39
SSD resnet50_v1 512* | VOC | 224 | 17.81 | 34.55 | 1.94 | 80.21 | 80.16
SSD mobilenet1.0 512* | VOC | 224 | 31.13 | 48.72 | 1.57 | 75.42 | 75.04

**\*nms_thresh=0.45, nms_topk=200**

These models are based on mxnet-mkl nightly build. Docs are WIP. Thanks for great support from GluonCV team:)

@pengzhao-intel @zhreshold