### PR TITLE
Bug Fix: Missing return on DeepLab `demo` method

### DIFF
--- a/gluoncv/model_zoo/deeplabv3.py
+++ b/gluoncv/model_zoo/deeplabv3.py
@@ -66,7 +66,7 @@ class DeepLabV3(SegBaseModel):
         return tuple(outputs)
 
     def demo(self, x):
-        self.predict(x)
+        return self.predict(x)
 
     def predict(self, x):
         h, w = x.shape[2:]


### PR DESCRIPTION
As part of switch from `demo` to `predict`, a return statement was missed which breaks backward compatability.