### PR TITLE
[Deprecation] Deprecate python2 as it has reached EOF on Jan 1st, 2020

### DIFF
--- a/gluoncv/__init__.py
+++ b/gluoncv/__init__.py
@@ -9,7 +9,8 @@ from . import data
 from . import model_zoo
 from . import nn
 from . import utils
-from .utils.version import _require_mxnet_version
+from .utils.version import _require_mxnet_version, _deprecate_python2
 from . import loss
 
+_deprecate_python2()
 _require_mxnet_version('1.4.0')

--- a/gluoncv/utils/version.py
+++ b/gluoncv/utils/version.py
@@ -36,7 +36,8 @@ def _require_mxnet_version(mx_version):
                 "Legacy mxnet-mkl=={} detected, some new modules may not work properly. "
                 "mxnet-mkl>={} is required. You can use pip to upgrade mxnet "
                 "`pip install mxnet-mkl --pre --upgrade` "
-                "or `pip install mxnet-cu100mkl --pre --upgrade`").format(mx.__version__, mx_version)
+                "or `pip install mxnet-cu100mkl --pre --upgrade`\
+                ").format(mx.__version__, mx_version)
             raise ImportError(msg)
     except ImportError:
         raise ImportError(

--- a/gluoncv/utils/version.py
+++ b/gluoncv/utils/version.py
@@ -1,7 +1,8 @@
 """Utility functions for version checking."""
+import sys
 import warnings
 
-__all__ = ['check_version', '_require_mxnet_version']
+__all__ = ['check_version', '_require_mxnet_version', '_deprecate_python2']
 
 def check_version(min_version, warning_only=False):
     """Check the version of gluoncv satisfies the provided minimum version.
@@ -35,10 +36,17 @@ def _require_mxnet_version(mx_version):
                 "Legacy mxnet-mkl=={} detected, some new modules may not work properly. "
                 "mxnet-mkl>={} is required. You can use pip to upgrade mxnet "
                 "`pip install mxnet-mkl --pre --upgrade` "
-                "or `pip install mxnet-cu90mkl --pre --upgrade`").format(mx.__version__, mx_version)
+                "or `pip install mxnet-cu100mkl --pre --upgrade`").format(mx.__version__, mx_version)
             raise ImportError(msg)
     except ImportError:
         raise ImportError(
             "Unable to import dependency mxnet. "
-            "A quick tip is to install via `pip install mxnet-mkl/mxnet-cu90mkl --pre`. "
+            "A quick tip is to install via `pip install mxnet-mkl/mxnet-cu100mkl --pre`. "
             "please refer to https://gluon-cv.mxnet.io/#installation for details.")
+
+def _deprecate_python2():
+    if sys.version_info[0] < 3:
+        msg = 'Python2 has reached the end of its life on January 1st, 2020. ' + \
+            'A future version of gluoncv will drop support for Python 2.'
+        warnings.simplefilter('always', DeprecationWarning)
+        warnings.warn(msg, DeprecationWarning)


### PR DESCRIPTION
Python2.7 has reached End of Life: https://www.python.org/dev/peps/pep-0373/
Numpy decided to stop future support for python2: https://docs.scipy.org/doc/numpy-1.14.0/neps/dropping-python2.7-proposal.html
So it's good time to drop python2. 