### PR TITLE
Add assertion for PSP and DeepLab

### DIFF
--- a/scripts/segmentation/train.py
+++ b/scripts/segmentation/train.py
@@ -103,8 +103,12 @@ def parse_args():
         args.ctx = [mx.cpu(0)]
     else:
         print('Number of GPUs:', args.ngpus)
-        assert args.ngpus > 0, 'No GPUs found, please enable --no-cuda to start training in CPU mode.'
+        assert args.ngpus > 0, 'No GPUs found, please enable --no-cuda for CPU mode.'
         args.ctx = [mx.gpu(i) for i in range(args.ngpus)]
+
+    if 'psp' in args.model or 'deeplab' in args.model:
+        assert args.crop_size % 8 == 0, ('For PSPNet and DeepLabV3 model families, '
+        'we only support input crop size as multiples of 8.')
 
     # logging and checkpoint saving
     if args.save_dir is None:


### PR DESCRIPTION
This PR adds assertion to check whether crop size is multiples of 8 for semantic segmentation training using PSPNet and DeepLabV3. This is a suggestion from issue #1173 .

The reason we have such constraint is because of model hybridization, we have to pass pre-computed shape to later stages, which may cause shape mismatch. 

For example, if we use a crop size of 350, the actual shape of feature map before ASPP is 44x44, but our pre-computed shape is `350 % 8 = 43`, which causes shape mismatch error. 
