### PR TITLE
Add Horovod, AMP and DALI to SSD training script

### DIFF
--- a/gluoncv/data/__init__.py
+++ b/gluoncv/data/__init__.py
@@ -7,6 +7,7 @@ from .imagenet.classification import ImageNet, ImageNet1kAttr
 from .dataloader import DetectionDataLoader, RandomTransformDataLoader
 from .pascal_voc.detection import VOCDetection
 from .mscoco.detection import COCODetection
+from .mscoco.detection import COCODetectionDALI
 from .mscoco.instance import COCOInstance
 from .mscoco.segmentation import COCOSegmentation
 from .mscoco.keypoints import COCOKeyPoints

--- a/gluoncv/data/transforms/presets/ssd.py
+++ b/gluoncv/data/transforms/presets/ssd.py
@@ -6,7 +6,16 @@ from .. import bbox as tbbox
 from .. import image as timage
 from .. import experimental
 
-__all__ = ['transform_test', 'load_test', 'SSDDefaultTrainTransform', 'SSDDefaultValTransform']
+try:
+    from nvidia.dali.pipeline import Pipeline
+    import nvidia.dali.ops as ops
+    import nvidia.dali.types as types
+except ImportError:
+    class Pipeline:
+        def __init__(self):
+            raise NotImplementedError("DALI not found, please check if you installed it correctly.")
+
+__all__ = ['transform_test', 'load_test', 'SSDDefaultTrainTransform', 'SSDDefaultValTransform', 'SSDCocoDALIPipeline']
 
 def transform_test(imgs, short, max_size=1024, mean=(0.485, 0.456, 0.406),
                    std=(0.229, 0.224, 0.225)):
@@ -211,3 +220,98 @@ class SSDDefaultValTransform(object):
         img = mx.nd.image.to_tensor(img)
         img = mx.nd.image.normalize(img, mean=self._mean, std=self._std)
         return img, bbox.astype(img.dtype)
+
+class SSDCocoDALIPipeline(Pipeline):
+    def __init__(self, num_shards, device_id, shard_id, batch_size, data_shape, anchors, file_root, annotations_file, num_workers):
+        super(SSDCocoDALIPipeline, self).__init__(
+            batch_size=batch_size,
+            device_id=device_id,
+            num_threads=num_workers)
+
+        self.input = ops.COCOReader(
+            file_root=file_root,
+            annotations_file=annotations_file,
+            skip_empty=True,
+            shard_id=shard_id,
+            num_shards=num_shards,
+            ratio=True,
+            ltrb=True,
+            shuffle_after_epoch=True)
+
+        self.decode = ops.HostDecoder(device="cpu", output_type=types.RGB)
+
+        # Augumentation techniques
+        self.crop = ops.RandomBBoxCrop(
+            device="cpu",
+            aspect_ratio=[0.5, 2.0],
+            thresholds=[0, 0.1, 0.3, 0.5, 0.7, 0.9],
+            scaling=[0.3, 1.0],
+            ltrb=True,
+            allow_no_crop=True,
+            num_attempts=1)
+        self.slice = ops.Slice(device="cpu")
+        self.twist = ops.ColorTwist(device="gpu")
+        self.resize = ops.Resize(
+            device="cpu",
+            resize_x=data_shape,
+            resize_y=data_shape,
+            min_filter=types.DALIInterpType.INTERP_TRIANGULAR)
+
+        # output_dtype = types.FLOAT16 if args.fp16 else types.FLOAT
+        output_dtype = types.FLOAT
+
+        self.normalize = ops.CropMirrorNormalize(
+            device="gpu",
+            crop=(data_shape, data_shape),
+            mean=[0.485 * 255, 0.456 * 255, 0.406 * 255],
+            std=[0.229 * 255, 0.224 * 255, 0.225 * 255],
+            mirror=0,
+            output_dtype=output_dtype,
+            output_layout=types.NCHW,
+            pad_output=False)
+
+        # Random variables
+        self.rng1 = ops.Uniform(range=[0.5, 1.5])
+        self.rng2 = ops.Uniform(range=[0.875, 1.125])
+        self.rng3 = ops.Uniform(range=[-0.5, 0.5])
+
+        self.flip = ops.Flip(device="cpu")
+        self.bbflip = ops.BbFlip(device="cpu", ltrb=True)
+        self.flip_coin = ops.CoinFlip(probability=0.5)
+
+        self.box_encoder = ops.BoxEncoder(
+            device="cpu",
+            criteria=0.5,
+            anchors=anchors,
+            offset=True,
+            stds=[0.1,0.1,0.2,0.2],
+            scale=data_shape)
+
+
+    def define_graph(self):
+        saturation = self.rng1()
+        contrast = self.rng1()
+        brightness = self.rng2()
+        hue = self.rng3()
+        coin_rnd = self.flip_coin()
+
+        inputs, bboxes, labels = self.input(name="Reader")
+        images = self.decode(inputs)
+
+        crop_begin, crop_size, bboxes, labels = self.crop(bboxes, labels)
+        images = self.slice(images, crop_begin, crop_size)
+
+        images = self.flip(images, horizontal=coin_rnd)
+        bboxes = self.bbflip(bboxes, horizontal=coin_rnd)
+        images = self.resize(images)
+        images = images.gpu()
+        images = self.twist(
+            images,
+            saturation=saturation,
+            contrast=contrast,
+            brightness=brightness,
+            hue=hue)
+        images = self.normalize(images)
+        bboxes, labels = self.box_encoder(bboxes, labels)
+
+        return (images, bboxes.gpu(), labels.gpu())

