### PR TITLE
Fix custom image size for PSP segmentation net

### DIFF
--- a/gluoncv/model_zoo/pspnet.py
+++ b/gluoncv/model_zoo/pspnet.py
@@ -38,8 +38,8 @@ class PSPNet(SegBaseModel):
         super(PSPNet, self).__init__(nclass, aux, backbone, ctx=ctx, base_size=base_size,
                                      crop_size=crop_size, pretrained_base=pretrained_base, **kwargs)
         with self.name_scope():
-            self.head = _PSPHead(nclass, height=self._up_kwargs['height']//8,
-                                 width=self._up_kwargs['width']//8, **kwargs)
+            self.head = _PSPHead(nclass, feature_map_height=self._up_kwargs['height']//8,
+                                 feature_map_width=self._up_kwargs['width']//8, **kwargs)
             self.head.initialize(ctx=ctx)
             self.head.collect_params().setattr('lr_mult', 10)
             if self.aux:
@@ -118,9 +118,9 @@ class _PyramidPooling(HybridBlock):
 
 class _PSPHead(HybridBlock):
     def __init__(self, nclass, norm_layer=nn.BatchNorm, norm_kwargs=None,
-                 height=60, width=60, **kwargs):
+                 feature_map_height=60, feature_map_width=60, **kwargs):
         super(_PSPHead, self).__init__()
-        self.psp = _PyramidPooling(2048, height=height, width=width,
+        self.psp = _PyramidPooling(2048, height=feature_map_height, width=feature_map_width,
                                    norm_layer=norm_layer,
                                    norm_kwargs=norm_kwargs)
         with self.name_scope():

--- a/tests/unittests/test_model_zoo.py
+++ b/tests/unittests/test_model_zoo.py
@@ -352,6 +352,24 @@ def test_segmentation_models():
     _test_model_list(models, ctx, x, pretrained=False, pretrained_base=True)
 
 
+@try_gpu(0)
+def test_segmentation_models_custom_size():
+    ctx = mx.context.current_context()
+    num_classes = 10
+    width = 720
+    height = 480
+    x = mx.random.uniform(shape=(1, 3, height, width), ctx=ctx)
+
+    net = gcv.model_zoo.FCN(num_classes, backbone='resnet50', aux=False, ctx=ctx, pretrained_base=True,
+                            height=height, width=width)
+    result = net.forward(x)
+    assert (result[0].shape == (1, num_classes, height, width))
+    net = gcv.model_zoo.PSPNet(num_classes, backbone='resnet50', aux=False, ctx=ctx, pretrained_base=True,
+                        height=height, width=width)
+    result = net.forward(x)
+    assert (result[0].shape == (1, num_classes, height, width))
+
+
 @with_cpu(0)
 def test_mobilenet_sync_bn():
     model_name = "mobilenet1.0"

--- a/tests/unittests/test_model_zoo.py
+++ b/tests/unittests/test_model_zoo.py
@@ -355,19 +355,19 @@ def test_segmentation_models():
 @try_gpu(0)
 def test_segmentation_models_custom_size():
     ctx = mx.context.current_context()
-    num_classes = 10
-    width = 720
-    height = 480
+    num_classes = 5
+    width = 96
+    height = 64
     x = mx.random.uniform(shape=(1, 3, height, width), ctx=ctx)
 
     net = gcv.model_zoo.FCN(num_classes, backbone='resnet50', aux=False, ctx=ctx, pretrained_base=True,
                             height=height, width=width)
     result = net.forward(x)
-    assert (result[0].shape == (1, num_classes, height, width))
+    assert result[0].shape == (1, num_classes, height, width)
     net = gcv.model_zoo.PSPNet(num_classes, backbone='resnet50', aux=False, ctx=ctx, pretrained_base=True,
-                        height=height, width=width)
+                               height=height, width=width)
     result = net.forward(x)
-    assert (result[0].shape == (1, num_classes, height, width))
+    assert result[0].shape == (1, num_classes, height, width)
 
 
 @with_cpu(0)


### PR DESCRIPTION
Fixing a bug with custom image size for PSP segmentation net, response to this bug: https://github.com/dmlc/gluon-cv/issues/805. Unit tests added