### PR TITLE
add mxnet 2.0 backward compatibility

### DIFF
--- a/gluoncv/__init__.py
+++ b/gluoncv/__init__.py
@@ -5,12 +5,14 @@ from __future__ import absolute_import
 
 __version__ = '0.8.0'
 
+from .utils.version import _require_mxnet_version, _deprecate_python2, _mxnet_v2_legacy_hook
+_deprecate_python2()
+_require_mxnet_version('1.4.0')
+_mxnet_v2_legacy_hook()
+
 from . import data
 from . import model_zoo
 from . import nn
 from . import utils
-from .utils.version import _require_mxnet_version, _deprecate_python2
-from . import loss
 
-_deprecate_python2()
-_require_mxnet_version('1.4.0')
+from . import loss

--- a/gluoncv/__init__.py
+++ b/gluoncv/__init__.py
@@ -5,10 +5,9 @@ from __future__ import absolute_import
 
 __version__ = '0.8.0'
 
-from .utils.version import _require_mxnet_version, _deprecate_python2, _mxnet_v2_legacy_hook
+from .utils.version import _require_mxnet_version, _deprecate_python2
 _deprecate_python2()
 _require_mxnet_version('1.4.0')
-_mxnet_v2_legacy_hook()
 
 from . import data
 from . import model_zoo

--- a/gluoncv/utils/metrics/accuracy.py
+++ b/gluoncv/utils/metrics/accuracy.py
@@ -1,7 +1,6 @@
 """Accuracy metirc with ignored labels."""
 # pylint: disable=assignment-from-no-return
 import numpy as np
-import mxnet as mx
 from mxnet import ndarray
 try:
     from mxnet.metric import EvalMetric, check_label_shapes

--- a/gluoncv/utils/metrics/accuracy.py
+++ b/gluoncv/utils/metrics/accuracy.py
@@ -3,10 +3,13 @@
 import numpy as np
 import mxnet as mx
 from mxnet import ndarray
-from mxnet.metric import check_label_shapes
+try:
+    from mxnet.metric import EvalMetric, check_label_shapes
+except ImportError:
+    from mxnet.gluon.metric import EvalMetric, check_label_shapes
 
 
-class Accuracy(mx.metric.EvalMetric):
+class Accuracy(EvalMetric):
     """Computes accuracy classification score with optional ignored labels.
     The accuracy score is defined as
     .. math::

--- a/gluoncv/utils/metrics/coco_detection.py
+++ b/gluoncv/utils/metrics/coco_detection.py
@@ -11,11 +11,13 @@ from os import path as osp
 import warnings
 import numpy as np
 import mxnet as mx
-from ...data.mscoco.utils import try_import_pycocotools
-from ...data.transforms.bbox import affine_transform
+try:
+    from mxnet.metric import EvalMetric
+except ImportError:
+    from mxnet.gluon.metric import EvalMetric
 
 
-class COCODetectionMetric(mx.metric.EvalMetric):
+class COCODetectionMetric(EvalMetric):
     """Detection metric for COCO bbox task.
 
     Parameters
@@ -108,6 +110,7 @@ class COCODetectionMetric(mx.metric.EvalMetric):
         pred = self.dataset.coco.loadRes(self._filename)
         gt = self.dataset.coco
         # lazy import pycocotools
+        from ...data.mscoco.utils import try_import_pycocotools
         try_import_pycocotools()
         from pycocotools.cocoeval import COCOeval
         coco_eval = COCOeval(gt, pred, 'bbox')
@@ -180,6 +183,7 @@ class COCODetectionMetric(mx.metric.EvalMetric):
             Prediction bounding boxes scores with shape `B, N`.
 
         """
+        from ...data.transforms.bbox import affine_transform
         def as_numpy(a):
             """Convert a (list of) mx.NDArray into numpy.ndarray"""
             if isinstance(a, (list, tuple)):

--- a/gluoncv/utils/metrics/coco_instance.py
+++ b/gluoncv/utils/metrics/coco_instance.py
@@ -9,10 +9,13 @@ from os import path as osp
 import mxnet as mx
 import numpy as np
 
-from ...data.mscoco.utils import try_import_pycocotools
+try:
+    from mxnet.metric import EvalMetric
+except ImportError:
+    from mxnet.gluon.metric import EvalMetric
 
 
-class COCOInstanceMetric(mx.metric.EvalMetric):
+class COCOInstanceMetric(EvalMetric):
     """Instance segmentation metric for COCO bbox and segm task.
     Will return box summary, box metric, seg summary and seg metric.
 
