### PR TITLE
Update cityscapes.py

### DIFF
--- a/gluoncv/data/cityscapes.py
+++ b/gluoncv/data/cityscapes.py
@@ -48,6 +48,7 @@ class CitySegmentation(SegmentationDataset):
     def __getitem__(self, index):
         img = Image.open(self.images[index]).convert('RGB')
         if self.mode == 'test':
+            img = self._img_transform(img)
             if self.transform is not None:
                 img = self.transform(img)
             return img, os.path.basename(self.images[index])


### PR DESCRIPTION
Fix the bug that when split is 'val' and mode is 'test', it returns a PIL.Image.Image object instead of NDArray.