### PR TITLE
Fix a logical error of mask rcnn training script

### DIFF
--- a/scripts/instance/mask_rcnn/train_mask_rcnn.py
+++ b/scripts/instance/mask_rcnn/train_mask_rcnn.py
@@ -615,12 +615,12 @@ def train(net, train_data, val_data, eval_metric, batch_size, ctx, logger, args)
     logger.info('Start training from [Epoch {}]'.format(args.start_epoch))
     best_map = [0]
     base_lr = trainer.learning_rate
+    if not args.disable_hybridization:
+        net.hybridize(static_alloc=args.static_alloc)
+    rcnn_task = ForwardBackwardTask(net, trainer, rpn_cls_loss, rpn_box_loss, rcnn_cls_loss,
+                                    rcnn_box_loss, rcnn_mask_loss)
+    executor = Parallel(args.executor_threads, rcnn_task) if not args.horovod else None
     for epoch in range(args.start_epoch, args.epochs):
-        if not args.disable_hybridization:
-            net.hybridize(static_alloc=args.static_alloc)
-        rcnn_task = ForwardBackwardTask(net, trainer, rpn_cls_loss, rpn_box_loss, rcnn_cls_loss,
-                                        rcnn_box_loss, rcnn_mask_loss)
-        executor = Parallel(args.executor_threads, rcnn_task) if not args.horovod else None
         while lr_steps and epoch >= lr_steps[0]:
             new_lr = trainer.learning_rate * lr_decay
             lr_steps.pop(0)

--- a/scripts/instance/mask_rcnn/train_mask_rcnn.py
+++ b/scripts/instance/mask_rcnn/train_mask_rcnn.py
@@ -615,12 +615,12 @@ def train(net, train_data, val_data, eval_metric, batch_size, ctx, logger, args)
     logger.info('Start training from [Epoch {}]'.format(args.start_epoch))
     best_map = [0]
     base_lr = trainer.learning_rate
-    if not args.disable_hybridization:
-        net.hybridize(static_alloc=args.static_alloc)
     rcnn_task = ForwardBackwardTask(net, trainer, rpn_cls_loss, rpn_box_loss, rcnn_cls_loss,
                                     rcnn_box_loss, rcnn_mask_loss)
     executor = Parallel(args.executor_threads, rcnn_task) if not args.horovod else None
     for epoch in range(args.start_epoch, args.epochs):
+        if not args.disable_hybridization:
+            net.hybridize(static_alloc=args.static_alloc)
         while lr_steps and epoch >= lr_steps[0]:
             new_lr = trainer.learning_rate * lr_decay
             lr_steps.pop(0)


### PR DESCRIPTION
After this fix, the training memory will be steady. If given a very big epoch（often with small dataset), this error will eat all GPU memory as epoch grows.
The script of faster rcnn training has this problem too. I‘ll fix it later when I get some tests passed.