### PR TITLE
fix groupnorm import in train_imagenet.py

### DIFF
--- a/scripts/classification/imagenet/train_imagenet.py
+++ b/scripts/classification/imagenet/train_imagenet.py
@@ -154,8 +154,7 @@ def main():
 
     kwargs = {'ctx': context, 'pretrained': opt.use_pretrained, 'classes': classes}
     if opt.use_gn:
-        from gluoncv.nn import GroupNorm
-        kwargs['norm_layer'] = GroupNorm
+        kwargs['norm_layer'] = nn.GroupNorm
     if model_name.startswith('vgg'):
         kwargs['batch_norm'] = opt.batch_norm
     elif model_name.startswith('resnext'):

--- a/scripts/classification/imagenet/train_imagenet.py
+++ b/scripts/classification/imagenet/train_imagenet.py
@@ -197,7 +197,7 @@ def main():
         std_rgb = [58.393, 57.12, 57.375]
 
         def batch_fn(batch, ctx):
-            data = gluon.utils.split_and_load(batch.data[0], ctx_list=ctx, batch_axis=0)
+            data = gluon.utils.split_and_load(batch.data[0].astype(opt.dtype, copy=False), ctx_list=ctx, batch_axis=0)
             label = gluon.utils.split_and_load(batch.label[0], ctx_list=ctx, batch_axis=0)
             return data, label
 
@@ -264,6 +264,7 @@ def main():
                                         saturation=jitter_param),
             transforms.RandomLighting(lighting_param),
             transforms.ToTensor(),
+            transforms.Cast(opt.dtype),
             normalize
         ])
         transform_test = transforms.Compose([


### PR DESCRIPTION
While using `--use-gn` flag user gets error:
```
Traceback (most recent call last):
    File "train_imagenet.py", line 489, in <module>
    main()
    File "train_imagenet.py", line 173, in main
    net = get_model(model_name, **kwargs)
    File "/usr/local/lib/python3.5/dist-packages/gluoncv/model_zoo/model_zoo.py", line 343, in get_model
    net = _models[name](**kwargs)
    File "/usr/local/lib/python3.5/dist-packages/gluoncv/model_zoo/resnet.py", line 745, in resnet50_v2
    return get_resnet(2, 50, use_se=False, **kwargs)
    File "/usr/local/lib/python3.5/dist-packages/gluoncv/model_zoo/resnet.py", line 555, in get_resnet
    net = resnet_class(block_class, layers, channels, use_se=use_se, **kwargs)
    File "/usr/local/lib/python3.5/dist-packages/gluoncv/model_zoo/resnet.py", line 462, in __init__
    **({} if norm_kwargs is None else norm_kwargs)))
    File "/usr/local/lib/python3.5/dist-packages/gluoncv/nn/gn.py", line 39, in __init__
super(GroupNorm, self).__init__(**kwargs)
    TypeError: __init__() got an unexpected keyword argument 'scale'
```
since lack of scale (at least) parameter in gluoncv.nn.GroupNorm. It exists in mxnet.gluon.nn.GroupNorm tho.
