### PR TITLE
(segmentation codebase)during training, actual lr is not set by args.lr

### DIFF
--- a/scripts/segmentation/train.py
+++ b/scripts/segmentation/train.py
@@ -153,7 +153,9 @@ class Trainer(object):
         kv = mx.kv.create(args.kvstore)
         optimizer_params = {'lr_scheduler': self.lr_scheduler,
                             'wd':args.weight_decay,
-                            'momentum': args.momentum}
+                            'momentum': args.momentum,
+                            'learning_rate': args.lr
+                           }
         if args.dtype == 'float16':
             optimizer_params['multi_precision'] = True
 

--- a/scripts/segmentation/train.py
+++ b/scripts/segmentation/train.py
@@ -180,7 +180,7 @@ class Trainer(object):
                 autograd.backward(losses)
             self.optimizer.step(self.args.batch_size)
             for loss in losses:
-                train_loss += loss.asnumpy()[0] / len(losses)
+                train_loss += np.mean(loss.asnumpy()) / len(losses)
             tbar.set_description('Epoch %d, training loss %.3f'%\
                 (epoch, train_loss/(i+1)))
             mx.nd.waitall()


### PR DESCRIPTION
initial `learning rate ` will be set as 0.01  in [optimizer.py](https://github.com/apache/incubator-mxnet/blob/master/python/mxnet/optimizer/optimizer.py)  if we don't pass `'learning_rate': args.lr` in `optimizer_params`