### PR TITLE
Remove unnecessary sentence in `yolo_target.py`

### DIFF
--- a/gluoncv/model_zoo/yolo/darknet.py
+++ b/gluoncv/model_zoo/yolo/darknet.py
@@ -78,7 +78,7 @@ class DarknetV3(gluon.HybridBlock):
     """
     def __init__(self, layers, channels, classes=1000,
                  norm_layer=BatchNorm, norm_kwargs=None, **kwargs):
-        super(DarknetV3, self).__init__(**kwargs)
+        super(DarknetV3, self).__init__(kwargs.get('prefix', None), kwargs.get('params', None))
         assert len(layers) == len(channels) - 1, (
             "len(channels) should equal to len(layers) + 1, given {} vs {}".format(
                 len(channels), len(layers)))

--- a/gluoncv/model_zoo/yolo/darknet.py
+++ b/gluoncv/model_zoo/yolo/darknet.py
@@ -79,11 +79,10 @@ class DarknetV3(gluon.HybridBlock):
     def __init__(self, layers, channels, classes=1000,
                  norm_layer=BatchNorm, norm_kwargs=None, **kwargs):
         # Checking the kwargs
-        for kwarg_key in kwargs.keys():
+        for kwarg_key in kwargs:
             if kwarg_key not in ['prefix', 'params']:
                 raise Warning("class DraknetV3 should only accept kwargs {'params', or 'prefix'}")
         super(DarknetV3, self).__init__(kwargs.get('prefix', None), kwargs.get('params', None))
-        
         assert len(layers) == len(channels) - 1, (
             "len(channels) should equal to len(layers) + 1, given {} vs {}".format(
                 len(channels), len(layers)))

--- a/gluoncv/model_zoo/yolo/darknet.py
+++ b/gluoncv/model_zoo/yolo/darknet.py
@@ -78,7 +78,12 @@ class DarknetV3(gluon.HybridBlock):
     """
     def __init__(self, layers, channels, classes=1000,
                  norm_layer=BatchNorm, norm_kwargs=None, **kwargs):
+        # Checking the kwargs
+        for kwarg_key in kwargs.keys():
+            if kwarg_key not in ['prefix', 'params']:
+                raise Warning("class DraknetV3 should only accept kwargs {'params', or 'prefix'}")
         super(DarknetV3, self).__init__(kwargs.get('prefix', None), kwargs.get('params', None))
+        
         assert len(layers) == len(channels) - 1, (
             "len(channels) should equal to len(layers) + 1, given {} vs {}".format(
                 len(channels), len(layers)))

--- a/gluoncv/model_zoo/yolo/yolo_target.py
+++ b/gluoncv/model_zoo/yolo/yolo_target.py
@@ -263,7 +263,6 @@ class YOLOV3TargetMerger(gluon.HybridBlock):
             weights = F.where(mask2, weights[1], weights[0])
             mask3 = mask.tile(reps=(self._num_class,))
             class_targets = F.where(mask3, clas[1], clas[0])
-            smooth_weight = 1. / self._num_class
             if self._label_smooth:
                 smooth_weight = min(1. / self._num_class, 1. / 40)
                 class_targets = F.where(


### PR DESCRIPTION
You see, I don't think the first sentence is necessary.

```
            smooth_weight = 1. / self._num_class
            if self._label_smooth:
                smooth_weight = min(1. / self._num_class, 1. / 40)
                class_targets = F.where(
                    class_targets > 0.5, class_targets - smooth_weight, class_targets)
                class_targets = F.where(
                    (class_targets < -0.5) + (class_targets > 0.5),
                    class_targets, F.ones_like(class_targets) * smooth_weight)
```