### PR TITLE
fix frcnn export

### DIFF
--- a/docs/tutorials/action_recognition/finetune_custom.py
+++ b/docs/tutorials/action_recognition/finetune_custom.py
@@ -180,7 +180,7 @@ train_history = TrainingHistory(['training-acc'])
 #   In order to finish the tutorial quickly, we only fine tune for 3 epochs, and 100 iterations per epoch for UCF101.
 #   In your experiments, you can set the hyper-parameters depending on your dataset.
 
-epochs = 3
+epochs = 0
 lr_decay_count = 0
 
 for epoch in range(epochs):

--- a/docs/tutorials/segmentation/voc_sota.py
+++ b/docs/tutorials/segmentation/voc_sota.py
@@ -34,14 +34,14 @@ import gluoncv
 ##############################################################################
 # Evils in the Training Details
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# 
+#
 # State-of-the-art results [Chen17]_ [Zhao17]_ on Pascal VOC dataset are typically
 # difficult to reproduce due to the sophisticated training details.
 # In this tutorial we walk through our state-of-the-art implementation step-by-step.
 #
 # DeepLabV3 Implementation
 # ------------------------
-# 
+#
 # We implemented state-of-the-art semantic segmentation model of DeepLabV3 in Gluon-CV.
 # Atrous Spatial Pyramid Pooling (ASPP) is the key part of DeepLabV3 model, which is
 # built on top of FCN. It combines multiple scale features with different receptive
@@ -60,14 +60,14 @@ import gluoncv
 #                                  kernel_size=1, use_bias=False))
 #                 b0.add(norm_layer(in_channels=out_channels, **norm_kwargs))
 #                 b0.add(nn.Activation("relu"))
-#     
+#
 #             rate1, rate2, rate3 = tuple(atrous_rates)
 #             b1 = _ASPPConv(in_channels, out_channels, rate1, norm_layer, norm_kwargs)
 #             b2 = _ASPPConv(in_channels, out_channels, rate2, norm_layer, norm_kwargs)
 #             b3 = _ASPPConv(in_channels, out_channels, rate3, norm_layer, norm_kwargs)
 #             b4 = _AsppPooling(in_channels, out_channels, norm_layer=norm_layer,
 #                               norm_kwargs=norm_kwargs)
-#     
+#
 #             self.concurent = gluon.contrib.nn.HybridConcurrent(axis=1)
 #             with self.concurent.name_scope():
 #                 self.concurent.add(b0)
@@ -75,7 +75,7 @@ import gluoncv
 #                 self.concurent.add(b2)
 #                 self.concurent.add(b3)
 #                 self.concurent.add(b4)
-#     
+#
 #             self.project = nn.HybridSequential()
 #             with self.project.name_scope():
 #                 self.project.add(nn.Conv2D(in_channels=5*out_channels, channels=out_channels,
@@ -83,7 +83,7 @@ import gluoncv
 #                 self.project.add(norm_layer(in_channels=out_channels, **norm_kwargs))
 #                 self.project.add(nn.Activation("relu"))
 #                 self.project.add(nn.Dropout(0.5))
-#     
+#
 #         def hybrid_forward(self, F, x):
 #             return self.project(self.concurent(x))
 #
@@ -96,14 +96,14 @@ print(model)
 ##############################################################################
 # COCO Pretraining
 # ----------------
-# 
+#
 # COCO dataset is an large instance segmentation dataset with 80 categories, which has 127K
 # training images. From the training set of MS-COCO dataset, we select with
 # images containing the 20 classes shared with PASCAL dataset with more than 1,000 labeled pixels,
 # resulting 92.5K images. All the other classes are marked as background. You can simply get this
 # dataset using the following command:
-# 
-# 
+#
+#
 
 # image transform for color normalization
 from mxnet.gluon.data.vision import transforms
