### PR TITLE
Add dim check for segmentation

### DIFF
--- a/docs/model_zoo/segmentation.rst
+++ b/docs/model_zoo/segmentation.rst
@@ -31,7 +31,7 @@ Table of pre-trained models for semantic segmentation and their performance.
   The test script :download:`Download test.py<../../scripts/segmentation/test.py>` can be used for
   evaluating the models (VOC results are evaluated using the official server). For example ``fcn_resnet50_ade``::
 
-    python test.py --dataset ade20k --model-zoo fcn_resnet50_ade --eval
+    python test.py --dataset ade20k --pretrained --model fcn --backbone resnet50 --eval
 
   The training commands work with the script: :download:`Download train.py<../../scripts/segmentation/train.py>`
 

--- a/gluoncv/utils/metrics/segmentation.py
+++ b/gluoncv/utils/metrics/segmentation.py
@@ -83,6 +83,7 @@ class SegmentationMetric(EvalMetric):
 def batch_pix_accuracy(output, target):
     """PixAcc"""
     # inputs are NDarray, output 4D, target 3D
+    # add new axis if missing batch dimension
     # the category -1 is ignored class, typically for background / boundary
     if len(output.shape) == 3:
         output = output[np.newaxis, :]
@@ -102,6 +103,7 @@ def batch_pix_accuracy(output, target):
 def batch_intersection_union(output, target, nclass):
     """mIoU"""
     # inputs are NDarray, output 4D, target 3D
+    # add new axis if missing batch dimension
     # the category -1 is ignored class, typically for background / boundary
     if len(output.shape) == 3:
         output = output[np.newaxis, :]


### PR DESCRIPTION
1. The test.py example mentioned at 
[segmentation.rst](https://github.com/dmlc/gluon-cv/blob/master/docs/model_zoo/segmentation.rst)
does not match the arguments mentioned in test.py
should probably be change to
`python test.py --dataset ade20k --pretrained --model fcn --backbone resnet50 --eval
`

2. The dimension doesn't seem right when calculating the pixACC and mIoU
The output is 3D and the target is 2D
The safest way I could think of is to add a new axis if batch dim is missing. 
Might have a better way to deal with.

Result after modification (without training)
![Screenshot from 2019-10-17 20-26-19](https://user-images.githubusercontent.com/18246639/67066806-ee450f80-f128-11e9-9011-b91fa8ee1859.png)


