### PR TITLE
Fix import error in segbase

### DIFF
--- a/gluoncv/model_zoo/segbase.py
+++ b/gluoncv/model_zoo/segbase.py
@@ -6,7 +6,7 @@ import mxnet as mx
 from mxnet.ndarray import NDArray
 from mxnet.gluon.nn import HybridBlock
 from ..utils.parallel import parallel_apply
-from .resnetv1b import resnet50_v1s, resnet101_v1s, resnet152_v1s
+from .resnetv1b import resnet18_v1b, resnet34_v1b, resnet50_v1s, resnet101_v1s, resnet152_v1s
 from ..utils.parallel import tuple_map
 # pylint: disable=wildcard-import,abstract-method,arguments-differ,dangerous-default-value,missing-docstring
 


### PR DESCRIPTION
As mentioned in issue #887 , the model definition for res18 and res34 are missing. 