### PR TITLE
Fix semseg training in CPU mode

### DIFF
--- a/scripts/segmentation/train.py
+++ b/scripts/segmentation/train.py
@@ -103,6 +103,7 @@ def parse_args():
         args.ctx = [mx.cpu(0)]
     else:
         print('Number of GPUs:', args.ngpus)
+        assert args.ngpus > 0, 'No GPUs found, please enable --no-cuda to start training in CPU mode.'
         args.ctx = [mx.gpu(i) for i in range(args.ngpus)]
 
     # logging and checkpoint saving


### PR DESCRIPTION
As mentioned in issue #1071 , training semantic segmentation model in CPU requires to set `--no-cuda`. Otherwise, there will be error because of mishandling of context. 

Add a assertion check in `train.py` to notify users. 