### PR TITLE
[WIP][DO NOT MERGE] Fit api

### DIFF
--- a/gluoncv/__init__.py
+++ b/gluoncv/__init__.py
@@ -5,13 +5,8 @@ from __future__ import absolute_import
 
 __version__ = '0.8.0'
 
-from .utils.version import _require_mxnet_version, _deprecate_python2
-_deprecate_python2()
-_require_mxnet_version('1.4.0', '2.0.0')
-
+from . import utils
 from . import data
 from . import model_zoo
 from . import nn
-from . import utils
-
 from . import loss

--- a/gluoncv/pipelines/__init__.py
+++ b/gluoncv/pipelines/__init__.py
@@ -1,0 +1,2 @@
+"""GluonCV pipelines for fit/predict/val..."""
+from .center_net import CenterNetEstimator

--- a/gluoncv/pipelines/base.py
+++ b/gluoncv/pipelines/base.py
@@ -88,6 +88,9 @@ class BaseEstimator(object):
     def fit(self, train_data):
         raise NotImplementedError
 
+    def evaluate(self, val_data):
+        raise NotImplementedError
+
     def predict(self, test_data):
         raise NotImplementedError
 

--- a/gluoncv/pipelines/base.py
+++ b/gluoncv/pipelines/base.py
@@ -50,7 +50,7 @@ class BaseEstimator(object):
         self.config = self._get_default_config()
         self._update_config(config)
         self.reporter = reporter
-        self.logdir = os.path.abspath(logdir) if cwd else os.getcwd()
+        self.logdir = os.path.abspath(logdir) if logdir else os.getcwd()
 
     def _update_config(self, config=None):
         if not config:

--- a/gluoncv/pipelines/base.py
+++ b/gluoncv/pipelines/base.py
@@ -1,0 +1,95 @@
+"""Base Estimator"""
+import os
+import argparse
+import copy
+from datetime import datetime
+from yacs.config import CfgNode
+
+def set_default(default_config_func):
+    def _apply(cls):
+        # docstring
+        cls.__doc__ = str(cls.__doc__) if cls.__doc__ else ''
+        cls.__doc__ += ("\n\nParameters\n"
+                        "----------\n"
+                        "config : str, list or CfgNode\n"
+                        "  Config used to override default configurations.\n"
+                        "reporter : Reporter, default is `None`.\n"
+                        "  If not `None`, reporter will be used to record metrics.\n"
+                        "logdir : str, default is None.\n"
+                        "  Directory for saving logs. If `None`, current working directory is used.\n")
+        cls.__doc__ += '\nDefault configurations: \n----------\n'
+        cls.__doc__ += str(default_config_func())
+        # default config
+        @classmethod
+        def get_default_cfg(cls):
+            return default_config_func()
+        cls._get_default_config = get_default_cfg
+        return cls
+    return _apply
+
+def config_to_args(parser, config, prefix=None):
+    if prefix is None:
+        prefix = []
+    for k, v in sorted(config.items()):
+        p = prefix + [str(k)]
+        if isinstance(v, CfgNode):
+            config_to_args(parser, v, prefix=p)
+        else:
+            parser.add_argument('--' + '.'.join(p), default=v, type=type(v), metavar="'" + str(v) + "'")
+    return parser
+
+def fullname(o):
+    module = o.__class__.__module__
+    if module is None or module == str.__class__.__module__:
+        return o.__class__.__name__
+    return module + '.' + o.__class__.__name__
+
+class BaseEstimator(object):
+    # docstring of BaseEstimator is deliberately left empty
+    def __init__(self, config=None, reporter=None, logdir=None):
+        self.config = self._get_default_config()
+        self._update_config(config)
+        self.reporter = reporter
+        self.logdir = os.path.abspath(logdir) if cwd else os.getcwd()
+
+    def _update_config(self, config=None):
+        if not config:
+            return
+        if isinstance(config, str) and os.path.splitext(config) in ('yml', 'yaml'):
+            self.config.merge_from_file(config)
+        elif isinstance(config, (list, tuple)):
+            self.config.merge_from_list(list(config))
+        elif isinstance(config, CfgNode):
+            self.config.merge_from_other_cfg(config)
+        else:
+            raise ValueError('Unsupported config type: {0}.'.format(type(config)))
+
+    def parse_args(self, args=None, namespace=None):
+        parser = argparse.ArgumentParser('Estimator Arguments')
+        parser = config_to_args(parser, self.config)
+        args = parser.parse_args(args=args, namespace=namespace)
+        list_config = []
+        for k in vars(args):
+            v = getattr(args, k)
+            if isinstance(v, (tuple, list)):
+                v = str(v)
+            list_config += [k, v]
+        self.config.merge_from_list(list_config)
+
+    def finalize_config(self):
+        self.config.freeze()
+        fn = fullname(self) + datetime.now().strftime("-%m-%d-%Y-%H-%M-%S.yml")
+        fn = os.path.join(self.logdir, fn)
+        with open(fn, 'wt') as f:
+            f.write('# ' + fn + '\n')
+            f.write(str(self.config))
+            f.write('\n')
+
+    def fit(self, train_data):
+        raise NotImplementedError
+
+    def predict(self, test_data):
+        raise NotImplementedError
+
+    def deploy(self):
+        raise NotImplementedError

