### PR TITLE
Fix yolo transform

### DIFF
--- a/gluoncv/data/transforms/presets/center_net.py
+++ b/gluoncv/data/transforms/presets/center_net.py
@@ -48,7 +48,7 @@ def transform_test(imgs, short, max_size=1024, mean=(0.485, 0.456, 0.406),
         if dim_imgs == 3:
             imgs = [imgs]
         elif dim_imgs == 4:
-            imgs = [*imgs]
+            imgs = [img for img in imgs]
 
     for im in imgs:
         assert isinstance(im, mx.nd.NDArray), "Expect NDArray, got {}".format(type(im))

--- a/gluoncv/data/transforms/presets/center_net.py
+++ b/gluoncv/data/transforms/presets/center_net.py
@@ -45,7 +45,7 @@ def transform_test(imgs, short, max_size=1024, mean=(0.485, 0.456, 0.406),
         dim_imgs = imgs.ndim
         assert dim_imgs in (3, 4), \
         "Expect 3 or 4-dimensional NDArray, got {}-dimensional".format(dim_imgs)
-        if dim_imgs == 3 :
+        if dim_imgs == 3:
             imgs = [imgs]
         elif dim_imgs == 4:
             imgs = [*imgs]

--- a/gluoncv/data/transforms/presets/center_net.py
+++ b/gluoncv/data/transforms/presets/center_net.py
@@ -48,7 +48,7 @@ def transform_test(imgs, short, max_size=1024, mean=(0.485, 0.456, 0.406),
         if dim_imgs == 3:
             imgs = [imgs]
         elif dim_imgs == 4:
-            imgs = [img for img in imgs]
+            imgs = list(imgs)
 
     for im in imgs:
         assert isinstance(im, mx.nd.NDArray), "Expect NDArray, got {}".format(type(im))

--- a/gluoncv/data/transforms/presets/center_net.py
+++ b/gluoncv/data/transforms/presets/center_net.py
@@ -42,7 +42,14 @@ def transform_test(imgs, short, max_size=1024, mean=(0.485, 0.456, 0.406),
 
     """
     if isinstance(imgs, mx.nd.NDArray):
-        imgs = [imgs]
+        dim_imgs = imgs.ndim
+        assert dim_imgs in (3, 4), \
+        "Expect 3 or 4-dimensional NDArray, got {}-dimensional".format(dim_imgs)
+        if dim_imgs == 3 :
+            imgs = [imgs]
+        elif dim_imgs == 4:
+            imgs = [*imgs]
+
     for im in imgs:
         assert isinstance(im, mx.nd.NDArray), "Expect NDArray, got {}".format(type(im))
 

--- a/gluoncv/data/transforms/presets/imagenet.py
+++ b/gluoncv/data/transforms/presets/imagenet.py
@@ -37,7 +37,7 @@ def transform_eval(imgs, resize_short=256, crop_size=224,
         if dim_imgs == 3:
             imgs = [imgs]
         elif dim_imgs == 4:
-            imgs = [img for img in imgs]
+            imgs = list(imgs)
 
     for im in imgs:
         assert isinstance(im, mx.nd.NDArray), "Expect NDArray, got {}".format(type(im))

--- a/gluoncv/data/transforms/presets/imagenet.py
+++ b/gluoncv/data/transforms/presets/imagenet.py
@@ -34,7 +34,7 @@ def transform_eval(imgs, resize_short=256, crop_size=224,
         dim_imgs = imgs.ndim
         assert dim_imgs in (3, 4), \
         "Expect 3 or 4-dimensional NDArray, got {}-dimensional".format(dim_imgs)
-        if dim_imgs == 3 :
+        if dim_imgs == 3:
             imgs = [imgs]
         elif dim_imgs == 4:
             imgs = [*imgs]

--- a/gluoncv/data/transforms/presets/imagenet.py
+++ b/gluoncv/data/transforms/presets/imagenet.py
@@ -37,7 +37,7 @@ def transform_eval(imgs, resize_short=256, crop_size=224,
         if dim_imgs == 3:
             imgs = [imgs]
         elif dim_imgs == 4:
-            imgs = [*imgs]
+            imgs = [img for img in imgs]
 
     for im in imgs:
         assert isinstance(im, mx.nd.NDArray), "Expect NDArray, got {}".format(type(im))

--- a/gluoncv/data/transforms/presets/imagenet.py
+++ b/gluoncv/data/transforms/presets/imagenet.py
@@ -31,7 +31,14 @@ def transform_eval(imgs, resize_short=256, crop_size=224,
         If multiple image names are supplied, return a list.
     """
     if isinstance(imgs, mx.nd.NDArray):
-        imgs = [imgs]
+        dim_imgs = imgs.ndim
+        assert dim_imgs in (3, 4), \
+        "Expect 3 or 4-dimensional NDArray, got {}-dimensional".format(dim_imgs)
+        if dim_imgs == 3 :
+            imgs = [imgs]
+        elif dim_imgs == 4:
+            imgs = [*imgs]
+
     for im in imgs:
         assert isinstance(im, mx.nd.NDArray), "Expect NDArray, got {}".format(type(im))
 

--- a/gluoncv/data/transforms/presets/rcnn.py
+++ b/gluoncv/data/transforms/presets/rcnn.py
@@ -50,7 +50,7 @@ def transform_test(imgs, short=600, max_size=1000, mean=(0.485, 0.456, 0.406),
         if dim_imgs == 3:
             imgs = [imgs]
         elif dim_imgs == 4:
-            imgs = [*imgs]
+            imgs = [img for img in imgs]
 
     for im in imgs:
         assert isinstance(im, mx.nd.NDArray), "Expect NDArray, got {}".format(type(im))

--- a/gluoncv/data/transforms/presets/rcnn.py
+++ b/gluoncv/data/transforms/presets/rcnn.py
@@ -47,7 +47,7 @@ def transform_test(imgs, short=600, max_size=1000, mean=(0.485, 0.456, 0.406),
         dim_imgs = imgs.ndim
         assert dim_imgs in (3, 4), \
         "Expect 3 or 4-dimensional NDArray, got {}-dimensional".format(dim_imgs)
-        if dim_imgs == 3 :
+        if dim_imgs == 3:
             imgs = [imgs]
         elif dim_imgs == 4:
             imgs = [*imgs]

--- a/gluoncv/data/transforms/presets/rcnn.py
+++ b/gluoncv/data/transforms/presets/rcnn.py
@@ -44,7 +44,14 @@ def transform_test(imgs, short=600, max_size=1000, mean=(0.485, 0.456, 0.406),
 
     """
     if isinstance(imgs, mx.nd.NDArray):
-        imgs = [imgs]
+        dim_imgs = imgs.ndim
+        assert dim_imgs in (3, 4), \
+        "Expect 3 or 4-dimensional NDArray, got {}-dimensional".format(dim_imgs)
+        if dim_imgs == 3 :
+            imgs = [imgs]
+        elif dim_imgs == 4:
+            imgs = [*imgs]
+   
     for im in imgs:
         assert isinstance(im, mx.nd.NDArray), "Expect NDArray, got {}".format(type(im))
 

--- a/gluoncv/data/transforms/presets/rcnn.py
+++ b/gluoncv/data/transforms/presets/rcnn.py
@@ -51,7 +51,7 @@ def transform_test(imgs, short=600, max_size=1000, mean=(0.485, 0.456, 0.406),
             imgs = [imgs]
         elif dim_imgs == 4:
             imgs = [*imgs]
-   
+
     for im in imgs:
         assert isinstance(im, mx.nd.NDArray), "Expect NDArray, got {}".format(type(im))
 

--- a/gluoncv/data/transforms/presets/rcnn.py
+++ b/gluoncv/data/transforms/presets/rcnn.py
@@ -50,7 +50,7 @@ def transform_test(imgs, short=600, max_size=1000, mean=(0.485, 0.456, 0.406),
         if dim_imgs == 3:
             imgs = [imgs]
         elif dim_imgs == 4:
-            imgs = [img for img in imgs]
+            imgs = list(imgs)
 
     for im in imgs:
         assert isinstance(im, mx.nd.NDArray), "Expect NDArray, got {}".format(type(im))

--- a/gluoncv/data/transforms/presets/ssd.py
+++ b/gluoncv/data/transforms/presets/ssd.py
@@ -46,7 +46,7 @@ def transform_test(imgs, short, max_size=1024, mean=(0.485, 0.456, 0.406),
         dim_imgs = imgs.ndim
         assert dim_imgs in (3, 4), \
         "Expect 3 or 4-dimensional NDArray, got {}-dimensional".format(dim_imgs)
-        if dim_imgs == 3 :
+        if dim_imgs == 3:
             imgs = [imgs]
         elif dim_imgs == 4:
             imgs = [*imgs]

--- a/gluoncv/data/transforms/presets/ssd.py
+++ b/gluoncv/data/transforms/presets/ssd.py
@@ -43,7 +43,14 @@ def transform_test(imgs, short, max_size=1024, mean=(0.485, 0.456, 0.406),
 
     """
     if isinstance(imgs, mx.nd.NDArray):
-        imgs = [imgs]
+        dim_imgs = imgs.ndim
+        assert dim_imgs in (3, 4), \
+        "Expect 3 or 4-dimensional NDArray, got {}-dimensional".format(dim_imgs)
+        if dim_imgs == 3 :
+            imgs = [imgs]
+        elif dim_imgs == 4:
+            imgs = [*imgs]
+
     for im in imgs:
         assert isinstance(im, mx.nd.NDArray), "Expect NDArray, got {}".format(type(im))
 

--- a/gluoncv/data/transforms/presets/ssd.py
+++ b/gluoncv/data/transforms/presets/ssd.py
@@ -49,7 +49,7 @@ def transform_test(imgs, short, max_size=1024, mean=(0.485, 0.456, 0.406),
         if dim_imgs == 3:
             imgs = [imgs]
         elif dim_imgs == 4:
-            imgs = [*imgs]
+            imgs = [img for img in imgs]
 
     for im in imgs:
         assert isinstance(im, mx.nd.NDArray), "Expect NDArray, got {}".format(type(im))

--- a/gluoncv/data/transforms/presets/ssd.py
+++ b/gluoncv/data/transforms/presets/ssd.py
@@ -49,7 +49,7 @@ def transform_test(imgs, short, max_size=1024, mean=(0.485, 0.456, 0.406),
         if dim_imgs == 3:
             imgs = [imgs]
         elif dim_imgs == 4:
-            imgs = [img for img in imgs]
+            imgs = list(imgs)
 
     for im in imgs:
         assert isinstance(im, mx.nd.NDArray), "Expect NDArray, got {}".format(type(im))

--- a/gluoncv/data/transforms/presets/yolo.py
+++ b/gluoncv/data/transforms/presets/yolo.py
@@ -50,7 +50,7 @@ def transform_test(imgs, short=416, max_size=1024, stride=1, mean=(0.485, 0.456,
         if dim_imgs == 3:
             imgs = [imgs]
         elif dim_imgs == 4:
-            imgs = [img for img in imgs]
+            imgs = list(imgs)
 
     for im in imgs:
         assert isinstance(im, mx.nd.NDArray), "Expect NDArray, got {}".format(type(im))

--- a/gluoncv/data/transforms/presets/yolo.py
+++ b/gluoncv/data/transforms/presets/yolo.py
@@ -45,7 +45,8 @@ def transform_test(imgs, short=416, max_size=1024, stride=1, mean=(0.485, 0.456,
     """
     if isinstance(imgs, mx.nd.NDArray):
         dim_imgs = imgs.ndim
-        assert dim_imgs in (3, 4), "Expect 3 or 4-dimensional NDArray, got {}-dimensional".format(dim_imgs)
+        assert dim_imgs in (3, 4), \
+        "Expect 3 or 4-dimensional NDArray, got {}-dimensional".format(dim_imgs)
         imgs = [imgs] if dim_imgs == 3 else [*imgs]
         
     for im in imgs:

--- a/gluoncv/data/transforms/presets/yolo.py
+++ b/gluoncv/data/transforms/presets/yolo.py
@@ -47,7 +47,7 @@ def transform_test(imgs, short=416, max_size=1024, stride=1, mean=(0.485, 0.456,
         dim_imgs = imgs.ndim
         assert dim_imgs in (3, 4), \
         "Expect 3 or 4-dimensional NDArray, got {}-dimensional".format(dim_imgs)
-        if dim_imgs == 3 :
+        if dim_imgs == 3:
             imgs = [imgs]
         elif dim_imgs == 4:
             imgs = [*imgs]

--- a/gluoncv/data/transforms/presets/yolo.py
+++ b/gluoncv/data/transforms/presets/yolo.py
@@ -45,7 +45,7 @@ def transform_test(imgs, short=416, max_size=1024, stride=1, mean=(0.485, 0.456,
     """
     if isinstance(imgs, mx.nd.NDArray):
         dim_imgs = imgs.ndim
-        assert dim_imgs == 3 or dim_imgs == 4, "Expect 3 or 4-dimensional NDArray, got {}-dimensional".format(dim_imgs)
+        assert dim_imgs in (3, 4), "Expect 3 or 4-dimensional NDArray, got {}-dimensional".format(dim_imgs)
         imgs = [imgs] if dim_imgs == 3 else [*imgs]
         
     for im in imgs:

--- a/gluoncv/data/transforms/presets/yolo.py
+++ b/gluoncv/data/transforms/presets/yolo.py
@@ -44,7 +44,10 @@ def transform_test(imgs, short=416, max_size=1024, stride=1, mean=(0.485, 0.456,
 
     """
     if isinstance(imgs, mx.nd.NDArray):
-        imgs = [imgs]
+        dim_imgs = imgs.ndim
+        assert dim_imgs == 3 or dim_imgs == 4, "Expect 3 or 4-dimensional NDArray, got {}-dimensional".format(dim_imgs)
+        imgs = [imgs] if dim_imgs == 3 else [*imgs]
+        
     for im in imgs:
         assert isinstance(im, mx.nd.NDArray), "Expect NDArray, got {}".format(type(im))
 

--- a/gluoncv/data/transforms/presets/yolo.py
+++ b/gluoncv/data/transforms/presets/yolo.py
@@ -47,8 +47,11 @@ def transform_test(imgs, short=416, max_size=1024, stride=1, mean=(0.485, 0.456,
         dim_imgs = imgs.ndim
         assert dim_imgs in (3, 4), \
         "Expect 3 or 4-dimensional NDArray, got {}-dimensional".format(dim_imgs)
-        imgs = [imgs] if dim_imgs == 3 else [*imgs]
-        
+        if dim_imgs == 3 :
+            imgs = [imgs]
+        elif dim_imgs == 4:
+            imgs = [*imgs]
+
     for im in imgs:
         assert isinstance(im, mx.nd.NDArray), "Expect NDArray, got {}".format(type(im))
 

--- a/gluoncv/data/transforms/presets/yolo.py
+++ b/gluoncv/data/transforms/presets/yolo.py
@@ -50,7 +50,7 @@ def transform_test(imgs, short=416, max_size=1024, stride=1, mean=(0.485, 0.456,
         if dim_imgs == 3:
             imgs = [imgs]
         elif dim_imgs == 4:
-            imgs = [*imgs]
+            imgs = [img for img in imgs]
 
     for im in imgs:
         assert isinstance(im, mx.nd.NDArray), "Expect NDArray, got {}".format(type(im))


### PR DESCRIPTION
When I tried to push NDArray of multiple images shaped as (batch, w, h, channel), the "transform_test" function didn't work, except with the array for a single image whose shape was (w, h, channel). Therefore I added some code to fix this issue.

KEY POINT IS :
a1 = numpy.zeros((512,512,3))
a2 = numpy.zeros((2, 512,512,3))
len([a1]) = 1 👍 
len(list(a1)) = 512 👎 
len([a2]) = 1 👎 
len(list(a2)) = 2 👍  
I think solutions may exist better than the one I proposed.