### PR TITLE
Segmentation models class names fix

### DIFF
--- a/gluoncv/data/mscoco/segmentation.py
+++ b/gluoncv/data/mscoco/segmentation.py
@@ -38,6 +38,11 @@ class COCOSegmentation(SegmentationDataset):
     CAT_LIST = [0, 5, 2, 16, 9, 44, 6, 3, 17, 62, 21, 67, 18, 19, 4,
                 1, 64, 20, 63, 7, 72]
     NUM_CLASS = 21
+    CLASSES = ("background", "airplane", "bicycle", "bird", "boat", "bottle",
+               "bus", "car", "cat", "chair", "cow", "diningtable", "dog", "horse",
+               "motorcycle", "person", "potted-plant", "sheep", "sofa", "train",
+               "tv")
+
     def __init__(self, root=os.path.expanduser('~/.mxnet/datasets/coco'),
                  split='train', mode=None, transform=None, **kwargs):
         super(COCOSegmentation, self).__init__(root, split, mode, transform, **kwargs)
@@ -131,7 +136,4 @@ class COCOSegmentation(SegmentationDataset):
     @property
     def classes(self):
         """Category names."""
-        return ('background', 'airplane', 'bicycle', 'bird', 'boat', 'bottle',
-                'bus', 'car', 'cat', 'chair', 'cow', 'diningtable', 'dog', 'horse',
-                'motorcycle', 'person', 'potted-plant', 'sheep', 'sofa', 'train',
-                'tv')
+        return type(self).CLASSES

--- a/gluoncv/data/pascal_aug/segmentation.py
+++ b/gluoncv/data/pascal_aug/segmentation.py
@@ -33,6 +33,11 @@ class VOCAugSegmentation(SegmentationDataset):
     """
     TRAIN_BASE_DIR = 'VOCaug/dataset/'
     NUM_CLASS = 21
+    CLASSES = ("background", "airplane", "bicycle", "bird", "boat", "bottle",
+               "bus", "car", "cat", "chair", "cow", "diningtable", "dog", "horse",
+               "motorcycle", "person", "potted-plant", "sheep", "sofa", "train",
+               "tv")
+
     def __init__(self, root=os.path.expanduser('~/.mxnet/datasets/voc'),
                  split='train', mode=None, transform=None, **kwargs):
         super(VOCAugSegmentation, self).__init__(root, split, mode, transform, **kwargs)
@@ -87,7 +92,4 @@ class VOCAugSegmentation(SegmentationDataset):
     @property
     def classes(self):
         """Category names."""
-        return ('background', 'airplane', 'bicycle', 'bird', 'boat', 'bottle',
-                'bus', 'car', 'cat', 'chair', 'cow', 'diningtable', 'dog', 'horse',
-                'motorcycle', 'person', 'potted-plant', 'sheep', 'sofa', 'train',
-                'tv')
+        return type(self).CLASSES

--- a/gluoncv/data/pascal_voc/segmentation.py
+++ b/gluoncv/data/pascal_voc/segmentation.py
@@ -35,6 +35,11 @@ class VOCSegmentation(SegmentationDataset):
     """
     BASE_DIR = 'VOC2012'
     NUM_CLASS = 21
+    CLASSES = ("background", "airplane", "bicycle", "bird", "boat", "bottle",
+               "bus", "car", "cat", "chair", "cow", "diningtable", "dog", "horse",
+               "motorcycle", "person", "potted-plant", "sheep", "sofa", "train",
+               "tv")
+
     def __init__(self, root=os.path.expanduser('~/.mxnet/datasets/voc'),
                  split='train', mode=None, transform=None, **kwargs):
         super(VOCSegmentation, self).__init__(root, split, mode, transform, **kwargs)
@@ -100,7 +105,4 @@ class VOCSegmentation(SegmentationDataset):
     @property
     def classes(self):
         """Category names."""
-        return ('background', 'airplane', 'bicycle', 'bird', 'boat', 'bottle',
-                'bus', 'car', 'cat', 'chair', 'cow', 'diningtable', 'dog', 'horse',
-                'motorcycle', 'person', 'potted-plant', 'sheep', 'sofa', 'train',
-                'tv')
+        return type(self).CLASSES

