### PR TITLE
Add export test for 3d models

### DIFF
--- a/gluoncv/utils/export_helper.py
+++ b/gluoncv/utils/export_helper.py
@@ -99,9 +99,9 @@ def export_block(path, block, data_shape=None, epoch=0, preprocess=True, layout=
     # try different data_shape if possible, until one fits the network
     last_exception = None
     for dshape in data_shapes:
-        if layout == 'HWC' or layout == 'CHW':
+        if layout in ('HWC', 'CHW'):
             h, w, c = dshape
-        elif layout == 'THWC' or layout == 'CTHW':
+        elif layout in ('THWC', 'CTHW'):
             t, h, w, c = dshape
         else:
             raise RuntimeError('Input layout %s is not supported yet.' % (layout))

--- a/gluoncv/utils/export_helper.py
+++ b/gluoncv/utils/export_helper.py
@@ -99,20 +99,18 @@ def export_block(path, block, data_shape=None, epoch=0, preprocess=True, layout=
     # try different data_shape if possible, until one fits the network
     last_exception = None
     for dshape in data_shapes:
-        if layout in ('HWC', 'CHW'):
-            h, w, c = dshape
-        elif layout in ('THWC', 'CTHW'):
-            t, h, w, c = dshape
-        else:
-            raise RuntimeError('Input layout %s is not supported yet.' % (layout))
 
         if layout == 'HWC':
+            h, w, c = dshape
             x = mx.nd.zeros((1, h, w, c), ctx=ctx)
         elif layout == 'CHW':
+            c, h, w = dshape
             x = mx.nd.zeros((1, c, h, w), ctx=ctx)
         elif layout == 'THWC':
+            t, h, w, c = dshape
             x = mx.nd.zeros((1, t, h, w, c), ctx=ctx)
         elif layout == 'CTHW':
+            c, t, h, w = dshape
             x = mx.nd.zeros((1, c, t, h, w), ctx=ctx)
         else:
             raise RuntimeError('Input layout %s is not supported yet.' % (layout))

--- a/gluoncv/utils/export_helper.py
+++ b/gluoncv/utils/export_helper.py
@@ -50,7 +50,8 @@ def export_block(path, block, data_shape=None, epoch=0, preprocess=True, layout=
     block : mxnet.gluon.HybridBlock
         The hybridizable block. Note that normal gluon.Block is not supported.
     data_shape : tuple of int, default is None
-        Fake data shape just for export purpose, in format (H, W, C).
+        Fake data shape just for export purpose, in format (H, W, C) for 2D data
+        or (T, H, W, C) for 3D data.
         If you don't specify ``data_shape``, `export_block` will try use some common data_shapes,
         e.g., (224, 224, 3), (256, 256, 3), (299, 299, 3), (512, 512, 3)...
         If any of this ``data_shape`` goes through, the export will succeed.
@@ -64,7 +65,7 @@ def export_block(path, block, data_shape=None, epoch=0, preprocess=True, layout=
         pre-trained models.
         You can use custom pre-process hybrid block or disable by set ``preprocess=None``.
     layout : str, default is 'HWC'
-        The layout for raw input data. By default is HWC. Supports 'HWC' and 'CHW'.
+        The layout for raw input data. By default is HWC. Supports 'HWC', 'CHW', 'THWC' and 'CTHW'.
         Note that image channel order is always RGB.
     ctx: mx.Context, default mx.cpu()
         Network context.
@@ -98,11 +99,23 @@ def export_block(path, block, data_shape=None, epoch=0, preprocess=True, layout=
     # try different data_shape if possible, until one fits the network
     last_exception = None
     for dshape in data_shapes:
-        h, w, c = dshape
+        if layout == 'HWC' or layout == 'CHW':
+            h, w, c = dshape
+        elif layout == 'THWC' or layout == 'CTHW':
+            t, h, w, c = dshape
+        else:
+            raise RuntimeError('Input layout %s is not supported yet.' % (layout))
+
         if layout == 'HWC':
             x = mx.nd.zeros((1, h, w, c), ctx=ctx)
         elif layout == 'CHW':
             x = mx.nd.zeros((1, c, h, w), ctx=ctx)
+        elif layout == 'THWC':
+            x = mx.nd.zeros((1, t, h, w, c), ctx=ctx)
+        elif layout == 'CTHW':
+            x = mx.nd.zeros((1, c, t, h, w), ctx=ctx)
+        else:
+            raise RuntimeError('Input layout %s is not supported yet.' % (layout))
 
         # hybridize and forward once
         wrapper_block.hybridize()

--- a/tests/unittests/test_utils_export.py
+++ b/tests/unittests/test_utils_export.py
@@ -15,13 +15,13 @@ def test_export_model_zoo():
             kwargs = {'data_shape':(480, 480, 3)}
         elif '3d' in model:
             # video action recognition models require 4d data shape
-            kwargs = {'data_shape':(32, 224, 224, 3), 'layout':'CTHW', 'preprocess':None}
+            kwargs = {'data_shape':(3, 32, 224, 224), 'layout':'CTHW', 'preprocess':None}
         elif 'slowfast_4x16' in model:
             # video action recognition models require 4d data shape
-            kwargs = {'data_shape':(36, 224, 224, 3), 'layout':'CTHW', 'preprocess':None}
+            kwargs = {'data_shape':(3, 36, 224, 224), 'layout':'CTHW', 'preprocess':None}
         elif 'slowfast_8x8' in model:
             # video action recognition models require 4d data shape
-            kwargs = {'data_shape':(40, 224, 224, 3), 'layout':'CTHW', 'preprocess':None}
+            kwargs = {'data_shape':(3, 40, 224, 224), 'layout':'CTHW', 'preprocess':None}
         else:
             kwargs = {}
 

--- a/tests/unittests/test_utils_export.py
+++ b/tests/unittests/test_utils_export.py
@@ -8,11 +8,26 @@ from common import try_gpu
 @try_gpu(0)
 def test_export_model_zoo():
     for model in pretrained_model_list():
-        if 'i3d' in model: continue    # 3D model do not support it now, skip. Data shape is 5D.
         print('exporting:', model)
-        kwargs = {'data_shape':(480, 480, 3)} if 'deeplab' in model or 'psp' in model else {}
+
+        if 'deeplab' in model or 'psp' in model:
+            # semantic segmentation models require fixed data shape
+            kwargs = {'data_shape':(480, 480, 3)}
+        elif '3d' in model:
+            # video action recognition models require 4d data shape
+            kwargs = {'data_shape':(32, 224, 224, 3), 'layout':'CTHW', 'preprocess':None}
+        elif 'slowfast_4x16' in model:
+            # video action recognition models require 4d data shape
+            kwargs = {'data_shape':(36, 224, 224, 3), 'layout':'CTHW', 'preprocess':None}
+        elif 'slowfast_8x8' in model:
+            # video action recognition models require 4d data shape
+            kwargs = {'data_shape':(40, 224, 224, 3), 'layout':'CTHW', 'preprocess':None}
+        else:
+            kwargs = {}
+
         if '_gn' in model:
             continue
+
         try:
             gcv.utils.export_block(model, gcv.model_zoo.get_model(model, pretrained=True), **kwargs)
         except ValueError:


### PR DESCRIPTION
This PR adds model exporting test for 3D models, including I3D and SlowFast. 

Previously, the two functions below only support 2D data, which is in `HWC` format. Now the test can cover 3D data, which is in `THWC` format. 