### PR TITLE
Support video loader for action recognition

### DIFF
--- a/gluoncv/data/kinetics400/classification.py
+++ b/gluoncv/data/kinetics400/classification.py
@@ -252,10 +252,13 @@ class Kinetics400(dataset.Dataset):
         for seg_ind in indices:
             offset = int(seg_ind)
             for i, _ in enumerate(range(0, self.skip_length, self.new_step)):
-                if offset + skip_offsets[i] <= duration:
-                    vid_frame = video_reader[offset + skip_offsets[i] - 1].asnumpy()
-                else:
-                    vid_frame = video_reader[offset - 1].asnumpy()
+                try:
+                    if offset + skip_offsets[i] <= duration:
+                        vid_frame = video_reader[offset + skip_offsets[i] - 1].asnumpy()
+                    else:
+                        vid_frame = video_reader[offset - 1].asnumpy()
+                except:
+                    raise RuntimeError('Error occured in reading frames from video {} of duration {}.'.format(directory, duration))
                 sampled_list.append(vid_frame)
                 if offset + self.new_step < duration:
                     offset += self.new_step

--- a/gluoncv/data/kinetics400/classification.py
+++ b/gluoncv/data/kinetics400/classification.py
@@ -5,7 +5,6 @@ import os
 import numpy as np
 from mxnet import nd
 from mxnet.gluon.data import dataset
-from decord import VideoReader
 
 __all__ = ['Kinetics400']
 
@@ -82,8 +81,9 @@ class Kinetics400(dataset.Dataset):
 
         super(Kinetics400, self).__init__()
 
-        from ...utils.filesystem import try_import_cv2
+        from ...utils.filesystem import try_import_cv2, try_import_decord
         self.cv2 = try_import_cv2()
+        self.decord = try_import_decord()
         self.root = root
         self.setting = setting
         self.train = train
@@ -114,7 +114,7 @@ class Kinetics400(dataset.Dataset):
 
         directory, duration, target = self.clips[index]
         if self.video_loader:
-            decord_vr = VideoReader('{}.{}'.format(directory, self.video_ext), width=self.new_width, height=self.new_height)
+            decord_vr = self.decord.VideoReader('{}.{}'.format(directory, self.video_ext), width=self.new_width, height=self.new_height)
             duration = len(decord_vr)
 
         if self.train and not self.test_mode:

--- a/gluoncv/utils/filesystem.py
+++ b/gluoncv/utils/filesystem.py
@@ -52,6 +52,18 @@ def try_import_cv2():
         or `pip install opencv-python --user` (note that this is unofficial PYPI package)."
     return try_import('cv2', msg)
 