--- a/gluoncv/pipelines/center_net.py
+++ b/gluoncv/pipelines/center_net.py
@@ -1,0 +1,28 @@
+"""CenterNet Estimator"""
+from .base import BaseEstimator, set_default
+from yacs.config import CfgNode as CN
+
+def get_cfg_defaults():
+    _C = CN()
+
+    _C.SYSTEM = CN()
+    # Number of GPUS to use in the experiment
+    _C.SYSTEM.NUM_GPUS = 8
+    # Number of workers for doing things
+    _C.SYSTEM.NUM_WORKERS = 4
+
+    _C.TRAIN = CN()
+    # A very important hyperparameter
+    _C.TRAIN.HYPERPARAMETER_1 = 0.1
+    # The all important scales for the stuff
+    _C.TRAIN.SCALES = (2, 4, 8, 16)
+    return _C.clone()
+
+@set_default(get_cfg_defaults)
+class CenterNetEstimator(BaseEstimator):
+    """CenterNet Estimator."""
+    def __init__(self, config=None, reporter=None, logdir=None):
+        super(CenterNetEstimator, self).__init__(config, reporter, logdir)
+
+    def fit(self, train_data):
+        self.finalize_config()

--- a/gluoncv/pipelines/center_net.py
+++ b/gluoncv/pipelines/center_net.py
@@ -2,7 +2,7 @@
 from .base import BaseEstimator, set_default
 from yacs.config import CfgNode as CN
 
-def get_cfg_defaults():
+def get_center_net_defaults():
     _C = CN()
 
     _C.SYSTEM = CN()
@@ -18,7 +18,7 @@ def get_cfg_defaults():
     _C.TRAIN.SCALES = (2, 4, 8, 16)
     return _C.clone()
 
-@set_default(get_cfg_defaults)
+@set_default(get_center_net_defaults)
 class CenterNetEstimator(BaseEstimator):
     """CenterNet Estimator."""
     def __init__(self, config=None, reporter=None, logdir=None):
@@ -26,3 +26,4 @@ class CenterNetEstimator(BaseEstimator):
 
     def fit(self, train_data):
         self.finalize_config()
+        # setup trainer, metrics, loss...

--- a/gluoncv/pipelines/center_net.py
+++ b/gluoncv/pipelines/center_net.py
@@ -1,22 +1,111 @@
 """CenterNet Estimator"""
-from .base import BaseEstimator, set_default
+import os
+import warnings
 from yacs.config import CfgNode as CN
+import mxnet as mx
+from mxnet import gluon
+from .base import BaseEstimator, set_default
+from ..data import COCODetection, VOCDetection
+from ..data.transforms.presets.center_net import CenterNetDefaultTrainTransform
+from ..data.transforms.presets.center_net import CenterNetDefaultValTransform, get_post_transform
+from ..data.batchify import Tuple, Stack, Pad
+from ..utils.metric import COCODetectionMetric
+from ..utils.metrics.accuracy import Accuracy
+from ..utils import LRScheduler, LRSequential
+from ..utils import random as _random
+from ..model_zoo.center_net import get_center_net
+from ..loss import *
+
 
 def get_center_net_defaults():
-    _C = CN()
+    cfg = CN()
 
