### PR TITLE
Disable quantized action recognition models

### DIFF
--- a/tests/unittests/test_model_zoo.py
+++ b/tests/unittests/test_model_zoo.py
@@ -678,15 +678,6 @@ def test_quantized_action_recognition_models():
     x = mx.random.uniform(shape=(1 * num_segments, 3, 224, 224), ctx=ctx)
     _test_model_list(model_list, ctx, x)
 
-    model_list = ['inceptionv3_ucf101_int8', 'inceptionv3_kinetics400_int8']
-    x = mx.random.uniform(shape=(1 * num_segments, 3, 299, 299), ctx=ctx)
-    _test_model_list(model_list, ctx, x)
-
-    num_segments = 7
-    model_list = ['resnet18_v1b_kinetics400_int8']
-    x = mx.random.uniform(shape=(1 * num_segments, 3, 224, 224), ctx=ctx)
-    _test_model_list(model_list, ctx, x)
-
 
 if __name__ == '__main__':
     import nose

--- a/tests/unittests/test_model_zoo.py
+++ b/tests/unittests/test_model_zoo.py
@@ -669,16 +669,6 @@ def test_quantized_pose_estimation_models():
     _test_model_list(model_list, ctx, x)
 
 
-@with_cpu(0)
-def test_quantized_action_recognition_models():
-    # num_segments should be aligned with value when calibrating FP32 models
-    num_segments = 3
-    model_list = ['vgg16_ucf101_int8']
-    ctx = mx.context.current_context()
-    x = mx.random.uniform(shape=(1 * num_segments, 3, 224, 224), ctx=ctx)
-    _test_model_list(model_list, ctx, x)
-
-
 if __name__ == '__main__':
     import nose
 


### PR DESCRIPTION
This PR temporarily disable unit test for quantized action recognition models because it often causes CI test error (OOM). We will add the test back when we root cause the problem. 

@zhreshold @wuxun-zhang 