--- a/gluoncv/model_zoo/deeplabv3.py
+++ b/gluoncv/model_zoo/deeplabv3.py
@@ -206,7 +206,7 @@ def get_deeplab(dataset='pascal_voc', backbone='resnet50', pretrained=False,
     from ..data import datasets
     # infer number of classes
     model = DeepLabV3(datasets[dataset].NUM_CLASS, backbone=backbone, ctx=ctx, **kwargs)
-    model.classes = datasets[dataset].classes
+    model.classes = datasets[dataset].CLASSES
     if pretrained:
         from .model_store import get_model_file
         model.load_parameters(get_model_file('deeplab_%s_%s'%(backbone, acronyms[dataset]),

--- a/gluoncv/model_zoo/deeplabv3_plus.py
+++ b/gluoncv/model_zoo/deeplabv3_plus.py
@@ -269,7 +269,7 @@ def get_deeplab_plus(dataset='pascal_voc', backbone='xception', pretrained=False
     from ..data import datasets
     # infer number of classes
     model = DeepLabV3Plus(datasets[dataset].NUM_CLASS, backbone=backbone, ctx=ctx, **kwargs)
-    model.classes = datasets[dataset].classes
+    model.classes = datasets[dataset].CLASSES
     if pretrained:
         from .model_store import get_model_file
         model.load_parameters(get_model_file('deeplab_%s_%s'%(backbone, acronyms[dataset]),

--- a/gluoncv/model_zoo/deeplabv3b_plus.py
+++ b/gluoncv/model_zoo/deeplabv3b_plus.py
@@ -239,7 +239,7 @@ def get_deeplabv3b_plus(dataset='citys', backbone='wideresnet', pretrained=False
     from ..data import datasets
     # infer number of classes
     model = DeepLabWV3Plus(datasets[dataset].NUM_CLASS, backbone=backbone, ctx=ctx, **kwargs)
-    model.classes = datasets[dataset].classes
+    model.classes = datasets[dataset].CLASSES
     if pretrained:
         from .model_store import get_model_file
         model.load_parameters(get_model_file('deeplab_v3b_plus_%s_%s'%(backbone, acronyms[dataset]),

--- a/gluoncv/model_zoo/fcn.py
+++ b/gluoncv/model_zoo/fcn.py
@@ -124,7 +124,7 @@ def get_fcn(dataset='pascal_voc', backbone='resnet50', pretrained=False,
     # infer number of classes
     model = FCN(datasets[dataset].NUM_CLASS, backbone=backbone, pretrained_base=pretrained_base,
                 ctx=ctx, **kwargs)
-    model.classes = datasets[dataset].classes
+    model.classes = datasets[dataset].CLASSES
     if pretrained:
         from .model_store import get_model_file
         model.load_parameters(get_model_file(

--- a/gluoncv/model_zoo/icnet.py
+++ b/gluoncv/model_zoo/icnet.py
@@ -351,7 +351,7 @@ def get_icnet(dataset='citys', backbone='resnet50', pretrained=False,
     # infer number of classes
     model = ICNet(datasets[dataset].NUM_CLASS, backbone=backbone,
                   pretrained_base=pretrained_base, ctx=ctx, **kwargs)
-    model.classes = datasets[dataset].classes
+    model.classes = datasets[dataset].CLASSES
 
     if pretrained:
         from .model_store import get_model_file

--- a/gluoncv/model_zoo/pspnet.py
+++ b/gluoncv/model_zoo/pspnet.py
@@ -178,7 +178,7 @@ def get_psp(dataset='pascal_voc', backbone='resnet50', pretrained=False,
     # infer number of classes
     model = PSPNet(datasets[dataset].NUM_CLASS, backbone=backbone,
                    pretrained_base=pretrained_base, ctx=ctx, **kwargs)
-    model.classes = datasets[dataset].classes
+    model.classes = datasets[dataset].CLASSES
     if pretrained:
         from .model_store import get_model_file
         model.load_parameters(get_model_file('psp_%s_%s'%(backbone, acronyms[dataset]),


### PR DESCRIPTION
This PR fixes issue #1234

The segmentation models have their `.classes` attribute set incorrectly: accessing them returns a `<property object>`. This is because the model loaders access a property of the dataset class, instead of a property of an instance of that class.

This change uses the class attribute `CLASSES` instead, in accordance with how other models like the object detection ones do ([like here](https://github.com/dmlc/gluon-cv/blob/master/gluoncv/model_zoo/yolo/yolo3.py#L605-L638)). Also, most classes already access `NUM_CLASS` in the same way. For those classes that didn't have a `CLASSES` attribute yet, the class names were moved there.