### PR TITLE
Fix Get RGB color from matplotlib colormap

### DIFF
--- a/gluoncv/utils/viz/keypoints.py
+++ b/gluoncv/utils/viz/keypoints.py
@@ -133,7 +133,7 @@ def cv_plot_keypoints(img, coords, confidence, class_ids, bboxes, scores,
         pts = coords[i]
         for cm_ind, jp in zip(colormap_index, joint_pairs):
             if joint_visible[i, jp[0]] and joint_visible[i, jp[1]]:
-                cm_color = tuple([int(x * 255) for x in plt.cm.cool(cm_ind)[1:]])
+                cm_color = tuple([int(x * 255) for x in plt.cm.cool(cm_ind)[:3]])
                 pt1 = (int(pts[jp, 0][0]), int(pts[jp, 1][0]))
                 pt2 = (int(pts[jp, 0][1]), int(pts[jp, 1][1]))
                 cv2.line(img, pt1, pt2, cm_color, 3)


### PR DESCRIPTION
I found a small bug.
Is there any special meaning to not using RGB?
Thank you.

plt.cm.cool returns RGBA
[https://matplotlib.org/3.1.0/api/_as_gen/matplotlib.colors.Colormap.html#matplotlib.colors.Colormap](https://matplotlib.org/3.1.0/api/_as_gen/matplotlib.colors.Colormap.html#matplotlib.colors.Colormap)

