### PR TITLE
Perform correct type check in RandomErasing

### DIFF
--- a/gluoncv/data/transforms/block.py
+++ b/gluoncv/data/transforms/block.py
@@ -110,13 +110,13 @@ class RandomErasing(Block):
         self.ratio = ratio
 
     def forward(self, x):
-        if not isinstance(self.probability, int):
+        if not isinstance(self.probability, float):
             raise TypeError('Got inappropriate size arg')
-        if not isinstance(self.s_min, int):
+        if not isinstance(self.s_min, float):
             raise TypeError('Got inappropriate size arg')
-        if not isinstance(self.s_max, int):
+        if not isinstance(self.s_max, float):
             raise TypeError('Got inappropriate size arg')
-        if not isinstance(self.ratio, int):
+        if not isinstance(self.ratio, float):
             raise TypeError('Got inappropriate size arg')
         if not isinstance(self.mean, (int, tuple)):
             raise TypeError('Got inappropriate size arg')


### PR DESCRIPTION
In `forward` function of `RandomErasing`, the type check used to require `self.probability`, `self.s_min`, `self.s_max`, and `self.ratio` to be `int`. However, all those arguments should have type `float`, which should be the case according to the original paper and the docstring. I just corrected the type checking, leaving other parts unchanged.