-    _C.SYSTEM = CN()
-    # Number of GPUS to use in the experiment
-    _C.SYSTEM.NUM_GPUS = 8
+    cfg.MODEL = CN()
+    # base feature network
+    cfg.MODEL.BASE_NETWORK = 'dla34_deconv_dcnv2'
+    cfg.MODEL.HEADS = CN()
+    # init bias for conv
+    cfg.MODEL.HEADS.BIAS = -2.19  # use bias = -log((1 - 0.1) / 0.1)
+    # wh head channel
+    cfg.MODEL.HEADS.WH_OUTPUTS = 2
+    # regression head channel
+    cfg.MODEL.HEADS.REG_OUTPUTS = 2
+    # additional conv channel
+    cfg.MODEL.HEADS.HEAD_CONV_CHANNEL = 64
+    # output vs input scaling ratio, e.g., input_h // feature_h
+    cfg.MODEL.SCALE = 4.0
+    # topk detection results will be kept after inference
+    cfg.MODEL.TOPK = 100
+    # model zoo root dir
+    cfg.MODEL.ROOT = os.path.join('~', '.mxnet', 'models')
+
+    cfg.DATA = CN()
+    # dataset root
+    cfg.DATA.ROOT = os.path.join('~', '.mxnet', 'datasets')
+    # dataset type
+    cfg.DATA.TYPE = 'coco'  # coco json style
+    cfg.DATA.TRAIN_SPLITS = 'instances_train2017'
+    cfg.DATA.VALID_SPLITS = 'instances_val2017'
+    cfg.DATA.VALID_SKIP_EMPTY = False
+
+    cfg.SYSTEM = CN()
+    # GPU IDs to use in the experiment
+    cfg.SYSTEM.GPUS = (0, 1, 2, 3, 4, 5, 6, 7)
     # Number of workers for doing things
-    _C.SYSTEM.NUM_WORKERS = 4
+    cfg.SYSTEM.NUM_WORKERS = 16
 
-    _C.TRAIN = CN()
+    cfg.TRAIN = CN()
+    # whether load the imagenet pre-trained base
+    cfg.TRAIN.PRETRAINED_BASE = True
+    # whether finetune from other models, expect a dataset name, e.g., 'coco'
+    cfg.TRAIN.TRANSFER_FROM = None
     # A very important hyperparameter
-    _C.TRAIN.HYPERPARAMETER_1 = 0.1
-    # The all important scales for the stuff
-    _C.TRAIN.SCALES = (2, 4, 8, 16)
-    return _C.clone()
+    cfg.TRAIN.BATCH_SIZE = 32
+    # training data shape
+    cfg.TRAIN.DATA_SHAPE = 512
+    # epochs
+    cfg.TRAIN.EPOCHS = 140
+    # Resume from previously saved parameters if not empty
+    cfg.TRAIN.RESUME = ''
+    # Starting epoch for resuming, default is 0 for new training
+    cfg.TRAIN.START_EPOCH = 0
+    # Learning rate
+    cfg.TRAIN.LR = 1.25e-4
+    # decay rate of learning rate.
+    cfg.TRAIN.LR_DECAY = 0.1
+    # epochs at which learning rate decays
+    cfg.TRAIN.LR_DECAY_EPOCH = (90, 120)
+    # learning rate scheduler mode. options are step, poly and cosine
+    cfg.TRAIN.LR_MODE = 'step'
+    # starting warmup learning rate.
+    cfg.TRAIN.WARMUP_LR = 0.0
+    # number of warmup epochs
+    cfg.TRAIN.WARMUP_EPOCHS = 0
+    # SGD momentum, default is 0.9
+    cfg.TRAIN.MOMENTUM = 0.9
+    # Weight decay, default is 1e-4
+    cfg.TRAIN.WD = 1e-4
+    # random seed
+    cfg.TRAIN.SEED = 123
+    # Loss weight for width/height
+    cfg.TRAIN.WH_WEIGHT = 0.1
+    # Center regression loss weight
+    cfg.TRAIN.CENTER_REG_WEIGHT = 1.0
+    # Saving parameters epoch interval, best model will always be saved
+    cfg.TRAIN.SAVE_INTERVAL = 10
+
+    cfg.VALID = CN()
+    # enable flip test
+    cfg.VALID.FLIP_TEST = True
+    # nms
+    cfg.VALID.NMS_THRESH = 0  # 0 means disable
+    # pre nms topk
+    cfg.VALID.NMS_TOPK = 400
+    # post nms topk
+    cfg.VALID.POST_NMS = 100
+    # Epoch interval for validation, increase the number will reduce the training time if validation is slow
+    cfg.VALID.INTERVAL = 10
+    return cfg.clone()
 
 @set_default(get_center_net_defaults)
 class CenterNetEstimator(BaseEstimator):
