### PR TITLE
fix bug in in scripts/detection/faster_rcnn/train_faster_rcnn.py that can't train with mixup

### DIFF
--- a/scripts/detection/faster_rcnn/train_faster_rcnn.py
+++ b/scripts/detection/faster_rcnn/train_faster_rcnn.py
@@ -207,8 +207,8 @@ def get_dataset(dataset, args):
     else:
         raise NotImplementedError('Dataset: {} not implemented.'.format(dataset))
     if args.mixup:
-        from gluoncv.data.mixup import MixupDetection
-        train_dataset = MixupDetection(train_dataset)
+        from gluoncv.data.mixup import detection
+        train_dataset = detection.MixupDetection(train_dataset)
     return train_dataset, val_dataset, val_metric
 
 
@@ -348,10 +348,10 @@ def train(net, train_data, val_data, eval_metric, ctx, args):
         mix_ratio = 1.0
         if args.mixup:
             # TODO(zhreshold) only support evenly mixup now, target generator needs to be modified otherwise
-            train_data._dataset.set_mixup(np.random.uniform, 0.5, 0.5)
+            train_data._dataset._data.set_mixup(np.random.uniform, 0.5, 0.5)
             mix_ratio = 0.5
             if epoch >= args.epochs - args.no_mixup_epochs:
-                train_data._dataset.set_mixup(None)
+                train_data._dataset._data.set_mixup(None)
                 mix_ratio = 1.0
         while lr_steps and epoch >= lr_steps[0]:
             new_lr = trainer.learning_rate * lr_decay


### PR DESCRIPTION
I found a bug when I run `train_faster_rcnn.py --mixup`, 
it will break and show `cannot import name 'MixupDetection' from 'gluoncv.data.mixup'`.
And here is my quick fix.