### PR TITLE
Fix reset_classes for YOLO and SSD from dicts

### DIFF
--- a/gluoncv/model_zoo/ssd/ssd.py
+++ b/gluoncv/model_zoo/ssd/ssd.py
@@ -256,22 +256,32 @@ class SSD(HybridBlock):
         if isinstance(reuse_weights, (dict, list)):
             if isinstance(reuse_weights, dict):
                 # trying to replace str with indices
+                new_keys = []
+                new_vals = []
                 for k, v in reuse_weights.items():
                     if isinstance(v, str):
                         try:
-                            v = old_classes.index(v)  # raise ValueError if not found
+                            new_vals.append(old_classes.index(v))  # raise ValueError if not found
                         except ValueError:
                             raise ValueError(
                                 "{} not found in old class names {}".format(v, old_classes))
-                        reuse_weights[k] = v
+                    else:
+                        if v < 0 or v >= len(old_classes):
+                            raise ValueError(
+                                "Index {} out of bounds for old class names".format(v))
+                        new_vals.append(v)
                     if isinstance(k, str):
                         try:
-                            new_idx = self.classes.index(k)  # raise ValueError if not found
+                            new_keys.append(self.classes.index(k))  # raise ValueError if not found
                         except ValueError:
                             raise ValueError(
                                 "{} not found in new class names {}".format(k, self.classes))
-                        reuse_weights.pop(k)
-                        reuse_weights[new_idx] = v
+                    else:
+                        if k < 0 or k >= len(self.classes):
+                            raise ValueError(
+                                "Index {} out of bounds for new class names".format(k))
+                        new_keys.append(k)
+                reuse_weights = dict(zip(new_keys, new_vals))
             else:
                 new_map = {}
                 for x in reuse_weights:

--- a/gluoncv/model_zoo/yolo/yolo3.py
+++ b/gluoncv/model_zoo/yolo/yolo3.py
@@ -470,22 +470,32 @@ class YOLOV3(gluon.HybridBlock):
         if isinstance(reuse_weights, (dict, list)):
             if isinstance(reuse_weights, dict):
                 # trying to replace str with indices
+                new_keys = []
+                new_vals = []
                 for k, v in reuse_weights.items():
                     if isinstance(v, str):
                         try:
-                            v = old_classes.index(v)  # raise ValueError if not found
+                            new_vals.append(old_classes.index(v))  # raise ValueError if not found
                         except ValueError:
                             raise ValueError(
                                 "{} not found in old class names {}".format(v, old_classes))
-                        reuse_weights[k] = v
+                    else:
+                        if v < 0 or v >= len(old_classes):
+                            raise ValueError(
+                                "Index {} out of bounds for old class names".format(v))
+                        new_vals.append(v)
                     if isinstance(k, str):
                         try:
-                            new_idx = self._classes.index(k)  # raise ValueError if not found
+                            new_keys.append(self.classes.index(k))  # raise ValueError if not found
                         except ValueError:
                             raise ValueError(
-                                "{} not found in new class names {}".format(k, self._classes))
-                        reuse_weights.pop(k)
-                        reuse_weights[new_idx] = v
+                                "{} not found in new class names {}".format(k, self.classes))
+                    else:
+                        if k < 0 or k >= len(self.classes):
+                            raise ValueError(
+                                "Index {} out of bounds for new class names".format(k))
+                        new_keys.append(k)
+                reuse_weights = dict(zip(new_keys, new_vals))
             else:
                 new_map = {}
                 for x in reuse_weights:

--- a/tests/unittests/test_model_zoo.py
+++ b/tests/unittests/test_model_zoo.py
@@ -206,7 +206,7 @@ def test_ssd_reset_class():
     net.reset_class(["person", "car", "bird"], reuse_weights={0: 14})
     net = gcv.model_zoo.get_model(model_name, pretrained=True, ctx=ctx)
     net.reset_class(["person", "car", "bird"], reuse_weights={0: "person"})
