### PR TITLE
Modify model zoo

### DIFF
--- a/docs/model_zoo/action_recognition.rst
+++ b/docs/model_zoo/action_recognition.rst
@@ -45,9 +45,9 @@ The following table lists pre-trained models trained on Kinetics400.
 
   ``Clip Length`` is the number of frames within an input clip. ``32 (64/2)`` means we use 32 frames, but actually the frames are formed by randomly selecting 64 consecutive frames from the video and then skipping every other frame. This strategy is widely adopted to reduce computation and memory cost.
 
-  ``Segments`` is the number of segments used during training. For testing (reporting these numbers), we use 250 views for 2D networks (25 segments and 10-crop) and 30 views for 3D networks (10 segments and 3-crop).
+  ``Segments`` is the number of segments used during training. For testing (reporting these numbers), we use 250 views for 2D networks (25 frames and 10-crop) and 30 views for 3D networks (10 clips and 3-crop) following the convention.
 
-  For ``SlowFast`` family of networks, our performance has a small gap to the numbers reported in the paper. This is because the performance of SlowFast network heavily depends on the frame rate. Official implementation forces re-encoding every video to a frame rate of 30. For fair comparison to other methods, we do not adopt that strategy, which leads to the small gap.
+  For ``SlowFast`` family of networks, our performance has a small gap to the numbers reported in the paper. This is because the performance of SlowFast network heavily depends on the frame rate. The official implementation forces re-encoding every video to a fixed frame rate of 30. For fair comparison to other methods, we do not adopt that strategy, which leads to the small gap.
 
 .. table::
     :widths: 40 8 8 8 10 8 8 10

--- a/docs/model_zoo/action_recognition.rst
+++ b/docs/model_zoo/action_recognition.rst
@@ -45,6 +45,10 @@ The following table lists pre-trained models trained on Kinetics400.
 
   ``Clip Length`` is the number of frames within an input clip. ``32 (64/2)`` means we use 32 frames, but actually the frames are formed by randomly selecting 64 consecutive frames from the video and then skipping every other frame. This strategy is widely adopted to reduce computation and memory cost.
 
+  ``Segments`` is the number of segments used during training. For testing (reporting these numbers), we use 250 views for 2D networks (25 segments and 10-crop) and 30 views for 3D networks (10 segments and 3-crop).
+
+  For ``SlowFast`` family of networks, our performance has a small gap to the numbers reported in the paper. This is because the performance of SlowFast network heavily depends on the frame rate. Official implementation forces re-encoding every video to a frame rate of 30. For fair comparison to other methods, we do not adopt that strategy, which leads to the small gap.
+
 .. table::
     :widths: 40 8 8 8 10 8 8 10
 


### PR DESCRIPTION
This PR adds the reason why there is a small gap between our trained SlowFast models to the official implementation. 

We also tested their provided pre-trained [models](https://github.com/facebookresearch/SlowFast/blob/master/MODEL_ZOO.md) on the un-normalized videos, their performance is usually 0.1%~0.4% lower than our trained models.