### PR TITLE
add whole dataset shuffle for SplitSortedBucketSampler

### DIFF
--- a/gluoncv/nn/cython_bbox.pyx
+++ b/gluoncv/nn/cython_bbox.pyx
@@ -12,7 +12,6 @@ def np_normalized_box_encoder(np.ndarray[float, ndim=2] samples, np.ndarray[long
                               np.ndarray[float, ndim=3] anchors, np.ndarray[float, ndim=3] refs,
                               np.ndarray[float, ndim=1] means, np.ndarray[float, ndim=1] stds):
     cdef int b = refs.shape[0]
-    cdef int m = refs.shape[1]
     cdef int n = anchors.shape[1]
     cdef float ref_width, ref_height, ref_x, ref_y, ref_xmin, ref_ymin
     cdef float a_width, a_height, a_x, a_y, a_xmin, a_ymin

--- a/gluoncv/nn/feature.py
+++ b/gluoncv/nn/feature.py
@@ -256,7 +256,7 @@ class FPNFeatureExpander(SymbolBlock):
                     # method 1 : mx.sym.Crop
                     # y = mx.sym.Crop(*[y, bf], name="P{}_clip".format(num_stages-i))
                     # method 2 : mx.sym.slice_like
-                    y = mx.sym.slice_like(y, bf * 0, axes=(2, 3),
+                    y = mx.sym.slice_like(y, bf, axes=(2, 3),
                                           name="P{}_clip".format(num_stages - i))
                     y = mx.sym.ElementWiseSum(bf, y, name="P{}_sum".format(num_stages - i))
             # Reduce the aliasing effect of upsampling described in ori paper

--- a/gluoncv/nn/sampler.py
+++ b/gluoncv/nn/sampler.py
@@ -11,8 +11,8 @@ from __future__ import absolute_import
 
 import random
 
-import mxnet as mx
 import numpy as np
+import mxnet as mx
 from mxnet import gluon, nd
 from mxnet.gluon.data import Sampler
 

--- a/gluoncv/nn/sampler.py
+++ b/gluoncv/nn/sampler.py
@@ -11,8 +11,8 @@ from __future__ import absolute_import
 
 import random
 
-import numpy as np
 import mxnet as mx
+import numpy as np
 from mxnet import gluon, nd
 from mxnet.gluon.data import Sampler
 
@@ -427,7 +427,8 @@ class SplitSortedBucketSampler(Sampler):
     [-etc-]
     """
 
-    def __init__(self, sort_keys, batch_size, mult=32, num_parts=1, part_index=0, shuffle=False):
+    def __init__(self, sort_keys, batch_size, mult=32, num_parts=1, part_index=0, shuffle=False,
+                 seed=233):
         assert len(sort_keys) > 0
         assert batch_size > 0
         assert mult >= 1, 'Bucket size multiplier must be greater or equal to 1'
@@ -444,10 +445,16 @@ class SplitSortedBucketSampler(Sampler):
         self._end = self._start + part_len
         if part_index == num_parts - 1:
             self._end = length
+        self._num_parts = num_parts
+        self._seed = seed
+        self._shuffled_ids = np.random.RandomState(seed=self._seed).permutation(range(length))
 
     def __iter__(self):
+        if self._num_parts > 1:
+            self._shuffled_ids = np.random.RandomState(seed=self._seed).permutation(
+                self._shuffled_ids)
         if self._shuffle:
-            sample_ids = np.random.permutation(range(self._start, self._end))
+            sample_ids = np.random.permutation(self._shuffled_ids[self._start:self._end])
         else:
             sample_ids = list(range(self._start, self._end))
         bucket_size = int(self._mult * self._batch_size)


### PR DESCRIPTION
Shuffle the entire dataset before we shard it. We use seed to make sure that for each shard the permutation is the same, so that each shard doesn't have overlapping data.