### PR TITLE
Fix rcnn nms

### DIFF
--- a/gluoncv/model_zoo/faster_rcnn/faster_rcnn.py
+++ b/gluoncv/model_zoo/faster_rcnn/faster_rcnn.py
@@ -412,7 +412,7 @@ class FasterRCNN(RCNN):
             bbox = self.box_decoder(box_pred, self.box_to_center(rpn_box))
             # res (C, N, 6)
             res = F.concat(*[cls_id, score, bbox], dim=-1)
-            if self.force_suppress:
+            if self.force_nms:
                 # res (1, C*N, 6), to allow cross-catogory suppression
                 res = res.reshape((1, -1, 0))
             # res (C, self.nms_topk, 6)

--- a/gluoncv/model_zoo/faster_rcnn/faster_rcnn.py
+++ b/gluoncv/model_zoo/faster_rcnn/faster_rcnn.py
@@ -124,6 +124,9 @@ class FasterRCNN(RCNN):
         necessarily very precise. However, using a very big number may impact the training speed.
     additional_output : boolean, default is False
         ``additional_output`` is only used for Mask R-CNN to get internal outputs.
+    force_nms : bool, default is False
+        Appy NMS to all categories, this is to avoid overlapping detection results from different
+        categories.
 
     Attributes
     ----------
@@ -142,6 +145,9 @@ class FasterRCNN(RCNN):
     nms_topk : int
         Apply NMS to top k detection results, use -1 to disable so that every Detection
          result is used in NMS.
+    force_nms : bool
+        Appy NMS to all categories, this is to avoid overlapping detection results from different
+        categories.
     post_nms : int
         Only return top `post_nms` detection results, the rest is discarded. The number is
         based on COCO dataset which has maximum 100 objects per image. You can adjust this
@@ -160,13 +166,13 @@ class FasterRCNN(RCNN):
                  rpn_train_pre_nms=12000, rpn_train_post_nms=2000,
                  rpn_test_pre_nms=6000, rpn_test_post_nms=300, rpn_min_size=16,
                  num_sample=128, pos_iou_thresh=0.5, pos_ratio=0.25, max_num_gt=300,
-                 additional_output=False, **kwargs):
+                 additional_output=False, force_nms=False, **kwargs):
         super(FasterRCNN, self).__init__(
             features=features, top_features=top_features, classes=classes,
             box_features=box_features, short=short, max_size=max_size,
             train_patterns=train_patterns, nms_thresh=nms_thresh, nms_topk=nms_topk,
             post_nms=post_nms, roi_mode=roi_mode, roi_size=roi_size, strides=strides, clip=clip,
-            **kwargs)
+            force_nms=force_nms, **kwargs)
         if rpn_train_post_nms > rpn_train_pre_nms:
             rpn_train_post_nms = rpn_train_pre_nms
         if rpn_test_post_nms > rpn_test_pre_nms:
@@ -407,11 +413,12 @@ class FasterRCNN(RCNN):
             # res (C, N, 6)
             res = F.concat(*[cls_id, score, bbox], dim=-1)
             # res (1, C*N, 6)
-            res = res.reshape((1, -1, 0))
+            if self.force_suppress:
+                res = res.reshape((1, -1, 0))
             # res (C, self.nms_topk, 6)
             res = F.contrib.box_nms(
                 res, overlap_thresh=self.nms_thresh, topk=self.nms_topk, valid_thresh=0.0001,
-                id_index=0, score_index=1, coord_start=2, force_suppress=True)
+                id_index=0, score_index=1, coord_start=2, force_suppress=self.force_nms)
             # res (C * self.nms_topk, 6)
             res = res.reshape((-3, 0))
             results.append(res)

--- a/gluoncv/model_zoo/faster_rcnn/faster_rcnn.py
+++ b/gluoncv/model_zoo/faster_rcnn/faster_rcnn.py
@@ -412,8 +412,8 @@ class FasterRCNN(RCNN):
             bbox = self.box_decoder(box_pred, self.box_to_center(rpn_box))
             # res (C, N, 6)
             res = F.concat(*[cls_id, score, bbox], dim=-1)
-            # res (1, C*N, 6)
             if self.force_suppress:
+                # res (1, C*N, 6), to allow cross-catogory suppression
                 res = res.reshape((1, -1, 0))
             # res (C, self.nms_topk, 6)
             res = F.contrib.box_nms(

--- a/gluoncv/model_zoo/faster_rcnn/faster_rcnn.py
+++ b/gluoncv/model_zoo/faster_rcnn/faster_rcnn.py
@@ -146,8 +146,8 @@ class FasterRCNN(RCNN):
         Apply NMS to top k detection results, use -1 to disable so that every Detection
          result is used in NMS.
     force_nms : bool
-        Appy NMS to all categories, this is to avoid overlapping detection results from different
-        categories.
+        Appy NMS to all categories, this is to avoid overlapping detection results
+        from different categories.
     post_nms : int
         Only return top `post_nms` detection results, the rest is discarded. The number is
         based on COCO dataset which has maximum 100 objects per image. You can adjust this

--- a/gluoncv/model_zoo/faster_rcnn/faster_rcnn.py
+++ b/gluoncv/model_zoo/faster_rcnn/faster_rcnn.py
@@ -406,6 +406,8 @@ class FasterRCNN(RCNN):
             bbox = self.box_decoder(box_pred, self.box_to_center(rpn_box))
             # res (C, N, 6)
             res = F.concat(*[cls_id, score, bbox], dim=-1)
+            # res (1, C*N, 6)
+            res = res.reshape((1, -1, 0))
             # res (C, self.nms_topk, 6)
             res = F.contrib.box_nms(
                 res, overlap_thresh=self.nms_thresh, topk=self.nms_topk, valid_thresh=0.0001,

--- a/gluoncv/model_zoo/rcnn/rcnn.py
+++ b/gluoncv/model_zoo/rcnn/rcnn.py
@@ -73,7 +73,7 @@ class RCNN(gluon.HybridBlock):
     def __init__(self, features, top_features, classes, box_features,
                  short, max_size, train_patterns,
                  nms_thresh, nms_topk, post_nms,
-                 roi_mode, roi_size, strides, clip, **kwargs):
+                 roi_mode, roi_size, strides, clip, force_nms=False, **kwargs):
         super(RCNN, self).__init__(**kwargs)
         self.classes = classes
         self.num_class = len(classes)
@@ -83,6 +83,7 @@ class RCNN(gluon.HybridBlock):
         self.nms_thresh = nms_thresh
         self.nms_topk = nms_topk
         self.post_nms = post_nms
+        self.force_nms = force_nms
 
         assert self.num_class > 0, "Invalid number of class : {}".format(self.num_class)
         assert roi_mode.lower() in ['align', 'pool'], "Invalid roi_mode: {}".format(roi_mode)
@@ -126,7 +127,7 @@ class RCNN(gluon.HybridBlock):
             return self.collect_params(self.train_patterns)
         return self.collect_params(select)
 
-    def set_nms(self, nms_thresh=0.3, nms_topk=400, post_nms=100):
+    def set_nms(self, nms_thresh=0.3, nms_topk=400, post_nms=100, force_nms=False):
         """Set NMS parameters to the network.
 
         .. Note::
@@ -144,6 +145,9 @@ class RCNN(gluon.HybridBlock):
             Only return top `post_nms` detection results, the rest is discarded. The number is
             based on COCO dataset which has maximum 100 objects per image. You can adjust this
             number if expecting more objects. You can use -1 to return all detections.
+        force_nms : bool, default is False
+            Appy NMS to all categories, this is to avoid overlapping detection results from different
+            categories.
 
         Returns
         -------
@@ -154,6 +158,7 @@ class RCNN(gluon.HybridBlock):
         self.nms_thresh = nms_thresh
         self.nms_topk = nms_topk
         self.post_nms = post_nms
+        self.force_nms = force_nms
 
     def reset_class(self, classes, reuse_weights=None):
         """Reset class categories and class predictors.

--- a/gluoncv/model_zoo/rcnn/rcnn.py
+++ b/gluoncv/model_zoo/rcnn/rcnn.py
@@ -146,8 +146,8 @@ class RCNN(gluon.HybridBlock):
             based on COCO dataset which has maximum 100 objects per image. You can adjust this
             number if expecting more objects. You can use -1 to return all detections.
         force_nms : bool, default is False
-            Appy NMS to all categories, this is to avoid overlapping detection results from different
-            categories.
+            Appy NMS to all categories, this is to avoid overlapping detection results
+            from different categories.
 
         Returns
         -------


### PR DESCRIPTION
Fix #830, there's a bug when `force_nms=True`, input detection results must be put together in order to get suppressed acorss categories. 