@@ -54,7 +57,7 @@ class COCOInstanceMetric(mx.metric.EvalMetric):
         self._current_id = starting_id
         self._results = []
         self._score_thresh = score_thresh
-
+        from ...data.mscoco.utils import try_import_pycocotools
         try_import_pycocotools()
         import pycocotools.mask as cocomask
         self._cocomask = cocomask
@@ -142,6 +145,7 @@ class COCOInstanceMetric(mx.metric.EvalMetric):
                 pred = self.dataset.coco.loadRes(self._filename)
         gt = self.dataset.coco
         # lazy import pycocotools
+        from ...data.mscoco.utils import try_import_pycocotools
         try_import_pycocotools()
         from pycocotools.cocoeval import COCOeval
         # only NVIDIA MSCOCO API support use_ext

--- a/gluoncv/utils/metrics/coco_keypoints.py
+++ b/gluoncv/utils/metrics/coco_keypoints.py
@@ -6,9 +6,12 @@ from os import path as osp
 from collections import OrderedDict
 import warnings
 import mxnet as mx
-from ...data.mscoco.utils import try_import_pycocotools
+try:
+    from mxnet.metric import EvalMetric
+except ImportError:
+    from mxnet.gluon.metric import EvalMetric
 
-class COCOKeyPointsMetric(mx.metric.EvalMetric):
+class COCOKeyPointsMetric(EvalMetric):
     """Detection metric for COCO bbox task.
 
     Parameters
@@ -84,6 +87,7 @@ class COCOKeyPointsMetric(mx.metric.EvalMetric):
         pred = self.dataset.coco.loadRes(self._filename)
         gt = self.dataset.coco
         # lazy import pycocotools
+        from ...data.mscoco.utils import try_import_pycocotools
         try_import_pycocotools()
         from pycocotools.cocoeval import COCOeval
         coco_eval = COCOeval(gt, pred, 'keypoints')

--- a/gluoncv/utils/metrics/coco_keypoints.py
+++ b/gluoncv/utils/metrics/coco_keypoints.py
@@ -5,7 +5,6 @@ import os
 from os import path as osp
 from collections import OrderedDict
 import warnings
-import mxnet as mx
 try:
     from mxnet.metric import EvalMetric
 except ImportError:

--- a/gluoncv/utils/metrics/heatmap_accuracy.py
+++ b/gluoncv/utils/metrics/heatmap_accuracy.py
@@ -1,7 +1,6 @@
 """Accuracy metric for heatmap prediction."""
 # pylint: disable=assignment-from-no-return
 import numpy as np
-import mxnet as mx
 try:
     from mxnet.metric import EvalMetric, check_label_shapes
 except ImportError:

--- a/gluoncv/utils/metrics/heatmap_accuracy.py
+++ b/gluoncv/utils/metrics/heatmap_accuracy.py
@@ -2,11 +2,13 @@
 # pylint: disable=assignment-from-no-return
 import numpy as np
 import mxnet as mx
-from mxnet.metric import check_label_shapes
+try:
+    from mxnet.metric import EvalMetric, check_label_shapes
+except ImportError:
+    from mxnet.gluon.metric import EvalMetric, check_label_shapes
 
-from ...data.transforms.pose import get_max_pred
 
-class HeatmapAccuracy(mx.metric.EvalMetric):
+class HeatmapAccuracy(EvalMetric):
     """Computes heatmap accuracy for keypoint
     Parameters
     ----------
@@ -77,6 +79,7 @@ class HeatmapAccuracy(mx.metric.EvalMetric):
             Prediction values for samples. Each prediction value can either be the class index,
             or a vector of likelihoods for all classes.
         """
+        from ...data.transforms.pose import get_max_pred
         labels, preds = check_label_shapes(labels, preds, True)
 
         num_joints = preds[0].shape[1]

--- a/gluoncv/utils/metrics/rcnn.py
+++ b/gluoncv/utils/metrics/rcnn.py
@@ -1,9 +1,13 @@
 """RCNN framewark Training Metrics."""
 
 import mxnet as mx
+try:
+    from mxnet.metric import EvalMetric
+except ImportError:
+    from mxnet.gluon.metric import EvalMetric
 
 
-class RPNAccMetric(mx.metric.EvalMetric):
+class RPNAccMetric(EvalMetric):
     """ RPN accuracy. """
 
     def __init__(self):

--- a/gluoncv/utils/metrics/segmentation.py
+++ b/gluoncv/utils/metrics/segmentation.py
@@ -2,7 +2,10 @@
 import threading
 import numpy as np
 import mxnet as mx
-from mxnet.metric import EvalMetric
+try:
+    from mxnet.metric import EvalMetric
+except ImportError:
+    from mxnet.gluon.metric import EvalMetric
 
 __all__ = ['SegmentationMetric', 'batch_pix_accuracy', 'batch_intersection_union',
            'pixelAccuracy', 'intersectionAndUnion']

--- a/gluoncv/utils/metrics/tracking.py
+++ b/gluoncv/utils/metrics/tracking.py
@@ -1,6 +1,6 @@
 """ SiamRPN metrics """
 import numpy as np
-from gluoncv.utils.filesystem import try_import_colorama
+from ..filesystem import try_import_colorama
 
 def Iou(rect1, rect2):
     """

