### PR TITLE
Fix invalid argument of clip when running ssd inference

### DIFF
--- a/gluoncv/nn/coder.py
+++ b/gluoncv/nn/coder.py
@@ -251,14 +251,14 @@ class NormalizedBoxCenterDecoder(gluon.HybridBlock):
     ----------
     stds : array-like of size 4
         Std value to be divided from encoded values, default is (0.1, 0.1, 0.2, 0.2).
-    clip : float, default is None
+    clip : float, default is -1.0
         If given, bounding box target will be clipped to this value.
     convert_anchor : boolean, default is False
         Whether to convert anchor from corner to center format.
 
     """
 
-    def __init__(self, stds=(0.1, 0.1, 0.2, 0.2), convert_anchor=False, clip=None):
+    def __init__(self, stds=(0.1, 0.1, 0.2, 0.2), convert_anchor=False, clip=-1.0):
         super(NormalizedBoxCenterDecoder, self).__init__()
         assert len(stds) == 4, "Box Encoder requires 4 std values."
         self._stds = stds


### PR DESCRIPTION
@pengzhao-intel @xinyu-intel @zhreshold 

This PR is to make the default value of clip in `NormalizedBoxCenterDecoder()` aligned with the value in MXNet (defined in [bounding_box-inl.h#L939](https://github.com/apache/incubator-mxnet/blob/master/src/operator/contrib/bounding_box-inl.h#L939), introduced by [PR#16215](https://github.com/apache/incubator-mxnet/pull/16215)) . 

Before, when running ssd inference, there will be an error, like below:
```
>>>  python eval_ssd.py --network=mobilenet1.0 --data-shape=512 --batch-size=1
......
mxnet.base.MXNetError: Invalid Parameter format for clip expect float but value='None', in operator _contrib_box_decode(name="", format="center", std2="0.2", clip="None", std3="0.2", std1="0.1", std0="0.1")
```