@@ -25,5 +114,109 @@ class CenterNetEstimator(BaseEstimator):
         super(CenterNetEstimator, self).__init__(config, reporter, logdir)
 
     def fit(self, train_data):
+        if isinstance(train_data, str) and train_data.lower() == 'coco':
+            self.config.DATA.TRAIN.TYPE = 'coco'
+            self.config.DATA.TRAIN.SPLITS = 'instances_train2017'
+            self.config.DATA.VALID.TYPE = 'coco'
+            self.config.DATA.VALID.SPLITS = 'instances_val2017'
+        elif isinstance(train_data, str) and train_data.lower() == 'voc':
+            self.config.DATA.TRAIN.TYPE = 'voc'
+            self.config.DATA.TRAIN.SPLITS = [(2007, 'trainval'), (2012, 'trainval')]
+            self.config.DATA.VALID.TYPE = 'voc'
+            self.config.DATA.VALID.SPLITS = [(2007, 'test')]
+        else:
+            raise NotImplementedError('CenterNetEstimator.fit now only supports coco and voc')
         self.finalize_config()
-        # setup trainer, metrics, loss...
+
+        # dataset
+        if self.config.DATA.TYPE == 'coco':
+            train_dataset = COCODetection(root=os.path.join(self.config.DATA.ROOT, 'coco'),
+                                          splits=self.config.DATA.TRAIN_SPLITS)
+            val_dataset = COCODetection(root=os.path.join(self.config.DATA.ROOT, 'coco'),
+                                        splits=self.config.DATA.VALID_SPLITS,
+                                        skip_empty=self.config.DATA.VALID_SKIP_EMPTY)
+            val_metric = COCODetectionMetric(
+                val_dataset, os.path.join(self.logdir, 'coco_eval'), cleanup=True,
+                data_shape=(self.config.TRAIN.DATA_SHAPE, self.config.TRAIN.DATA_SHAPE),
+                post_affine=get_post_transform)
+        elif self.config.DATA.TYPE == 'voc':
+            train_dataset = VOCDetection(splits=self.config.DATA.TRAIN_SPLITS)
+            val_dataset = VOCDetection(splits=self.config.DATA.VALID_SPLITS)
+            val_metric = VOC07MApMetric(iou_thresh=0.5, class_names=val_dataset.classes)
+        else:
+            raise NotImplementedError('Invalid dataset type: {}'.format(self.config.DATA.TYPE))
+
+        # network
+        ctx = [mx.gpu(int(i)) for i in self.config.SYSTEM.GPUS]
+        ctx = ctx if ctx else [mx.cpu()]
+
+        net_name = '_'.join(('center_net', self.config.MODEL.BASE_NETWORK, self.config.DATA.TYPE))
+        heads = OrderedDict([
+            ('heatmap', {'num_output': train_dataset.num_class, 'bias': self.config.MODEL.HEADS.BIAS}),
+            ('wh', {'num_output': self.config.MODEL.HEADS.WH_OUTPUTS}),
+            ('reg', {'num_output': self.config.MODEL.HEADS.REG_OUTPUTS})
+            ])
+        net = get_center_net(self.config.MODEL.BASE_NETWORK,
+                             self.config.DATA.TYPE,
+                             base_network=self.config.MODEL.BASE_NETWORK,
+                             heads=heads,
+                             head_conv_channel=self.config.MODEL.HEADS.HEAD_CONV_CHANNEL,
+                             classes=train_dataset.classes,
+                             scale=self.config.MODEL.SCALE,
+                             topk=self.config.MODEL.TOPK,
+                             pretrained_base=self.config.TRAIN.PRETRAINED_BASE,
+                             norm_layer=gluon.nn.BatchNorm)
+        if self.config.TRAIN.RESUME.strip():
+            net.load_parameters(self.config.TRAIN.RESUME.strip())
+        else:
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                net.initialize()
+
+        # dataloader
+        _random.seed(self.config.TRAIN.SEED)
+        batch_size = self.config.TRAIN.BATCH_SIZE
+        width, height = self.config.TRAIN.DATA_SHAPE, self.config.TRAIN.DATA_SHAPE
+        num_class = len(train_dataset.classes)
+        batchify_fn = Tuple([Stack() for _ in range(6)])  # stack image, cls_targets, box_targets
+        train_loader = gluon.data.DataLoader(
+            train_dataset.transform(CenterNetDefaultTrainTransform(
+                width, height, num_class=num_class, scale_factor=net.scale)),
+            batch_size, True, batchify_fn=batchify_fn, last_batch='rollover',
+            num_workers=self.config.SYSTEM.NUM_WORKERS)
+        val_batchify_fn = Tuple(Stack(), Pad(pad_val=-1))
+        val_loader = gluon.data.DataLoader(
+            val_dataset.transform(CenterNetDefaultValTransform(width, height)),
+            batch_size, False, batchify_fn=val_batchify_fn, last_batch='keep',
+            num_workers=self.config.SYSTEM.NUM_WORKERS)
+
+    def _train(self, net, train_data, val_data, eval_metric, ctx):
+        net.collect_params().reset_ctx(ctx)
+        # lr decay policy
+        lr_decay = float(self.config.TRAIN.LR_DECAY)
+        lr_steps = sorted(self.config.TRAIN.LR_DECAY_EPOCH)
+        lr_decay_epoch = [e - self.config.TRAIN.WARMUP_EPOCHS for e in lr_steps]
+        num_batches = len(train_data) // self.config.TRAIN.BATCH_SIZE
+        lr_scheduler = LRSequential([
+            LRScheduler('linear', base_lr=0, target_lr=self.config.TRAIN.LR,
+                        nepochs=self.config.TRAIN.WARMUP_EPOCHS, iters_per_epoch=num_batches),
+            LRScheduler(self.config.TRAIN.LR_MODE, base_lr=self.config.TRAIN.LR,
+                        nepochs=self.config.TRAIN.EPOCHS - self.config.TRAIN.WARMUP_EPOCHS,
+                        iters_per_epoch=num_batches,
+                        step_epoch=lr_decay_epoch,
+                        step_factor=self.config.TRAIN.LR_DECAY, power=2),
+        ])
+
+        for k, v in net.collect_params('.*bias').items():
+            v.wd_mult = 0.0
+        trainer = gluon.Trainer(
+                    net.collect_params(), 'adam',
+                    {'learning_rate': self.config.TRAIN.LR, 'wd': self.config.TRAIN.WD,
+                     'lr_scheduler': lr_scheduler})
+
+        heatmap_loss = HeatmapFocalLoss(from_logits=True)
+        wh_loss = MaskedL1Loss(weight=args.wh_weight)
+        center_reg_loss = MaskedL1Loss(weight=args.center_reg_weight)
+        heatmap_loss_metric = mx.metric.Loss('HeatmapFocal')
+        wh_metric = mx.metric.Loss('WHL1')
+        center_reg_metric = mx.metric.Loss('CenterRegL1')

