### PR TITLE
Add MobileNet V3 models to model zoo

### DIFF
--- a/docs/model_zoo/classification.rst
+++ b/docs/model_zoo/classification.rst
@@ -213,6 +213,10 @@ MobileNet
    +--------------------------+--------+--------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------+
    | MobileNetV2_0.25 [5]_    | 51.76  | 74.89  | 9b1d2cc3 | `shell script <https://raw.githubusercontent.com/dmlc/web-data/master/gluoncv/logs/classification/imagenet/mobilenetv2_0.25.sh>`_       | `log <https://raw.githubusercontent.com/dmlc/web-data/master/gluoncv/logs/classification/imagenet/mobilenetv2_0.25.log>`_     |
    +--------------------------+--------+--------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------+
+   | MobileNetV3_Large [15]_  | 75.32  | 92.30  | eaa44578 | `shell script <https://raw.githubusercontent.com/dmlc/web-data/master/gluoncv/logs/classification/imagenet/mobilenetv3_large.sh>`_      | `log <https://raw.githubusercontent.com/dmlc/web-data/master/gluoncv/logs/classification/imagenet/mobilenetv3_large.log>`_    |
+   +--------------------------+--------+--------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------+
+   | MobileNetV2_Small [15]_  | 67.72  | 87.51  | 33c100a7 | `shell script <https://raw.githubusercontent.com/dmlc/web-data/master/gluoncv/logs/classification/imagenet/mobilenetv3_small.sh>`_      | `log <https://raw.githubusercontent.com/dmlc/web-data/master/gluoncv/logs/classification/imagenet/mobilenetv3_small.log>`_    |
+   +--------------------------+--------+--------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------+
 
 VGG
 ---
@@ -407,3 +411,6 @@ The following table lists pre-trained models trained on CIFAR10.
        "mixup: Beyond empirical risk minimization." \
        arXiv preprint arXiv:1710.09412 (2017).
 .. [14] Hu, Jie, Li Shen, and Gang Sun. "Squeeze-and-excitation networks." arXiv preprint arXiv:1709.01507 7 (2017).
+.. [15] Howard, Andrew, Mark Sandler, Grace Chu, Liang-Chieh Chen, Bo Chen, Mingxing Tan, Weijun Wang et al. \
+       "Searching for mobilenetv3." \
+       arXiv preprint arXiv:1905.02244 (2019).

--- a/gluoncv/model_zoo/model_store.py
+++ b/gluoncv/model_zoo/model_store.py
@@ -23,6 +23,8 @@ _model_sha1 = {name: checksum for checksum, name in [
     ('b56e3d1c33eb52d0b90678db4ce6c5ca6c9a6704', 'mobilenetv2_0.75'),
     ('0803818513599fa1329524ee3607b708b4a4630f', 'mobilenetv2_0.5'),
     ('9b1d2cc38fed4cd171a7f7a0d17fe1a905573887', 'mobilenetv2_0.25'),
+    ('eaa44578554ddffaf2a2630ced9093181ff79688', 'mobilenetv3_large'),
+    ('33c100a740c0a278ec06e8640b19f52b744d1f11', 'mobilenetv3_small'),
     ('a0666292f0a30ff61f857b0b66efc0228eb6a54b', 'resnet18_v1'),
     ('48216ba99a8b1005d75c0f3a0c422301a0473233', 'resnet34_v1'),
     ('cc729d95031ca98cf2ff362eb57dee4d9994e4b2', 'resnet50_v1'),

--- a/tests/unittests/test_model_zoo.py
+++ b/tests/unittests/test_model_zoo.py
@@ -111,6 +111,7 @@ def test_imagenet_models():
               'senet_154', 'squeezenet1.0', 'squeezenet1.1',
               'mobilenet1.0', 'mobilenet0.75', 'mobilenet0.5', 'mobilenet0.25',
               'mobilenetv2_1.0', 'mobilenetv2_0.75', 'mobilenetv2_0.5', 'mobilenetv2_0.25',
+              'mobilenetv3_large', 'mobilenetv3_small',
               'densenet121', 'densenet161', 'densenet169', 'densenet201',
               'darknet53', 'alexnet',
               'vgg11', 'vgg11_bn', 'vgg13', 'vgg13_bn',


### PR DESCRIPTION
This PR reproduces the accuracy of MobileNet v3 models, but with a different set of training parameters.

The actual model params will be uploaded later, so the CI is likely to fail. Need to trigger the CI again once they are on the server.