### PR TITLE
fix ctx issue of faster/mask-rcnn

### DIFF
--- a/gluoncv/model_zoo/faster_rcnn/faster_rcnn.py
+++ b/gluoncv/model_zoo/faster_rcnn/faster_rcnn.py
@@ -447,7 +447,7 @@ def get_faster_rcnn(name, dataset, pretrained=False, ctx=mx.cpu(),
         full_name = '_'.join(('faster_rcnn', name, dataset))
         net.load_parameters(get_model_file(full_name, tag=pretrained, root=root), ctx=ctx)
     else:
-        net.collect_params().reset(ctx)
+        net.collect_params().reset_ctx(ctx)
     return net
 
 

--- a/gluoncv/model_zoo/faster_rcnn/faster_rcnn.py
+++ b/gluoncv/model_zoo/faster_rcnn/faster_rcnn.py
@@ -446,6 +446,8 @@ def get_faster_rcnn(name, dataset, pretrained=False, ctx=mx.cpu(),
         from ..model_store import get_model_file
         full_name = '_'.join(('faster_rcnn', name, dataset))
         net.load_parameters(get_model_file(full_name, tag=pretrained, root=root), ctx=ctx)
+    else:
+        net.collect_params().reset(ctx)
     return net
 
 

--- a/gluoncv/model_zoo/faster_rcnn/faster_rcnn.py
+++ b/gluoncv/model_zoo/faster_rcnn/faster_rcnn.py
@@ -447,7 +447,11 @@ def get_faster_rcnn(name, dataset, pretrained=False, ctx=mx.cpu(),
         full_name = '_'.join(('faster_rcnn', name, dataset))
         net.load_parameters(get_model_file(full_name, tag=pretrained, root=root), ctx=ctx)
     else:
-        net.collect_params().reset_ctx(ctx)
+        for v in net.collect_params().values():
+            try:
+                v.reset_ctx(ctx)
+            except ValueError:
+                pass
     return net
 
 

--- a/gluoncv/model_zoo/mask_rcnn/mask_rcnn.py
+++ b/gluoncv/model_zoo/mask_rcnn/mask_rcnn.py
@@ -329,6 +329,8 @@ def get_mask_rcnn(name, dataset, pretrained=False, ctx=mx.cpu(),
         from ..model_store import get_model_file
         full_name = '_'.join(('mask_rcnn', name, dataset))
         net.load_parameters(get_model_file(full_name, tag=pretrained, root=root), ctx=ctx)
+    else:
+        net.collect_params().reset_ctx(ctx)
     return net
 
 

--- a/gluoncv/model_zoo/mask_rcnn/mask_rcnn.py
+++ b/gluoncv/model_zoo/mask_rcnn/mask_rcnn.py
@@ -330,7 +330,11 @@ def get_mask_rcnn(name, dataset, pretrained=False, ctx=mx.cpu(),
         full_name = '_'.join(('mask_rcnn', name, dataset))
         net.load_parameters(get_model_file(full_name, tag=pretrained, root=root), ctx=ctx)
     else:
-        net.collect_params().reset_ctx(ctx)
+        for v in net.collect_params().values():
+            try:
+                v.reset_ctx(ctx)
+            except ValueError:
+                pass
     return net
 
 


### PR DESCRIPTION
Should fix the ctx issue when pretrained model is `False`