### PR TITLE
[Refactor MRCNN target generation]  make code more concise and efficient

### DIFF
--- a/gluoncv/model_zoo/mask_rcnn/rcnn_target.py
+++ b/gluoncv/model_zoo/mask_rcnn/rcnn_target.py
@@ -90,7 +90,7 @@ class MaskTargetGenerator(gluon.HybridBlock):
                 same_cids = same_cids.reshape((-2, 1, 1))
 
                 # (N, MS, MS) -> (N, C, 1, 1) -> (N, C, MS, MS)
-                mask_mask = F.broadcast_like(same_cids, pooled_mask, 
+                mask_mask = F.broadcast_like(same_cids, pooled_mask,
                                              lhs_axes=(2, 3), rhs_axes=(2, 3))
 
                 # (N, 1, MS, MS) -> (N, C, MS, MS)

--- a/gluoncv/model_zoo/mask_rcnn/rcnn_target.py
+++ b/gluoncv/model_zoo/mask_rcnn/rcnn_target.py
@@ -2,7 +2,6 @@
 from __future__ import absolute_import
 
 from mxnet import gluon, autograd
-import pdb
 
 
 class MaskTargetGenerator(gluon.HybridBlock):


### PR DESCRIPTION
make code for MRCNN target generation more concise and efficient by removing unnecessary operations, like reshape, transpose and expand_dim. 