### PR TITLE
Fixed bug in darknet.py where not using passed in norm_layer

### DIFF
--- a/gluoncv/model_zoo/yolo/darknet.py
+++ b/gluoncv/model_zoo/yolo/darknet.py
@@ -95,7 +95,7 @@ class DarknetV3(gluon.HybridBlock):
                 # add nlayer basic blocks
                 for _ in range(nlayer):
                     self.features.add(DarknetBasicBlockV3(channel // 2,
-                                                          norm_layer=BatchNorm,
+                                                          norm_layer=norm_layer,
                                                           norm_kwargs=None))
             # output
             self.output = nn.Dense(classes)


### PR DESCRIPTION
 Fixed bug in darknet.py where BatchNorm was being used instead of the norm_layer argument