-    test_classes = ['bench', 'bicycle', 'bus', 'car', 'cat']
+    test_classes = ['bird', 'bicycle', 'bus', 'car', 'cat']
     test_classes_dict = dict(zip(test_classes, test_classes))
     net = gcv.model_zoo.get_model(model_name, pretrained=True, ctx=ctx)
     net.reset_class(test_classes, reuse_weights=test_classes_dict)

--- a/tests/unittests/test_model_zoo.py
+++ b/tests/unittests/test_model_zoo.py
@@ -206,7 +206,10 @@ def test_ssd_reset_class():
     net.reset_class(["person", "car", "bird"], reuse_weights={0: 14})
     net = gcv.model_zoo.get_model(model_name, pretrained=True, ctx=ctx)
     net.reset_class(["person", "car", "bird"], reuse_weights={0: "person"})
-
+    test_classes = ['bench', 'bicycle', 'bus', 'car', 'cat']
+    test_classes_dict = dict(zip(classes, classes))
+    net = gcv.model_zoo.get_model(model_name, pretrained=True, ctx=ctx)
+    net.reset_class(test_classes, reuse_weights=test_classes_dict)
     net(x)
 
 
@@ -225,12 +228,21 @@ def test_ssd_reset_class_on_gpu():
 
 
 def test_yolo3_reset_class():
+    test_classes = ['bird', 'bicycle', 'bus', 'car', 'cat']
+    test_classes_dict = dict(zip(test_classes, test_classes))
+
     ctx = mx.context.current_context()
-    x = mx.random.uniform(shape=(1, 3, 512, 544), ctx=ctx)  # allow non-squre and larger inputs
+    x = mx.random.uniform(shape=(1, 3, 512, 544), ctx=ctx)  # allow non-square and larger inputs
     model_name = 'yolo3_darknet53_voc'
     net = gcv.model_zoo.get_model(model_name, pretrained=True, ctx=ctx)
     net.hybridize()
     net.reset_class(["bus", "car", "bird"], reuse_weights=["bus", "car", "bird"])
+    net(x)
+    mx.nd.waitall()
+
+    net = gcv.model_zoo.get_model(model_name, pretrained=True, ctx=ctx)
+    net.hybridize()
+    net.reset_class(test_classes, reuse_weights=test_classes_dict)
     net(x)
     mx.nd.waitall()
 
@@ -243,6 +255,12 @@ def test_yolo3_reset_class():
     net = gcv.model_zoo.get_model(model_name, pretrained=True, ctx=ctx)
     net.hybridize()
     net.reset_class(["bus", "car", "bird"])
+    net(x)
+    mx.nd.waitall()
+
+    net = gcv.model_zoo.get_model(model_name, pretrained=True, ctx=ctx)
+    net.hybridize()
+    net.reset_class(test_classes, reuse_weights=test_classes_dict)
     net(x)
     mx.nd.waitall()
 

--- a/tests/unittests/test_model_zoo.py
+++ b/tests/unittests/test_model_zoo.py
@@ -207,7 +207,7 @@ def test_ssd_reset_class():
     net = gcv.model_zoo.get_model(model_name, pretrained=True, ctx=ctx)
     net.reset_class(["person", "car", "bird"], reuse_weights={0: "person"})
     test_classes = ['bench', 'bicycle', 'bus', 'car', 'cat']
-    test_classes_dict = dict(zip(classes, classes))
+    test_classes_dict = dict(zip(test_classes, test_classes))
     net = gcv.model_zoo.get_model(model_name, pretrained=True, ctx=ctx)
     net.reset_class(test_classes, reuse_weights=test_classes_dict)
     net(x)


### PR DESCRIPTION
This pull request fixes an issue when target and source classes in `reset_class` from YOLO and SSD are mapped through a dictionary.

Adds the dictionary test to unit tests.

More details in https://github.com/dmlc/gluon-cv/issues/911