### PR TITLE
SSD fix_gamma disabled

### DIFF
--- a/gluoncv/nn/feature.py
+++ b/gluoncv/nn/feature.py
@@ -143,13 +143,13 @@ class FeatureExpander(SymbolBlock):
                     y, num_filter=num_trans, kernel=(1, 1), no_bias=use_bn,
                     name='expand_trans_conv{}'.format(i), attr={'__init__': weight_init})
                 if use_bn:
-                    y = mx.sym.BatchNorm(y, name='expand_trans_bn{}'.format(i))
+                    y = mx.sym.BatchNorm(y, fix_gamma=False, name='expand_trans_bn{}'.format(i))
                 y = mx.sym.Activation(y, act_type='relu', name='expand_trans_relu{}'.format(i))
             y = mx.sym.Convolution(
                 y, num_filter=f, kernel=(3, 3), pad=(1, 1), stride=(2, 2),
                 no_bias=use_bn, name='expand_conv{}'.format(i), attr={'__init__': weight_init})
             if use_bn:
-                y = mx.sym.BatchNorm(y, name='expand_bn{}'.format(i))
+                y = mx.sym.BatchNorm(y, fix_gamma=False, name='expand_bn{}'.format(i))
             y = mx.sym.Activation(y, act_type='relu', name='expand_reu{}'.format(i))
             outputs.append(y)
         if global_pool:


### PR DESCRIPTION
Hi
I found that SSD feature expander uses batchnorm with fixed gamma, because default value is ```fix_gamma=True```.
As I know, there were no batchnorm freeze trick in SSD paper. 
So, I fixed code.