--- a/gluoncv/pipelines/estimator/yolov3.py
+++ b/gluoncv/pipelines/estimator/yolov3.py
@@ -1,9 +1,0 @@
-from ...model_zoo.yolo import YOLOv3
-
-
-class YOLOv3Estimator:
-    def __init__(self):
-        pass
-
-    def fit(self, data):
-        pass

--- a/gluoncv/pipelines/estimator/yolov3.py
+++ b/gluoncv/pipelines/estimator/yolov3.py
@@ -1,0 +1,9 @@
+from ...model_zoo.yolo import YOLOv3
+
+
+class YOLOv3Estimator:
+    def __init__(self):
+        pass
+
+    def fit(self, data):
+        pass

--- a/gluoncv/utils/__init__.py
+++ b/gluoncv/utils/__init__.py
@@ -2,6 +2,7 @@
 # pylint: disable=wildcard-import
 from __future__ import absolute_import
 
+from . import version
 from . import bbox
 from . import viz
 from . import random
@@ -16,4 +17,3 @@ from .lr_scheduler import LRSequential, LRScheduler
 from .plot_history import TrainingHistory
 from .export_helper import export_block, export_tvm
 from .sync_loader_helper import split_data, split_and_load
-from .version import *

--- a/gluoncv/utils/version.py
+++ b/gluoncv/utils/version.py
@@ -55,3 +55,6 @@ def _deprecate_python2():
             'A future version of gluoncv will drop support for Python 2.'
         warnings.simplefilter('always', DeprecationWarning)
         warnings.warn(msg, DeprecationWarning)