--- a/gluoncv/utils/metrics/voc_detection.py
+++ b/gluoncv/utils/metrics/voc_detection.py
@@ -5,8 +5,12 @@ from collections import defaultdict
 import numpy as np
 import mxnet as mx
 from ..bbox import bbox_iou
+try:
+    from mxnet.metric import EvalMetric
+except ImportError:
+    from mxnet.gluon.metric import EvalMetric
 
-class VOCMApMetric(mx.metric.EvalMetric):
+class VOCMApMetric(EvalMetric):
     """
     Calculate mean AP for object detection task
 

--- a/gluoncv/utils/version.py
+++ b/gluoncv/utils/version.py
@@ -2,7 +2,7 @@
 import sys
 import warnings
 
-__all__ = ['check_version', '_require_mxnet_version', '_deprecate_python2']
+__all__ = ['check_version', '_require_mxnet_version', '_deprecate_python2', '_mxnet_v2_legacy_hook']
 
 def check_version(min_version, warning_only=False):
     """Check the version of gluoncv satisfies the provided minimum version.
@@ -52,3 +52,10 @@ def _deprecate_python2():
             'A future version of gluoncv will drop support for Python 2.'
         warnings.simplefilter('always', DeprecationWarning)
         warnings.warn(msg, DeprecationWarning)
+
+def _mxnet_v2_legacy_hook():
+    import mxnet
+    try:
+        from mxnet import metric
+    except ImportError:
+        mxnet.metric = mxnet.gluon.metric

--- a/gluoncv/utils/version.py
+++ b/gluoncv/utils/version.py
@@ -56,6 +56,8 @@ def _deprecate_python2():
 def _mxnet_v2_legacy_hook():
     import mxnet
     try:
+        # pylint: disable=unused-import
         from mxnet import metric
+        # TODO(zhreshold): migrate to mxnet 2.0 style
     except ImportError:
         mxnet.metric = mxnet.gluon.metric

--- a/gluoncv/utils/version.py
+++ b/gluoncv/utils/version.py
@@ -2,7 +2,7 @@
 import sys
 import warnings
 
-__all__ = ['check_version', '_require_mxnet_version', '_deprecate_python2', '_mxnet_v2_legacy_hook']
+__all__ = ['check_version', '_require_mxnet_version', '_deprecate_python2']
 
 def check_version(min_version, warning_only=False):
     """Check the version of gluoncv satisfies the provided minimum version.
@@ -52,12 +52,3 @@ def _deprecate_python2():
             'A future version of gluoncv will drop support for Python 2.'
         warnings.simplefilter('always', DeprecationWarning)
         warnings.warn(msg, DeprecationWarning)
-
-def _mxnet_v2_legacy_hook():
-    import mxnet
-    try:
-        # pylint: disable=unused-import
-        from mxnet import metric
-        # TODO(zhreshold): migrate to mxnet 2.0 style
-    except ImportError:
-        mxnet.metric = mxnet.gluon.metric

--- a/gluoncv/utils/viz/mask.py
+++ b/gluoncv/utils/viz/mask.py
@@ -4,8 +4,6 @@ from __future__ import absolute_import, division
 import numpy as np
 import mxnet as mx
 
-from ...data.transforms.mask import fill
-
 def expand_mask(masks, bboxes, im_shape, scores=None, thresh=0.5, scale=1.0, sortby=None):
     """Expand instance segmentation mask to full image size.
 
@@ -36,6 +34,7 @@ def expand_mask(masks, bboxes, im_shape, scores=None, thresh=0.5, scale=1.0, sor
     numpy.ndarray
         Index array of sorted masks
     """
+    from ...data.transforms.mask import fill
     if len(masks) != len(bboxes):
         raise ValueError('The length of bboxes and masks mismatch, {} vs {}'
                          .format(len(bboxes), len(masks)))


### PR DESCRIPTION
- Fix `mxnet.metric` being replaced by `mx.gluon.metric`
- Fix potential cyclic import that will cause complete mess of modular dependencies