### PR TITLE
Add multiprocessing lock for model download

### DIFF
--- a/docs/build.yml
+++ b/docs/build.yml
@@ -18,3 +18,4 @@ dependencies:
   - requests
   - Pillow
   - opencv-python
+  - portalocker

--- a/gluoncv/model_zoo/model_store.py
+++ b/gluoncv/model_zoo/model_store.py
@@ -1,4 +1,4 @@
-"""Model store which provides pretrained models."""
+    """Model store which provides pretrained models."""
 from __future__ import print_function
 
 __all__ = ['get_model_file', 'purge']
@@ -6,6 +6,7 @@ import os
 import zipfile
 
 from ..utils import download, check_sha1
+import fasteners
 
 _model_sha1 = {name: checksum for checksum, name in [
     ('44335d1f0046b328243b32a26a4fbd62d9057b45', 'alexnet'),
@@ -217,32 +218,33 @@ def get_model_file(name, tag=None, root=os.path.join('~', '.mxnet', 'models')):
         sha1_hash = tag
     else:
         sha1_hash = _model_sha1[name]
-    if os.path.exists(file_path):
+    with fasteners.InterProcessLock(file_path):
+        if os.path.exists(file_path):
+            if check_sha1(file_path, sha1_hash):
+                return file_path
+            else:
+                print('Mismatch in the content of model file detected. Downloading again.')
+        else:
+            print('Model file is not found. Downloading.')
+
+        if not os.path.exists(root):
+            os.makedirs(root)
+
+        zip_file_path = os.path.join(root, file_name + '.zip')
+        repo_url = os.environ.get('MXNET_GLUON_REPO', apache_repo_url)
+        if repo_url[-1] != '/':
+            repo_url = repo_url + '/'
+        download(_url_format.format(repo_url=repo_url, file_name=file_name),
+                 path=zip_file_path,
+                 overwrite=True)
+        with zipfile.ZipFile(zip_file_path) as zf:
+            zf.extractall(root)
+        os.remove(zip_file_path)
+
         if check_sha1(file_path, sha1_hash):
             return file_path
         else:
-            print('Mismatch in the content of model file detected. Downloading again.')
-    else:
-        print('Model file is not found. Downloading.')
-
-    if not os.path.exists(root):
-        os.makedirs(root)
-
-    zip_file_path = os.path.join(root, file_name + '.zip')
-    repo_url = os.environ.get('MXNET_GLUON_REPO', apache_repo_url)
-    if repo_url[-1] != '/':
-        repo_url = repo_url + '/'
-    download(_url_format.format(repo_url=repo_url, file_name=file_name),
-             path=zip_file_path,
-             overwrite=True)
-    with zipfile.ZipFile(zip_file_path) as zf:
-        zf.extractall(root)
-    os.remove(zip_file_path)
-
-    if check_sha1(file_path, sha1_hash):
-        return file_path
-    else:
-        raise ValueError('Downloaded file has different hash. Please try again.')
+            raise ValueError('Downloaded file has different hash. Please try again.')
 
 
 def purge(root=os.path.join('~', '.mxnet', 'models')):

--- a/gluoncv/model_zoo/model_store.py
+++ b/gluoncv/model_zoo/model_store.py
@@ -4,9 +4,9 @@ from __future__ import print_function
 __all__ = ['get_model_file', 'purge']
 import os
 import zipfile
+import logging
 
 from ..utils import download, check_sha1
-import logging
 import portalocker
 
 _model_sha1 = {name: checksum for checksum, name in [

--- a/gluoncv/model_zoo/model_store.py
+++ b/gluoncv/model_zoo/model_store.py
@@ -5,9 +5,9 @@ __all__ = ['get_model_file', 'purge']
 import os
 import zipfile
 import logging
+import portalocker
 
 from ..utils import download, check_sha1
-import portalocker
 
 _model_sha1 = {name: checksum for checksum, name in [
     ('44335d1f0046b328243b32a26a4fbd62d9057b45', 'alexnet'),

--- a/gluoncv/model_zoo/model_store.py
+++ b/gluoncv/model_zoo/model_store.py
@@ -6,8 +6,8 @@ import os
 import zipfile
 
 from ..utils import download, check_sha1
-import portalocker
 import logging
+import portalocker
 
 _model_sha1 = {name: checksum for checksum, name in [
     ('44335d1f0046b328243b32a26a4fbd62d9057b45', 'alexnet'),

--- a/gluoncv/model_zoo/model_store.py
+++ b/gluoncv/model_zoo/model_store.py
@@ -225,8 +225,8 @@ def get_model_file(name, tag=None, root=os.path.join('~', '.mxnet', 'models')):
             if check_sha1(params_path, sha1_hash):
                 return params_path
             else:
-                logging.warning("Hash mismatch in the content of model file '%s' detected. Downloading again.",
-                                params_path)
+                logging.warning("Hash mismatch in the content of model file '%s' detected. "
+                                "Downloading again.", params_path)
         else:
             logging.info('Model file not found. Downloading.')
 

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ requirements = [
     'requests',
     # 'mxnet',
     'matplotlib',
-    'fasteners',
+    'portalocker',
     'Pillow',
     'scipy',
 ]

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ requirements = [
     'requests',
     # 'mxnet',
     'matplotlib',
+    'fasteners',
     'Pillow',
     'scipy',
 ]

--- a/tests/py2.yml
+++ b/tests/py2.yml
@@ -22,3 +22,4 @@ dependencies:
     - nose-timer
     - opencv-python
     - git+https://github.com/zhanghang1989/detail-api.git#subdirectory=PythonAPI
+    - portalocker

--- a/tests/py3.yml
+++ b/tests/py3.yml
@@ -22,3 +22,4 @@ dependencies:
     - nose-timer
     - opencv-python
     - git+https://github.com/zhanghang1989/detail-api.git#subdirectory=PythonAPI
+    - portalocker


### PR DESCRIPTION
Downloading models doesn't work in distributed training (horovod) scenario as all the processes race to write the model file and training fails.

This change adds a lock file around the model so only one process in each machine will download the model, while the other processes wait.

@Jerryzcn 