--- a/gluoncv/utils/__init__.py
+++ b/gluoncv/utils/__init__.py
@@ -9,6 +9,7 @@ from . import parallel
 
 from .download import download, check_sha1
 from .filesystem import makedirs
+from .filesystem import try_import_dali
 from .bbox import bbox_iou
 from .block import recursive_visit, set_lr_mult, freeze_bn
 from .lr_scheduler import LRSequential, LRScheduler

--- a/gluoncv/utils/filesystem.py
+++ b/gluoncv/utils/filesystem.py
@@ -95,3 +95,17 @@ def import_try_install(package, extern_url=None):
                 sys.path.append(user_site)
             return __import__(package)
     return __import__(package)
+
+def try_import_dali():
+    """Try import NVIDIA DALI at runtime.
+    """
+    try:
+        dali = __import__('nvidia.dali', fromlist=['pipeline', 'ops', 'types'])
+        dali.Pipeline = dali.pipeline.Pipeline
+    except ImportError:
+        class dali:
+            class Pipeline:
+                def __init__(self):
+                    raise NotImplementedError(
+                        "DALI not found, please check if you installed it correctly.")
+    return dali

--- a/scripts/detection/ssd/README.md
+++ b/scripts/detection/ssd/README.md
@@ -2,6 +2,9 @@
 
 [GluonCV Model Zoo](http://gluon-cv.mxnet.io/model_zoo/index.html#object-detection)
 
+- `--dali` Use [DALI](https://docs.nvidia.com/deeplearning/sdk/dali-developer-guide/docs/index.html) for faster data loading and data preprocessing in training with COCO dataset. DALI >= 0.12 required.
+- `--amp` Use [Automatic Mixed Precision training](https://mxnet.incubator.apache.org/versions/master/tutorials/amp/amp_tutorial.html), automatically casting FP16 where safe.
+- `--horovod` Use [Horovod](https://github.com/horovod/horovod) for distributed training, with a network agnostic wrapper for the optimizer, allowing efficient allreduce using OpemMPI and NCCL.
 
 ## References
 1. Wei Liu, et al. "SSD: Single shot multibox detector" ECCV 2016.

--- a/scripts/detection/ssd/train_ssd.py
+++ b/scripts/detection/ssd/train_ssd.py
@@ -133,8 +133,13 @@ def get_dali_dataset(dataset_name, devices, args):
     if dataset_name.lower() == "coco":
         # training
         expanded_file_root = os.path.expanduser(args.dataset_root)
-        coco_root = expanded_file_root + '/coco/train2017'
-        coco_annotations = expanded_file_root + '/coco/annotations/instances_train2017.json'
+        coco_root = os.path.join(expanded_file_root,
+                                 'coco',
+                                 'train2017')
+        coco_annotations = os.path.join(expanded_file_root,
+                                        'coco',
+                                        'annotations',
+                                        'instances_train2017.json')
         if args.horovod:
             train_dataset = [gdata.COCODetectionDALI(num_shards=hvd.size(), shard_id=hvd.rank(), file_root=coco_root,
                                                      annotations_file=coco_annotations)]
@@ -144,7 +149,9 @@ def get_dali_dataset(dataset_name, devices, args):
 
         # validation
         if (not args.horovod or hvd.rank() == 0):
-            val_dataset = gdata.COCODetection(root=(args.dataset_root + '/coco'), splits='instances_val2017', skip_empty=False)
+            val_dataset = gdata.COCODetection(root=os.path.join(args.dataset_root + '/coco'),
+                                              splits='instances_val2017',
+                                              skip_empty=False)
             val_metric = COCODetectionMetric(
                 val_dataset, args.save_prefix + '_eval', cleanup=True,
                 data_shape=(args.data_shape, args.data_shape))

--- a/scripts/detection/ssd/train_ssd.py
+++ b/scripts/detection/ssd/train_ssd.py
@@ -16,9 +16,21 @@ from gluoncv.model_zoo import get_model
 from gluoncv.data.batchify import Tuple, Stack, Pad
 from gluoncv.data.transforms.presets.ssd import SSDDefaultTrainTransform
 from gluoncv.data.transforms.presets.ssd import SSDDefaultValTransform
+from gluoncv.data.transforms.presets.ssd import SSDCocoDALIPipeline
+
 from gluoncv.utils.metrics.voc_detection import VOC07MApMetric
 from gluoncv.utils.metrics.coco_detection import COCODetectionMetric
 from gluoncv.utils.metrics.accuracy import Accuracy
+
+from mxnet.contrib import amp
+
+import horovod.mxnet as hvd
+
+try:
+    from nvidia.dali.plugin.mxnet import DALIGenericIterator
+    dali_found = True
+except ImportError:
+    dali_found = False
 
 def parse_args():
     parser = argparse.ArgumentParser(description='Train SSD networks.')
@@ -30,6 +42,8 @@ def parse_args():
                         help='Training mini-batch size')
     parser.add_argument('--dataset', type=str, default='voc',
                         help='Training dataset. Now support voc.')
+    parser.add_argument('--dataset-root', type=str, default='~/.mxnet/datasets/',
+                        help='Path of the directory where the dataset is located.')
     parser.add_argument('--num-workers', '-j', dest='num_workers', type=int,
                         default=4, help='Number of data workers, you can use larger '
                         'number to accelerate data loading, if you CPU and GPUs are powerful.')
@@ -66,6 +80,15 @@ def parse_args():
                         help='Random seed to be fixed.')
     parser.add_argument('--syncbn', action='store_true',
                         help='Use synchronize BN across devices.')
+    parser.add_argument('--dali', action='store_true',
+                        help='Use DALI for data loading and data preprocessing in training. '
+                        'Currently supports only COCO.')
+    parser.add_argument('--amp', action='store_true',
+                        help='Use MXNet AMP for mixed precision training.')
+    parser.add_argument('--horovod', action='store_true',
+                    help='Use MXNet Horovod for distributed training. Must be run with OpenMPI. '
+                         '--gpus is ignored when using --horovod.')
+
     args = parser.parse_args()
     return args
 
@@ -77,8 +100,8 @@ def get_dataset(dataset, args):
             splits=[(2007, 'test')])
         val_metric = VOC07MApMetric(iou_thresh=0.5, class_names=val_dataset.classes)
     elif dataset.lower() == 'coco':
-        train_dataset = gdata.COCODetection(splits='instances_train2017')
-        val_dataset = gdata.COCODetection(splits='instances_val2017', skip_empty=False)
+        train_dataset = gdata.COCODetection(root=args.dataset_root + "/coco", splits='instances_train2017')
+        val_dataset = gdata.COCODetection(root=args.dataset_root + "/coco", splits='instances_val2017', skip_empty=False)
         val_metric = COCODetectionMetric(
             val_dataset, args.save_prefix + '_eval', cleanup=True,
             data_shape=(args.data_shape, args.data_shape))
@@ -89,12 +112,13 @@ def get_dataset(dataset, args):
         raise NotImplementedError('Dataset: {} not implemented.'.format(dataset))
     return train_dataset, val_dataset, val_metric
 
-def get_dataloader(net, train_dataset, val_dataset, data_shape, batch_size, num_workers):
+def get_dataloader(net, train_dataset, val_dataset, data_shape, batch_size, num_workers, ctx):
     """Get dataloader."""
     width, height = data_shape, data_shape
     # use fake data to generate fixed anchors for target generation
     with autograd.train_mode():
-        _, _, anchors = net(mx.nd.zeros((1, 3, height, width)))
+        _, _, anchors = net(mx.nd.zeros((1, 3, height, width), ctx))
+    anchors = anchors.as_in_context(mx.cpu())
     batchify_fn = Tuple(Stack(), Stack(), Stack())  # stack image, cls_targets, box_targets
     train_loader = gluon.data.DataLoader(
         train_dataset.transform(SSDDefaultTrainTransform(width, height, anchors)),
@@ -104,6 +128,72 @@ def get_dataloader(net, train_dataset, val_dataset, data_shape, batch_size, num_
         val_dataset.transform(SSDDefaultValTransform(width, height)),
         batch_size, False, batchify_fn=val_batchify_fn, last_batch='keep', num_workers=num_workers)
     return train_loader, val_loader
+
+def to_normalized_ltrb_list(anchors, size):
+    anchors_np = anchors.squeeze().asnumpy()
+    anchors_np_ltrb = anchors_np.copy()
+    anchors_np_ltrb[:, 0] = anchors_np[:, 0] - 0.5 * anchors_np[:, 2]
+    anchors_np_ltrb[:, 1] = anchors_np[:, 1] - 0.5 * anchors_np[:, 3]
+    anchors_np_ltrb[:, 2] = anchors_np[:, 0] + 0.5 * anchors_np[:, 2]
+    anchors_np_ltrb[:, 3] = anchors_np[:, 1] + 0.5 * anchors_np[:, 3]
+    anchors_np_ltrb /= size
+    return anchors_np_ltrb.flatten().tolist()
+
+def get_dali_dataloader(net, dataset_name, data_shape, global_batch_size, num_workers, devices, file_root, ctx, horovod):
+    if dataset_name.lower() == "coco":
+        width, height = data_shape, data_shape
+        with autograd.train_mode():
+            _, _, anchors = net(mx.nd.zeros((1, 3, height, width), ctx=ctx))
+        anchors = anchors.as_in_context(mx.cpu())
+
+        # prepare anchors into ltrb (normalized DALI anchors format list)
+        anchors_ltrb = to_normalized_ltrb_list(anchors, data_shape)
+
+        # training
+        expanded_file_root = os.path.expanduser(file_root)
+        coco_root = expanded_file_root + '/coco/train2017'
+        coco_annotations = expanded_file_root + '/coco/annotations/instances_train2017.json'
+        coco_size = 118287
+
+        if horovod:
+            batch_size = global_batch_size // hvd.size()
+            pipelines = [SSDCocoDALIPipeline(num_shards=hvd.size(), device_id=hvd.local_rank(), shard_id=hvd.rank(),
+                                             batch_size=batch_size, data_shape=data_shape, anchors=anchors_ltrb,
+                                             num_workers=num_workers, file_root=coco_root,
+                                             annotations_file=coco_annotations)]
+        else:
+            num_devices = len(devices)
+            batch_size = global_batch_size // num_devices
+            pipelines = [SSDCocoDALIPipeline(num_shards=num_devices, device_id=device_id, shard_id=i,
+                                             batch_size=batch_size, data_shape=data_shape, anchors=anchors_ltrb,
+                                            num_workers=num_workers, file_root=coco_root,
+                                             annotations_file=coco_annotations) for i, device_id in enumerate(devices)]
+
+        if horovod:
+            coco_size //= hvd.size()
+        train_loader = DALIGenericIterator(pipelines, [('data', DALIGenericIterator.DATA_TAG),
+                                                       ('bboxes', DALIGenericIterator.LABEL_TAG),
+                                                       ('label', DALIGenericIterator.LABEL_TAG)],
+                                                       coco_size, auto_reset=True)
+
+        # validation
+        if (not horovod or hvd.rank() == 0):
+            val_dataset = gdata.COCODetection(root=(args.dataset_root + '/coco'), splits='instances_val2017', skip_empty=False)
+            val_metric = COCODetectionMetric(
+                val_dataset, args.save_prefix + '_eval', cleanup=True,
+                data_shape=(args.data_shape, args.data_shape))
+            val_batchify_fn = Tuple(Stack(), Pad(pad_val=-1))
+            val_loader = gluon.data.DataLoader(
+                val_dataset.transform(SSDDefaultValTransform(width, height)),
+                global_batch_size, False, batchify_fn=val_batchify_fn, last_batch='keep', num_workers=num_workers)
+        else:
+            val_loader = None
+            val_metric = None
+    else:
+        raise NotImplementedError('Dataset: {} not implemented with DALI.'.format(dataset_name))
+
+    return train_loader, val_loader, val_metric
+
 
 def save_params(net, best_map, current_map, epoch, save_interval, prefix):
     current_map = float(current_map)
@@ -149,9 +239,20 @@ def validate(net, val_data, ctx, eval_metric):
 def train(net, train_data, val_data, eval_metric, ctx, args):
     """Training pipeline"""
     net.collect_params().reset_ctx(ctx)
-    trainer = gluon.Trainer(
-        net.collect_params(), 'sgd',
-        {'learning_rate': args.lr, 'wd': args.wd, 'momentum': args.momentum})
+
+    if args.horovod:
+        hvd.broadcast_parameters(net.collect_params(), root_rank=0)
+        trainer = hvd.DistributedTrainer(
+                        net.collect_params(), 'sgd',
+                        {'learning_rate': args.lr, 'wd': args.wd, 'momentum': args.momentum})
+    else:
+        trainer = gluon.Trainer(
+                    net.collect_params(), 'sgd',
+                    {'learning_rate': args.lr, 'wd': args.wd, 'momentum': args.momentum},
+                    update_on_kvstore=(False if args.amp else None))
+
+    if args.amp:
+        amp.init_trainer(trainer)
 
     # lr decay policy
     lr_decay = float(args.lr_decay)
@@ -174,6 +275,7 @@ def train(net, train_data, val_data, eval_metric, ctx, args):
     logger.info(args)
     logger.info('Start training from [Epoch {}]'.format(args.start_epoch))
     best_map = [0]
+
     for epoch in range(args.start_epoch, args.epochs):
         while lr_steps and epoch >= lr_steps[0]:
             new_lr = trainer.learning_rate * lr_decay
@@ -185,11 +287,19 @@ def train(net, train_data, val_data, eval_metric, ctx, args):
         tic = time.time()
         btic = time.time()
         net.hybridize(static_alloc=True, static_shape=True)
+
         for i, batch in enumerate(train_data):
-            batch_size = batch[0].shape[0]
-            data = gluon.utils.split_and_load(batch[0], ctx_list=ctx, batch_axis=0)
-            cls_targets = gluon.utils.split_and_load(batch[1], ctx_list=ctx, batch_axis=0)
-            box_targets = gluon.utils.split_and_load(batch[2], ctx_list=ctx, batch_axis=0)
+            if args.dali:
+                # dali iterator returns a mxnet.io.DataBatch
+                data = [d.data[0] for d in batch]
+                box_targets = [d.label[0] for d in batch]
+                cls_targets = [nd.cast(d.label[1], dtype='float32') for d in batch]
+
+            else:
+                data = gluon.utils.split_and_load(batch[0], ctx_list=ctx, batch_axis=0)
+                cls_targets = gluon.utils.split_and_load(batch[1], ctx_list=ctx, batch_axis=0)
+                box_targets = gluon.utils.split_and_load(batch[2], ctx_list=ctx, batch_axis=0)
+
             with autograd.record():
                 cls_preds = []
                 box_preds = []
@@ -199,41 +309,59 @@ def train(net, train_data, val_data, eval_metric, ctx, args):
                     box_preds.append(box_pred)
                 sum_loss, cls_loss, box_loss = mbox_loss(
                     cls_preds, box_preds, cls_targets, box_targets)
-                autograd.backward(sum_loss)
+                if args.amp:
+                    with amp.scale_loss(sum_loss, trainer) as scaled_loss:
+                        autograd.backward(scaled_loss)
+                else:
+                    autograd.backward(sum_loss)
             # since we have already normalized the loss, we don't want to normalize
             # by batch-size anymore
             trainer.step(1)
-            ce_metric.update(0, [l * batch_size for l in cls_loss])
-            smoothl1_metric.update(0, [l * batch_size for l in box_loss])
-            if args.log_interval and not (i + 1) % args.log_interval:
-                name1, loss1 = ce_metric.get()
-                name2, loss2 = smoothl1_metric.get()
-                logger.info('[Epoch {}][Batch {}], Speed: {:.3f} samples/sec, {}={:.3f}, {}={:.3f}'.format(
-                    epoch, i, batch_size/(time.time()-btic), name1, loss1, name2, loss2))
-            btic = time.time()
 
-        name1, loss1 = ce_metric.get()
-        name2, loss2 = smoothl1_metric.get()
-        logger.info('[Epoch {}] Training cost: {:.3f}, {}={:.3f}, {}={:.3f}'.format(
-            epoch, (time.time()-tic), name1, loss1, name2, loss2))
-        if (epoch % args.val_interval == 0) or (args.save_interval and epoch % args.save_interval == 0):
-            # consider reduce the frequency of validation to save time
-            map_name, mean_ap = validate(net, val_data, ctx, eval_metric)
-            val_msg = '\n'.join(['{}={}'.format(k, v) for k, v in zip(map_name, mean_ap)])
-            logger.info('[Epoch {}] Validation: \n{}'.format(epoch, val_msg))
-            current_map = float(mean_ap[-1])
-        else:
-            current_map = 0.
-        save_params(net, best_map, current_map, epoch, args.save_interval, args.save_prefix)
+            if (not args.horovod or hvd.rank() == 0):
+                local_batch_size = int(args.batch_size // (hvd.size() if args.horovod else 1))
+                ce_metric.update(0, [l * local_batch_size for l in cls_loss])
+                smoothl1_metric.update(0, [l * local_batch_size for l in box_loss])
+                if args.log_interval and not (i + 1) % args.log_interval:
+                    name1, loss1 = ce_metric.get()
+                    name2, loss2 = smoothl1_metric.get()
+                    logger.info('[Epoch {}][Batch {}], Speed: {:.3f} samples/sec, {}={:.3f}, {}={:.3f}'.format(
+                        epoch, i, args.batch_size/(time.time()-btic), name1, loss1, name2, loss2))
+                btic = time.time()
+
+        if (not args.horovod or hvd.rank() == 0):
+            name1, loss1 = ce_metric.get()
+            name2, loss2 = smoothl1_metric.get()
+            logger.info('[Epoch {}] Training cost: {:.3f}, {}={:.3f}, {}={:.3f}'.format(
+                epoch, (time.time()-tic), name1, loss1, name2, loss2))
+            if (epoch % args.val_interval == 0) or (args.save_interval and epoch % args.save_interval == 0):
+                # consider reduce the frequency of validation to save time
+                map_name, mean_ap = validate(net, val_data, ctx, eval_metric)
+                val_msg = '\n'.join(['{}={}'.format(k, v) for k, v in zip(map_name, mean_ap)])
+                logger.info('[Epoch {}] Validation: \n{}'.format(epoch, val_msg))
+                current_map = float(mean_ap[-1])
+            else:
+                current_map = 0.
+            save_params(net, best_map, current_map, epoch, args.save_interval, args.save_prefix)
 
 if __name__ == '__main__':
     args = parse_args()
+
+    if args.amp:
+        amp.init()
+
+    if args.horovod:
+        hvd.init()
+
     # fix seed for mxnet, numpy and python builtin random generator.
     gutils.random.seed(args.seed)
 
     # training contexts
-    ctx = [mx.gpu(int(i)) for i in args.gpus.split(',') if i.strip()]
-    ctx = ctx if ctx else [mx.cpu()]
+    if args.horovod:
+        ctx = [mx.gpu(hvd.local_rank())]
+    else:
+        ctx = [mx.gpu(int(i)) for i in args.gpus.split(',') if i.strip()]
+        ctx = ctx if ctx else [mx.cpu()]
 
     # network
     net_name = '_'.join(('ssd', str(args.data_shape), args.network, args.dataset))
@@ -253,11 +381,23 @@ if __name__ == '__main__':
             warnings.simplefilter("always")
             net.initialize()
             async_net.initialize()
+            # needed for net to be first gpu when using AMP
+            net.collect_params().reset_ctx(ctx[0])
 
     # training data
-    train_dataset, val_dataset, eval_metric = get_dataset(args.dataset, args)
-    train_data, val_data = get_dataloader(
-        async_net, train_dataset, val_dataset, args.data_shape, args.batch_size, args.num_workers)
+    if args.dali:
+        if not dali_found:
+            raise SystemExit("DALI not found, please check if you installed it correctly.")
+        devices = [int(i) for i in args.gpus.split(',') if i.strip()]
+        train_data, val_data, eval_metric = get_dali_dataloader(
+            async_net, args.dataset, args.data_shape, args.batch_size, args.num_workers, devices, args.dataset_root, ctx[0], args.horovod)
+    else:
+        train_dataset, val_dataset, eval_metric = get_dataset(args.dataset, args)
+        batch_size = (args.batch_size // hvd.size()) if args.horovod else args.batch_size
+        train_data, val_data = get_dataloader(
+            async_net, train_dataset, val_dataset, args.data_shape, batch_size, args.num_workers, ctx[0])
+
+
 
     # training
     train(net, train_data, val_data, eval_metric, ctx, args)

--- a/scripts/detection/ssd/train_ssd.py
+++ b/scripts/detection/ssd/train_ssd.py
@@ -86,8 +86,8 @@ def parse_args():
     parser.add_argument('--amp', action='store_true',
                         help='Use MXNet AMP for mixed precision training.')
     parser.add_argument('--horovod', action='store_true',
-                    help='Use MXNet Horovod for distributed training. Must be run with OpenMPI. '
-                         '--gpus is ignored when using --horovod.')
+                        help='Use MXNet Horovod for distributed training. Must be run with OpenMPI. '
+                        '--gpus is ignored when using --horovod.')
 
     args = parser.parse_args()
     return args


### PR DESCRIPTION
Add three options to accelerate training of SSD with COCO:
- `--dali` Use [DALI](https://docs.nvidia.com/deeplearning/sdk/dali-developer-guide/docs/index.html) for faster data loading and data preprocessing in training with COCO dataset. DALI >= 0.11 required.
- `--amp` Use [Automatic Mixed Precision training](https://mxnet.incubator.apache.org/versions/master/tutorials/amp/amp_tutorial.html), automatically casting FP16 where safe
- `--horovod` Use [Horovod](https://github.com/horovod/horovod) for distributed training, with a network agnostic wrapper for the optimizer, allowing efficient allreduce using OpemMPI and NCCL

All combined, these changes yield a ~4.5x speed improvement on the DGX-1V (8xTesla V100 GPUs) it was tested on:

```
python train_ssd.py --dataset coco -j 4 --gpus 0,1,2,3,4,5,6,7 --network resnet50_v1 --data-shape 512 --log-interval 5
...
INFO:root:[Epoch 0][Batch 2004], Speed: 34.658 samples/sec, CrossEntropy=5.614, SmoothL1=3.033
INFO:root:[Epoch 0][Batch 2009], Speed: 40.668 samples/sec, CrossEntropy=5.612, SmoothL1=3.032
INFO:root:[Epoch 0][Batch 2014], Speed: 124.791 samples/sec, CrossEntropy=5.610, SmoothL1=3.031
INFO:root:[Epoch 0][Batch 2019], Speed: 126.232 samples/sec, CrossEntropy=5.607, SmoothL1=3.031
INFO:root:[Epoch 0][Batch 2024], Speed: 105.187 samples/sec, CrossEntropy=5.606, SmoothL1=3.030
INFO:root:[Epoch 0][Batch 2029], Speed: 28.480 samples/sec, CrossEntropy=5.604, SmoothL1=3.029
```

```
horovodrun -np 8 -H localhost:8 python ./gluon-cv/scripts/detection/ssd/train_ssd.py --dataset coco -j 4 --network resnet50_v1 --data-shape 512 --log-interval 5 --horovod --dali --amp
...
INFO:root:[Epoch 0][Batch 2004], Speed: 316.286 samples/sec, CrossEntropy=5.601, SmoothL1=2.271
INFO:root:[Epoch 0][Batch 2009], Speed: 332.049 samples/sec, CrossEntropy=5.598, SmoothL1=2.270
INFO:root:[Epoch 0][Batch 2014], Speed: 347.680 samples/sec, CrossEntropy=5.595, SmoothL1=2.269
INFO:root:[Epoch 0][Batch 2019], Speed: 315.211 samples/sec, CrossEntropy=5.594, SmoothL1=2.268
INFO:root:[Epoch 0][Batch 2024], Speed: 332.870 samples/sec, CrossEntropy=5.590, SmoothL1=2.267
INFO:root:[Epoch 0][Batch 2029], Speed: 332.070 samples/sec, CrossEntropy=5.587, SmoothL1=2.266
```

Even though the training localisation loss (SmoothL1) differs, the validation mAP is similar:

![convergence_curve_ssd_rn50_mxnet](https://user-images.githubusercontent.com/3193578/59324983-2c19cd80-8d1c-11e9-96e1-9725066aa5c2.jpg)


Signed-off-by: Serge Panev <spanev@nvidia.com>