### PR TITLE
Do not create additional contexts on GPU 0 when running SSD with DALI and Horovod

### DIFF
--- a/gluoncv/data/mscoco/detection.py
+++ b/gluoncv/data/mscoco/detection.py
@@ -233,9 +233,11 @@ class COCODetectionDALI(object):
         Directory containing the COCO dataset.
     annotations_file
         The COCO annotation file to read from.
+    device_id: int
+         GPU device used for the DALI pipeline.
     """
 
-    def __init__(self, num_shards, shard_id, file_root, annotations_file):
+    def __init__(self, num_shards, shard_id, file_root, annotations_file, device_id):
         self.input = dali.ops.COCOReader(
             file_root=file_root,
             annotations_file=annotations_file,
@@ -256,9 +258,9 @@ class COCODetectionDALI(object):
             and get the epoch size. To be replaced by DALI standalone op, when available.
             """
 
-            def __init__(self):
+            def __init__(self, device_id):
                 super(DummyMicroPipe, self).__init__(batch_size=1,
-                                                     device_id=0,
+                                                     device_id=device_id,
                                                      num_threads=1)
                 self.input = dali.ops.COCOReader(
                     file_root=file_root,
@@ -268,7 +270,7 @@ class COCODetectionDALI(object):
                 inputs, bboxes, labels = self.input(name="Reader")
                 return (inputs, bboxes, labels)
 
-        micro_pipe = DummyMicroPipe()
+        micro_pipe = DummyMicroPipe(device_id=device_id)
         micro_pipe.build()
         self._size = micro_pipe.epoch_size(name="Reader")
         del micro_pipe

--- a/scripts/detection/ssd/train_ssd.py
+++ b/scripts/detection/ssd/train_ssd.py
@@ -147,10 +147,10 @@ def get_dali_dataset(dataset_name, devices, args):
                                         'instances_train2017.json')
         if args.horovod:
             train_dataset = [gdata.COCODetectionDALI(num_shards=hvd.size(), shard_id=hvd.rank(), file_root=coco_root,
-                                                     annotations_file=coco_annotations)]
+                                                     annotations_file=coco_annotations, device_id=hvd.local_rank())]
         else:
             train_dataset = [gdata.COCODetectionDALI(num_shards= len(devices), shard_id=i, file_root=coco_root,
-                                                     annotations_file=coco_annotations) for i, _ in enumerate(devices)]
+                                                     annotations_file=coco_annotations, device_id=i) for i, _ in enumerate(devices)]
 
         # validation
         if (not args.horovod or hvd.rank() == 0):


### PR DESCRIPTION
Current COCODetectionDALI creates additional contexts on GPU 0 to get the dataset size, due to passing 0 to device_id parameter in DALI Pipeline constructor. In the case of multiprocess execution (like Horovod training) this results in unnecessary memory consumption on GPU 0.

@Kh4L @zhreshold FYI