### PR TITLE
demo_imagenet.py: load the ImageNet classes when not using a pretrained model

### DIFF
--- a/scripts/classification/imagenet/demo_imagenet.py
+++ b/scripts/classification/imagenet/demo_imagenet.py
@@ -2,6 +2,7 @@ import argparse
 
 from mxnet import nd, image
 
+from gluoncv.data import ImageNet1kAttr
 from gluoncv.data.transforms.presets.imagenet import transform_eval
 from gluoncv.model_zoo import get_model
 
@@ -21,6 +22,10 @@ net = get_model(model_name, pretrained=pretrained)
 
 if not pretrained:
     net.load_parameters(opt.saved_params)
+    attrib = ImageNet1kAttr()
+    classes = attrib.classes
+else:
+    classes = net.classes
 
 # Load Images
 img = image.imread(opt.input_pic)
@@ -34,4 +39,4 @@ ind = nd.topk(pred, k=topK)[0].astype('int')
 print('The input picture is classified to be')
 for i in range(topK):
     print('\t[%s], with probability %.3f.'%
-          (net.classes[ind[i].asscalar()], nd.softmax(pred)[0][ind[i]].asscalar()))
+          (classes[ind[i].asscalar()], nd.softmax(pred)[0][ind[i]].asscalar()))

--- a/scripts/classification/imagenet/demo_imagenet.py
+++ b/scripts/classification/imagenet/demo_imagenet.py
@@ -1,12 +1,9 @@
 import argparse
 
-import matplotlib.pyplot as plt
-
 from mxnet import nd, image
-from mxnet.gluon.data.vision import transforms
 
-from gluoncv.model_zoo import get_model
 from gluoncv.data.transforms.presets.imagenet import transform_eval
+from gluoncv.model_zoo import get_model
 
 parser = argparse.ArgumentParser(description='Predict ImageNet classes from a given image')
 parser.add_argument('--model', type=str, required=True,


### PR DESCRIPTION
This change solves an unhandled exception "‘ResNetV1’ object has no attribute ‘classes’" when the script is started with a parameters file instead of the pretrained model.

This replaces pull request #780.