### PR TITLE
Fixed bug where passed in norm_layer was not being used.

### DIFF
--- a/gluoncv/model_zoo/yolo/darknet.py
+++ b/gluoncv/model_zoo/yolo/darknet.py
@@ -95,8 +95,8 @@ class DarknetV3(gluon.HybridBlock):
                 # add nlayer basic blocks
                 for _ in range(nlayer):
                     self.features.add(DarknetBasicBlockV3(channel // 2,
-                                                          norm_layer=BatchNorm,
-                                                          norm_kwargs=None))
+                                                          norm_layer=norm_layer,
+                                                          norm_kwargs=norm_kwargs))
             # output
             self.output = nn.Dense(classes)
 


### PR DESCRIPTION
BatchNorm was being used when adding a DarknetBasicBlockV3 to DarknetV3 regardless of what was passed in as norm_layer.