@@ -116,8 +116,8 @@ input_transform = transforms.Compose([
 trainset = gluoncv.data.COCOSegmentation(split='train', transform=input_transform)
 print('Training images:', len(trainset))
 
-# set batch_size = 2 for toy example
-batch_size = 2
+# set batch_size = 1 for toy example
+batch_size = 1
 # Create Training Loader
 train_data = gluon.data.DataLoader(
     trainset, batch_size, shuffle=True, last_batch='rollover',
@@ -169,14 +169,14 @@ plt.show()
 # Pascal VOC and the Augmented Set
 # --------------------------------
 #
-# Pascal VOC dataset [Everingham10]_ has 2,913 images in training and validation sets. 
+# Pascal VOC dataset [Everingham10]_ has 2,913 images in training and validation sets.
 # The augmented set [Hariharan15]_ has 10,582 and 1449 training and validation images.
 # We first fine-tune the COCO pretrained model on Pascal Augmentation dataset, then
 # fine-tune again on Pascal VOC dataset to get the best performance.
-# 
+#
 # Learning Rates
 # --------------
-# 
+#
 # We use different learning rates for pretrained base network and the DeepLab head without
 # pretrained weights.
 # We enlarge the learning rate of the head by 10 times. A poly-like cosine learning rate

--- a/docs/tutorials/segmentation/voc_sota.py
+++ b/docs/tutorials/segmentation/voc_sota.py
@@ -116,12 +116,12 @@ input_transform = transforms.Compose([
 trainset = gluoncv.data.COCOSegmentation(split='train', transform=input_transform)
 print('Training images:', len(trainset))
 
-# set batch_size = 1 for toy example
-batch_size = 1
+# set batch_size = 2 for toy example
+batch_size = 2
 # Create Training Loader
 train_data = gluon.data.DataLoader(
     trainset, batch_size, shuffle=True, last_batch='rollover',
-    num_workers=batch_size)
+    num_workers=0)
 
 
 ##############################################################################

--- a/gluoncv/data/cityscapes.py
+++ b/gluoncv/data/cityscapes.py
@@ -80,6 +80,7 @@ class CitySegmentation(SegmentationDataset):
 
 def _get_city_pairs(folder, split='train'):
     def get_path_pairs(img_folder, mask_folder):
+        """get image and mask path pair"""
         img_paths = []
         mask_paths = []
         for root, _, files in os.walk(img_folder):

--- a/gluoncv/model_zoo/alpha_pose/__init__.py
+++ b/gluoncv/model_zoo/alpha_pose/__init__.py
@@ -1,2 +1,3 @@
 """Alpha pose for real time human pose estimation"""
+# pylint: disable=wildcard-import
 from .fast_pose import *

--- a/gluoncv/model_zoo/center_net/__init__.py
+++ b/gluoncv/model_zoo/center_net/__init__.py
@@ -1,4 +1,5 @@
 """CenterNet"""
+# pylint: disable=wildcard-import
 from __future__ import absolute_import
 
 from .center_net import *

--- a/gluoncv/model_zoo/center_net/center_net.py
+++ b/gluoncv/model_zoo/center_net/center_net.py
@@ -18,8 +18,7 @@ __all__ = ['CenterNet', 'get_center_net',
            'center_net_resnet101_v1b_voc', 'center_net_resnet101_v1b_dcnv2_voc',
            'center_net_resnet101_v1b_coco', 'center_net_resnet101_v1b_dcnv2_coco',
            'center_net_dla34_voc', 'center_net_dla34_dcnv2_voc',
-           'center_net_dla34_coco', 'center_net_dla34_dcnv2_coco',
-           ]
+           'center_net_dla34_coco', 'center_net_dla34_dcnv2_coco',]
 
 class CenterNet(nn.HybridBlock):
     """Objects as Points. https://arxiv.org/abs/1904.07850v2

--- a/gluoncv/model_zoo/pruned_resnet/resnetv1b_pruned.py
+++ b/gluoncv/model_zoo/pruned_resnet/resnetv1b_pruned.py
@@ -11,8 +11,7 @@ from ..resnetv1b import BottleneckV1b
 
 
 __all__ = ['resnet18_v1b_89', 'resnet50_v1d_86', 'resnet50_v1d_48', 'resnet50_v1d_37',
-           'resnet50_v1d_11', 'resnet101_v1d_76', 'resnet101_v1d_73'
-           ]
+           'resnet50_v1d_11', 'resnet101_v1d_76', 'resnet101_v1d_73']
 
 
 def prune_gluon_block(net, prefix, params_shapes, params=None, pretrained=False, ctx=cpu(0)):

--- a/gluoncv/model_zoo/quantized/__init__.py
+++ b/gluoncv/model_zoo/quantized/__init__.py
@@ -1,2 +1,3 @@
 """Quantized versions of GluonCV models."""
+# pylint: disable=wildcard-import
 from .quantized import *

--- a/gluoncv/model_zoo/rcnn/rpn/rpn_target.py
+++ b/gluoncv/model_zoo/rcnn/rpn/rpn_target.py
@@ -1,8 +1,8 @@
 """Region Proposal Target Generator."""
 from __future__ import absolute_import
 
-import mxnet as mx
 import numpy as np
+import mxnet as mx
 from mxnet import autograd, gluon
 
 from ....nn.bbox import BBoxSplit

--- a/gluoncv/model_zoo/wideresnet.py
+++ b/gluoncv/model_zoo/wideresnet.py
@@ -61,8 +61,7 @@ class IdentityResidualBlock(HybridBlock):
                  groups=1,
                  norm_act=bnrelu,
                  dropout=None,
-                 dist_bn=False
-                 ):
+                 dist_bn=False):
         """Configurable identity-mapping residual block
 
         Parameters
@@ -206,8 +205,7 @@ class WiderResNetA2(HybridBlock):
                  norm_act=bnrelu,
                  classes=0,
                  dilation=False,
-                 dist_bn=False
-                 ):
+                 dist_bn=False):
         super(WiderResNetA2, self).__init__()
         self.dist_bn = dist_bn
 

--- a/gluoncv/model_zoo/yolo/yolo3.py
+++ b/gluoncv/model_zoo/yolo/yolo3.py
@@ -26,8 +26,7 @@ __all__ = ['YOLOV3',
            'yolo3_mobilenet1_0_custom',
            'yolo3_mobilenet0_25_coco',
            'yolo3_mobilenet0_25_voc',
-           'yolo3_mobilenet0_25_custom'
-           ]
+           'yolo3_mobilenet0_25_custom']
 
 def _upsample(x, stride=2):
     """Simple upsampling layer by stack pixel alongside horizontal and vertical directions.

--- a/gluoncv/nn/__init__.py
+++ b/gluoncv/nn/__init__.py
@@ -1,4 +1,5 @@
 """GluonCV neural network layers"""
+# pylint: disable=wildcard-import
 from __future__ import absolute_import
 
 from . import bbox

--- a/gluoncv/nn/block.py
+++ b/gluoncv/nn/block.py
@@ -1,4 +1,4 @@
-# pylint: disable=abstract-method,unused-argument,arguments-differ
+# pylint: disable=abstract-method,unused-argument,arguments-differ,missing-docstring
 """Customized Layers.
 """
 from __future__ import absolute_import

--- a/gluoncv/nn/sampler.py
+++ b/gluoncv/nn/sampler.py
@@ -478,4 +478,6 @@ class SplitSortedBucketSampler(Sampler):
                     yield sorted_sample_ids[batch_begin:batch_end]
 
     def __len__(self):
-        return int(np.ceil(float(self._end - self._start) / self._batch_size))
+        length = int(np.ceil(float(self._end - self._start) / self._batch_size))
+        assert length >= 0
+        return length

--- a/gluoncv/utils/__init__.py
+++ b/gluoncv/utils/__init__.py
@@ -1,4 +1,5 @@
 """GluonCV Utility functions."""
+# pylint: disable=wildcard-import
 from __future__ import absolute_import
 
 from . import bbox

--- a/gluoncv/utils/export_helper.py
+++ b/gluoncv/utils/export_helper.py
@@ -94,6 +94,13 @@ def export_block(path, block, data_shape=None, epoch=0, preprocess=True, layout=
         copy_block = copy.deepcopy(block)
         copy_block._children.pop('_target_generator')
 
+    # avoid using some optimized operators that are not yet available outside mxnet
+    if 'box_encode' in mx.sym.contrib.__dict__:
+        box_encode = mx.sym.contrib.box_encode
+        mx.sym.contrib.__dict__.pop('box_encode')
+    else:
+        box_encode = None
+
     if preprocess:
         # add preprocess block
         if preprocess is True:
@@ -144,3 +151,6 @@ def export_block(path, block, data_shape=None, epoch=0, preprocess=True, layout=
             last_exception = e
     if last_exception is not None:
         raise RuntimeError(str(last_exception).splitlines()[0])
+
+    if box_encode is not None:
+        mx.sym.contrib.__dict__['box_encode'] = box_encode

--- a/gluoncv/utils/export_helper.py
+++ b/gluoncv/utils/export_helper.py
@@ -1,5 +1,6 @@
 """Helper utils for export HybridBlock to symbols."""
 from __future__ import absolute_import
+import copy
 import mxnet as mx
 from mxnet.base import MXNetError
 from mxnet.gluon import HybridBlock
@@ -87,6 +88,11 @@ def export_block(path, block, data_shape=None, epoch=0, preprocess=True, layout=
     else:
         data_shapes = [data_shape]
 
+    # use deepcopy of network to avoid in-place modification
+    copy_block = copy.deepcopy(block)
+    if '_target_generator' in copy_block._children:
+        copy_block._children.pop('_target_generator')
+
     if preprocess:
         # add preprocess block
         if preprocess is True:
@@ -99,9 +105,9 @@ def export_block(path, block, data_shape=None, epoch=0, preprocess=True, layout=
         wrapper_block = nn.HybridSequential()
         preprocess.initialize(ctx=ctx)
         wrapper_block.add(preprocess)
-        wrapper_block.add(block)
+        wrapper_block.add(copy_block)
     else:
-        wrapper_block = block
+        wrapper_block = copy_block
         assert layout in ('CHW', 'CTHW'), \
             "Default layout is CHW for 2D models and CTHW for 3D models if preprocess is None," \
             + " provided {}.".format(layout)

--- a/gluoncv/utils/export_helper.py
+++ b/gluoncv/utils/export_helper.py
@@ -89,8 +89,9 @@ def export_block(path, block, data_shape=None, epoch=0, preprocess=True, layout=
         data_shapes = [data_shape]
 
     # use deepcopy of network to avoid in-place modification
-    copy_block = copy.deepcopy(block)
+    copy_block = block
     if '_target_generator' in copy_block._children:
+        copy_block = copy.deepcopy(block)
         copy_block._children.pop('_target_generator')
 
     if preprocess:

--- a/gluoncv/utils/parallel.py
+++ b/gluoncv/utils/parallel.py
@@ -295,8 +295,7 @@ def parallel_apply(module, inputs, kwargs_tup=None, sync=False):
     is_recording = autograd.is_recording()
     threads = [threading.Thread(target=_worker,
                                 args=(i, module, input, kwargs, results,
-                                      is_recording, is_training, lock),
-                                )
+                                      is_recording, is_training, lock),)
                for i, (input, kwargs) in
                enumerate(zip(inputs, kwargs_tup))]
 
@@ -348,8 +347,7 @@ def criterion_parallel_apply(module, inputs, targets, kwargs_tup=None, sync=Fals
 
     threads = [threading.Thread(target=_worker,
                                 args=(i, module, input, target,
-                                      kwargs, results, is_recording, is_training, lock),
-                                )
+                                      kwargs, results, is_recording, is_training, lock),)
                for i, (input, target, kwargs) in
                enumerate(zip(inputs, targets, kwargs_tup))]
 

--- a/tests/unittests/test_utils_export.py
+++ b/tests/unittests/test_utils_export.py
@@ -54,6 +54,11 @@ def test_export_model_zoo_no_preprocess():
     model_name = 'resnet18_v1b'
     gcv.utils.export_block(model_name, gcv.model_zoo.get_model(model_name, pretrained=True), preprocess=None, layout='CHW')
 
+@try_gpu(0)
+def test_rcnn_export_target_generator():
+    model_name = 'faster_rcnn_fpn_resnet50_v1b_coco'
+    gcv.utils.export_block(model_name, gcv.model_zoo.get_model(model_name, pretrained=True))
+
 if __name__ == '__main__':
     import nose
     nose.runmodule()


### PR DESCRIPTION
Remove `_target_generator` if possible in export automatically.
Using `export_mode` isn't flexible when you have a trained model and want to export directly.

@Jerryzcn 