### PR TITLE
Update DALI decoder

### DIFF
--- a/gluoncv/data/mscoco/detection.py
+++ b/gluoncv/data/mscoco/detection.py
@@ -248,7 +248,7 @@ class COCODetectionDALI(object):
             ltrb=True,
             shuffle_after_epoch=True)
 
-        self.decode = dali.ops.HostDecoder(device="cpu", output_type=dali.types.RGB)
+        self.decode = dali.ops.ImageDecoder(device="cpu", output_type=dali.types.RGB)
 
         # We need to build the COCOReader ops to parse the annotations
         # and have acces to the dataset size.


### PR DESCRIPTION
DALI's `HostDecoder` was removed in favor of `ImageDecoder` https://docs.nvidia.com/deeplearning/sdk/dali-developer-guide/docs/supported_ops.html#nvidia.dali.ops.ImageDecoder