### PR TITLE
fix ssd incorrect clip results when mxnet is old

### DIFF
--- a/gluoncv/model_zoo/model_store.py
+++ b/gluoncv/model_zoo/model_store.py
@@ -227,6 +227,10 @@ def get_model_file(name, tag=None, root=os.path.join('~', '.mxnet', 'models')):
         sha1_hash = tag
     else:
         sha1_hash = _model_sha1[name]
+
+    if not os.path.exists(root):
+        os.makedirs(root)
+    
     with portalocker.Lock(lockfile, timeout=int(os.environ.get('GLUON_MODEL_LOCK_TIMEOUT', 300))):
         if os.path.exists(params_path):
             if check_sha1(params_path, sha1_hash):
@@ -236,9 +240,6 @@ def get_model_file(name, tag=None, root=os.path.join('~', '.mxnet', 'models')):
                                 "Downloading again.", params_path)
         else:
             logging.info('Model file not found. Downloading.')
-
-        if not os.path.exists(root):
-            os.makedirs(root)
 
         zip_file_path = os.path.join(root, file_name + '.zip')
         repo_url = os.environ.get('MXNET_GLUON_REPO', apache_repo_url)

--- a/gluoncv/model_zoo/model_store.py
+++ b/gluoncv/model_zoo/model_store.py
@@ -230,7 +230,7 @@ def get_model_file(name, tag=None, root=os.path.join('~', '.mxnet', 'models')):
 
     if not os.path.exists(root):
         os.makedirs(root)
-    
+
     with portalocker.Lock(lockfile, timeout=int(os.environ.get('GLUON_MODEL_LOCK_TIMEOUT', 300))):
         if os.path.exists(params_path):
             if check_sha1(params_path, sha1_hash):

--- a/gluoncv/nn/coder.py
+++ b/gluoncv/nn/coder.py
@@ -251,14 +251,14 @@ class NormalizedBoxCenterDecoder(gluon.HybridBlock):
     ----------
     stds : array-like of size 4
         Std value to be divided from encoded values, default is (0.1, 0.1, 0.2, 0.2).
-    clip : float, default is -1.0
+    clip : float, default is None
         If given, bounding box target will be clipped to this value.
     convert_anchor : boolean, default is False
         Whether to convert anchor from corner to center format.
 
     """
 
-    def __init__(self, stds=(0.1, 0.1, 0.2, 0.2), convert_anchor=False, clip=-1.0):
+    def __init__(self, stds=(0.1, 0.1, 0.2, 0.2), convert_anchor=False, clip=None):
         super(NormalizedBoxCenterDecoder, self).__init__()
         assert len(stds) == 4, "Box Encoder requires 4 std values."
         self._stds = stds
@@ -272,6 +272,8 @@ class NormalizedBoxCenterDecoder(gluon.HybridBlock):
     def hybrid_forward(self, F, x, anchors):
         if 'box_decode' in F.contrib.__dict__:
             x, anchors = F.amp_multicast(x, anchors, num_outputs=2, cast_narrow=True)
+            if self._clip is None:
+                self._clip = -1  # match the signature of c++ operator
             return F.contrib.box_decode(x, anchors, self._stds[0], self._stds[1], self._stds[2],
                                         self._stds[3], clip=self._clip, format=self._format)
         if self.corner_to_center is not None:


### PR DESCRIPTION
Fix #1026 which cause invalid bbox for SSD models if MXNet is old.
Also fix #1041 which cause checking lock file error when ~/.mxnet root folder is not exist