+
+_deprecate_python2()
+_require_mxnet_version('1.4.0', '2.0.0')

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ requirements = [
     'portalocker',
     'Pillow',
     'scipy',
+    'yacs',
 ]
 if with_cython:
     _NP_INCLUDE_DIRS = np.get_include()


### PR DESCRIPTION
This is a proposal for simplified estimator development.


To avoid manual coding for arguments, I am providing an example `Estimator` that can generate docstring from default configurations.

An example would be
```python
def get_center_net_defaults():
    _C = CN()

    _C.SYSTEM = CN()
    # Number of GPUS to use in the experiment
    _C.SYSTEM.NUM_GPUS = 8
    # Number of workers for doing things
    _C.SYSTEM.NUM_WORKERS = 4

    _C.TRAIN = CN()
    # A very important hyperparameter
    _C.TRAIN.HYPERPARAMETER_1 = 0.1
    # The all important scales for the stuff
    _C.TRAIN.SCALES = (2, 4, 8, 16)
    return _C.clone()

@set_default(get_center_net_defaults)
class CenterNetEstimator(BaseEstimator):
    """CenterNet Estimator."""
    def __init__(self, config=None, reporter=None, logdir=None):
        super(CenterNetEstimator, self).__init__(config, reporter, logdir)

    def fit(self, train_data):
        self.finalize_config() # avoid modification to config, and save to yaml file for reference
        trainer = ...
        metrics = ...
```

### One time configuration
First of all, a util function that returns the default arguments for this particular estimator is provided so that you don't have to repetitively write the docs for each argument. Though there's no excellent solution so far to inject comments into the docstring or yaml file.

### Automatic docstring generation
A decorator for injecting the default arguments into the BaseEstimator with lots of helper functions is provided. The `__doc__` will be generated by reading the default values from the config.

For example, call help(estimator) of above example will produce:

```
class CenterNetEstimator(gluoncv.pipelines.base.BaseEstimator)
 |  CenterNetEstimator(config=None, reporter=None, logdir=None)
 |
 |  CenterNet Estimator.
 |
 |  Parameters
 |  ----------
 |  config : str, list or CfgNode
 |    Config used to override default configurations.
 |  reporter : Reporter, default is `None`.
 |    If not `None`, reporter will be used to record metrics.
 |  logdir : str, default is None.
 |    Directory for saving logs. If `None`, current working directory is used.
 |
 |  Default configurations:
 |  ----------
 |  SYSTEM:
 |    NUM_GPUS: 8
 |    NUM_WORKERS: 4
 |  TRAIN:
 |    HYPERPARAMETER_1: 0.1
 |    SCALES: (2, 4, 8, 16)
 |
 |  Method resolution order:
 |      CenterNetEstimator
 |      gluoncv.pipelines.base.BaseEstimator
 |      builtins.object
```

### Parse configurations from yaml file or command line
`parse_args` is provided by `BaseEstimator` to automatically create a ArgParser with default values set. This is very convenient, thus no manual argparse creation. 

```python
estimator = CenterNetEstimator(config='exp.yml', logdir='.')
estimator.parse_args()  # by default, parse from sys.argv
# or from string
estimator.parse_args(['--SYSTEM.NUM_GPUS', '1'])  # this will override the configs read from yaml
```

### Finalize config and dump to yaml file
To ensure that we don't modify the config by accident, we can call `finalize_config`, this will also save the yaml file to `logdir` for reference.
The generated 'xxx_module.xxxEstimator-05-27-2020-21-06-03.yml' file looks like this:
```yaml
# gluoncv.pipelines.center_net.CenterNetEstimator-05-27-2020-21-06-03.yml
SYSTEM:
  NUM_GPUS: 1
  NUM_WORKERS: 4
TRAIN:
  HYPERPARAMETER_1: 0.1
  SCALES: (2, 4, 8, 16)
```




