### PR TITLE
Add AMP and Horovod to Faster-RCNN

### DIFF
--- a/scripts/detection/faster_rcnn/README.md
+++ b/scripts/detection/faster_rcnn/README.md
@@ -2,6 +2,9 @@
 
 [GluonCV Model Zoo](http://gluon-cv.mxnet.io/model_zoo/index.html#object-detection)
 
+- `--amp` Use [Automatic Mixed Precision training](https://mxnet.incubator.apache.org/versions/master/tutorials/amp/amp_tutorial.html), automatically casting FP16 where safe.
+- `--horovod` Use [Horovod](https://github.com/horovod/horovod) for distributed training, with a network agnostic wrapper for the optimizer, allowing efficient allreduce using OpemMPI and NCCL.
+
 ## References
 1. Shaoqing Ren, Kaiming He, Ross Girshick, and Jian Sun. "Faster R-CNN: Towards real-time object detection with region proposal networks." In IEEE Transactions on Pattern Analysis and Machine Intelligence, 2016.
 2. Ross Girshick. "Fast R-CNN." In Proceedings of the IEEE International Conference on Computer Vision, 2015.

--- a/scripts/detection/faster_rcnn/train_faster_rcnn.py
+++ b/scripts/detection/faster_rcnn/train_faster_rcnn.py
@@ -20,8 +20,11 @@ from gluoncv.data.transforms.presets.rcnn import FasterRCNNDefaultTrainTransform
     FasterRCNNDefaultValTransform
 from gluoncv.utils.metrics.voc_detection import VOC07MApMetric
 from gluoncv.utils.metrics.coco_detection import COCODetectionMetric
-import horovod.mxnet as hvd
 
+try:
+    import horovod.mxnet as hvd
+except ImportError:
+    hvd = None
 
 def parse_args():
     parser = argparse.ArgumentParser(description='Train Faster-RCNN networks e2e.')
@@ -484,6 +487,8 @@ if __name__ == '__main__':
         amp.init()
 
     if args.horovod:
+        if hvd is None:
+            raise SystemExit("Horovod not found, please check if you installed it correctly.")
         hvd.init()
 
     # training contexts


### PR DESCRIPTION
### Overview

Add two options to accelerate the training of Faster-RCNN in GluonCV:

- `--amp` Use Automatic Mixed Precision training, automatically casting FP16 where safe
- `--horovod` Use Horovod for distributed training, with a network agnostic wrapper for the optimizer, allowing efficient allreduce using OpemMPI and NCCL

### Note

For Python < 3.6, the training with Horovod requires the fix in  https://github.com/horovod/horovod/pull/1186

### Results
On a system with DGX-1 with 8 V100 GPUs, training with COCO dataset and ResNet-50 backbone **increase training speed by x4**.

Default: ~21 img/s 
```
$ python ../gluon-cv/scripts/detection/faster_rcnn/train_faster_rcnn.py --dataset coco -j 4 --log-interval 10 --gpus=0,1,2,3,4,5,6,7

[Epoch 0][Batch 939], Speed: 22.155 samples/sec, RPN_Conf=0.219,RPN_SmoothL1=0.138,RCNN_CrossEntropy=0.811,RCNN_SmoothL1=0.387,RPNAcc=0.909,RPNL1Loss=0.548,RCNNAcc=0.818,RCNNL1Loss=1.986
[Epoch 0][Batch 949], Speed: 21.807 samples/sec, RPN_Conf=0.219,RPN_SmoothL1=0.138,RCNN_CrossEntropy=0.811,RCNN_SmoothL1=0.388,RPNAcc=0.909,RPNL1Loss=0.548,RCNNAcc=0.817,RCNNL1Loss=1.986
[Epoch 0][Batch 959], Speed: 21.567 samples/sec, RPN_Conf=0.219,RPN_SmoothL1=0.138,RCNN_CrossEntropy=0.810,RCNN_SmoothL1=0.388,RPNAcc=0.910,RPNL1Loss=0.547,RCNNAcc=0.817,RCNNL1Loss=1.986
[Epoch 0][Batch 969], Speed: 22.045 samples/sec, RPN_Conf=0.218,RPN_SmoothL1=0.138,RCNN_CrossEntropy=0.809,RCNN_SmoothL1=0.388,RPNAcc=0.910,RPNL1Loss=0.547,RCNNAcc=0.818,RCNNL1Loss=1.984

```

AMP + Horovod: ~80 img/s

```
$ horovodrun -np 8 -H localhost:8 python ./gluon-cv/scripts/detection/faster_rcnn/train_faster_rcnn.py --dataset coco -j 4 --log-interval 10 --horovod --amp

[Epoch 0][Batch 939], Speed: 71.054 samples/sec, RPN_Conf=0.281,RPN_SmoothL1=0.158,RCNN_CrossEntropy=0.968,RCNN_SmoothL1=0.329,RPNAcc=0.891,RPNL1Loss=0.637,RCNNAcc=0.830,RCNNL1Loss=1.962
[Epoch 0][Batch 949], Speed: 79.616 samples/sec, RPN_Conf=0.280,RPN_SmoothL1=0.158,RCNN_CrossEntropy=0.968,RCNN_SmoothL1=0.330,RPNAcc=0.891,RPNL1Loss=0.638,RCNNAcc=0.829,RCNNL1Loss=1.967
[Epoch 0][Batch 959], Speed: 79.883 samples/sec, RPN_Conf=0.280,RPN_SmoothL1=0.158,RCNN_CrossEntropy=0.968,RCNN_SmoothL1=0.331,RPNAcc=0.891,RPNL1Loss=0.637,RCNNAcc=0.829,RCNNL1Loss=1.966
[Epoch 0][Batch 969], Speed: 80.262 samples/sec, RPN_Conf=0.280,RPN_SmoothL1=0.158,RCNN_CrossEntropy=0.967,RCNN_SmoothL1=0.333,RPNAcc=0.891,RPNL1Loss=0.636,RCNNAcc=0.829,RCNNL1Loss=1.970
```