### PR TITLE
Handle no Cython error in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,11 +5,17 @@ import re
 import sys
 
 import numpy as np
-from Cython.Build import cythonize
+try:
+    from Cython.Build import cythonize
+except ImportError:
+    cythonize = None
 from setuptools import setup, find_packages, Extension
 
 with_cython = False
 if '--with-cython' in sys.argv:
+    if not cythonize:
+        print("Cython not found, please run `pip install Cython`")
+        exit(1)
     with_cython = True
     sys.argv.remove('--with-cython')
 


### PR DESCRIPTION
The installation was failing when Cython package is not installed, even when building without `--install-option="--with-cython"`.

Add an import exception handler and an explicit error message.