### PR TITLE
Do not throw runtime exception when there are no CUDA-capable devices.

### DIFF
--- a/gluoncv/utils/filesystem.py
+++ b/gluoncv/utils/filesystem.py
@@ -138,10 +138,13 @@ def try_import_dali():
     try:
         dali = __import__('nvidia.dali', fromlist=['pipeline', 'ops', 'types'])
         dali.Pipeline = dali.pipeline.Pipeline
-    except ImportError:
+    except (ImportError, RuntimeError) as e:
+        if isinstance(e, ImportError):
+            msg = "DALI not found, please check if you installed it correctly."
+        elif isinstance(e, RuntimeError):
+            msg = "No CUDA-capable device is detected ({}).".format(e)
         class dali:
             class Pipeline:
                 def __init__(self):
-                    raise NotImplementedError(
-                        "DALI not found, please check if you installed it correctly.")
+                    raise NotImplementedError(msg)
     return dali


### PR DESCRIPTION
Some use cases do not use GPU, but DALI will throw a `RuntimeError` during importing `nvidia.dali.ops`. We failed to patch `gluoncv/__init__.py` as the exception was thrown at the very beginning.