+def try_import_decord():
+    """Try import decord at runtime.
+
+    Returns
+    -------
+    Decord module if found. Raise ImportError otherwise
+
+    """
+    msg = "Decord is required, you can install by `pip install decord --user` \
+        (note that this is unofficial PYPI package)."
+    return try_import('decord', msg)
+
 def try_import_mmcv():
     """Try import mmcv at runtime.
 

--- a/scripts/action-recognition/test_recognizer.py
+++ b/scripts/action-recognition/test_recognizer.py
@@ -135,7 +135,9 @@ def parse_args():
     parser.add_argument('--use-softmax', action='store_true',
                         help='whether to use softmax scores.')
     parser.add_argument('--video-loader', action='store_true',
-                        help='if set to True, use decord to read videos directly instead of reading frames.')
+                        help='if set to True, read videos directly instead of reading frames.')
+    parser.add_argument('--use-decord', action='store_true',
+                        help='if set to True, use Decord video loader to load data. Otherwise use mmcv video loader.')
     opt = parser.parse_args()
     return opt
 
@@ -226,7 +228,7 @@ def main():
     elif opt.dataset == 'kinetics400':
         val_dataset = kinetics400.classification.Kinetics400(setting=opt.val_list, root=opt.data_dir, train=False,
                                                new_width=opt.new_width, new_height=opt.new_height, new_length=opt.new_length, new_step=opt.new_step,
-                                               target_width=opt.input_size, target_height=opt.input_size, video_loader=opt.video_loader,
+                                               target_width=opt.input_size, target_height=opt.input_size, video_loader=opt.video_loader, use_decord=opt.use_decord,
                                                test_mode=True, num_segments=opt.num_segments, transform=transform_test)
     else:
         logger.info('Dataset %s is not supported yet.' % (opt.dataset))

--- a/scripts/action-recognition/test_recognizer.py
+++ b/scripts/action-recognition/test_recognizer.py
@@ -134,6 +134,8 @@ def parse_args():
                         help='the input is 4d or 5d tensor. 5d is for 3D CNN models.')
     parser.add_argument('--use-softmax', action='store_true',
                         help='whether to use softmax scores.')
+    parser.add_argument('--video-loader', action='store_true',
+                        help='if set to True, use decord to read videos directly instead of reading frames.')
     opt = parser.parse_args()
     return opt
 
@@ -224,14 +226,14 @@ def main():
     elif opt.dataset == 'kinetics400':
         val_dataset = kinetics400.classification.Kinetics400(setting=opt.val_list, root=opt.data_dir, train=False,
                                                new_width=opt.new_width, new_height=opt.new_height, new_length=opt.new_length, new_step=opt.new_step,
-                                               target_width=opt.input_size, target_height=opt.input_size,
+                                               target_width=opt.input_size, target_height=opt.input_size, video_loader=opt.video_loader,
                                                test_mode=True, num_segments=opt.num_segments, transform=transform_test)
     else:
         logger.info('Dataset %s is not supported yet.' % (opt.dataset))
 
     val_data = gluon.data.DataLoader(val_dataset, batch_size=batch_size, shuffle=False, num_workers=num_workers,
                                      prefetch=int(opt.prefetch_ratio * num_workers), batchify_fn=tsn_mp_batchify_fn, last_batch='discard')
-    print('Load %d test samples.' % len(val_dataset))
+    print('Load %d test samples in %d iterations.' % (len(val_dataset), len(val_data)))
 
     start_time = time.time()
     acc_top1_val, acc_top5_val = test(context, val_data, opt, net)

--- a/scripts/action-recognition/train_recognizer.py
+++ b/scripts/action-recognition/train_recognizer.py
@@ -136,6 +136,8 @@ def parse_args():
                         help='KVStore type. Supports local, device, dist_sync_device, dist_async_device')
     parser.add_argument('--input-5d', action='store_true',
                         help='the input is 4d or 5d tensor. 5d is for 3D CNN models.')
+    parser.add_argument('--video-loader', action='store_true',
+                        help='if set to True, use decord to read videos directly instead of reading frames.')
     parser.add_argument('--accumulate', type=int, default=1,
                         help='new step to accumulate gradient. If >1, the batch size is enlarged.')
     opt = parser.parse_args()
@@ -161,11 +163,11 @@ def get_data_loader(opt, batch_size, num_workers, logger, kvstore=None):
     if opt.dataset == 'kinetics400':
         train_dataset = kinetics400.classification.Kinetics400(setting=opt.train_list, root=data_dir, train=True,
                                                      new_width=opt.new_width, new_height=opt.new_height, new_length=opt.new_length, new_step=opt.new_step,
-                                                     target_width=input_size, target_height=input_size,
+                                                     target_width=input_size, target_height=input_size, video_loader=opt.video_loader,
                                                      num_segments=opt.num_segments, transform=transform_train)
         val_dataset = kinetics400.classification.Kinetics400(setting=opt.val_list, root=val_data_dir, train=False,
                                                    new_width=opt.new_width, new_height=opt.new_height, new_length=opt.new_length, new_step=opt.new_step,
-                                                   target_width=input_size, target_height=input_size,
+                                                   target_width=input_size, target_height=input_size, video_loader=opt.video_loader,
                                                    num_segments=opt.num_segments, transform=transform_test)
     elif opt.dataset == 'ucf101':
         train_dataset = ucf101.classification.UCF101(setting=opt.train_list, root=data_dir, train=True,

--- a/scripts/action-recognition/train_recognizer.py
+++ b/scripts/action-recognition/train_recognizer.py
@@ -137,7 +137,9 @@ def parse_args():
     parser.add_argument('--input-5d', action='store_true',
                         help='the input is 4d or 5d tensor. 5d is for 3D CNN models.')
     parser.add_argument('--video-loader', action='store_true',
-                        help='if set to True, use decord to read videos directly instead of reading frames.')
+                        help='if set to True, read videos directly instead of reading frames.')
+    parser.add_argument('--use-decord', action='store_true',
+                        help='if set to True, use Decord video loader to load data. Otherwise use mmcv video loader.')
     parser.add_argument('--accumulate', type=int, default=1,
                         help='new step to accumulate gradient. If >1, the batch size is enlarged.')
     opt = parser.parse_args()
@@ -163,11 +165,11 @@ def get_data_loader(opt, batch_size, num_workers, logger, kvstore=None):
     if opt.dataset == 'kinetics400':
         train_dataset = kinetics400.classification.Kinetics400(setting=opt.train_list, root=data_dir, train=True,
                                                      new_width=opt.new_width, new_height=opt.new_height, new_length=opt.new_length, new_step=opt.new_step,
-                                                     target_width=input_size, target_height=input_size, video_loader=opt.video_loader,
+                                                     target_width=input_size, target_height=input_size, video_loader=opt.video_loader, use_decord=opt.use_decord,
                                                      num_segments=opt.num_segments, transform=transform_train)
         val_dataset = kinetics400.classification.Kinetics400(setting=opt.val_list, root=val_data_dir, train=False,
                                                    new_width=opt.new_width, new_height=opt.new_height, new_length=opt.new_length, new_step=opt.new_step,
-                                                   target_width=input_size, target_height=input_size, video_loader=opt.video_loader,
+                                                   target_width=input_size, target_height=input_size, video_loader=opt.video_loader, use_decord=opt.use_decord,
                                                    num_segments=opt.num_segments, transform=transform_test)
     elif opt.dataset == 'ucf101':
         train_dataset = ucf101.classification.UCF101(setting=opt.train_list, root=data_dir, train=True,


### PR DESCRIPTION
**Description**

This PR supports reading videos directly during training and testing for video action recognition. 

On four models we have: 

1. Training accuracy is similar to that of reading frames. The training curves match.

2. Testing accuracy is almost the same as that of reading frames (within 0.2% gap). 

3. Using Decord to load videos directly is significantly faster than using mmcv videoreader (8x speed up). But it is still slower than reading from frames (0.5x speed). This makes sense because frames are already decoded beforehand, there is no need to perform video decoding on the fly. 

4. However, video loader still has its advantages, e.g., saving disk space and making dataset preparation easier. For Kinetics400 dataset, the videos only take 400G space, while the extracted frames take more than 3TB. And the process of decoding videos to frames also takes time, e.g., it takes about 8 hours using 60 workers to do this decoding. 

