### PR TITLE
[WIP] Fit api with sacred config

### DIFF
--- a/gluoncv/__init__.py
+++ b/gluoncv/__init__.py
@@ -13,5 +13,5 @@ from . import data
 from . import model_zoo
 from . import nn
 from . import utils
-
 from . import loss
+from . import pipelines

--- a/gluoncv/pipelines/__init__.py
+++ b/gluoncv/pipelines/__init__.py
@@ -1,0 +1,2 @@
+"""GluonCV pipelines"""
+from .estimator import *

--- a/gluoncv/pipelines/data/__init__.py
+++ b/gluoncv/pipelines/data/__init__.py
@@ -1,0 +1,1 @@
+"""Data Pipelines"""

--- a/gluoncv/pipelines/data/coco_detection.py
+++ b/gluoncv/pipelines/data/coco_detection.py
@@ -1,0 +1,14 @@
+"""COCO detection pipeline"""
+import os
+from sacred import Ingredient
+
+coco_detection = Ingredient('coco_detection')
+
+@coco_detection.config
+def cfg():
+    root = os.path.expanduser(os.path.join('~', '.mxnet', 'datasets'))
+    train_splits = 'instances_train2017'
+    valid_splits = 'instances_val2017'
+    valid_skip_empty = False
+    data_shape = None
+    cleanup = True

--- a/gluoncv/pipelines/estimator/__init__.py
+++ b/gluoncv/pipelines/estimator/__init__.py
@@ -1,0 +1,2 @@
+"""Estimator implementations"""
+from .center_net import CenterNetEstimator

--- a/gluoncv/pipelines/estimator/base_estimator.py
+++ b/gluoncv/pipelines/estimator/base_estimator.py
@@ -6,6 +6,8 @@ from sacred.commands import _format_config, save_config, print_config
 # from sacred.settings import SETTINGS
 # SETTINGS.CONFIG.READ_ONLY_CONFIG = False
 
+from ...utils import random as _random
+
 def _fullname(o):
     module = o.__class__.__module__
     if module is None or module == str.__class__.__module__:
@@ -49,11 +51,14 @@ class BaseEstimator:
         self._logdir = os.path.abspath(logdir) if logdir else os.getcwd()
 
     def fit(self):
+        # finalize the config
         r = self._ex.run('_get_config', options={'--loglevel': 50})
         print_config(r)
         config_fn = _fullname(self) + datetime.now().strftime("-%m-%d-%Y-%H-%M-%S.yaml")
         config_file = os.path.join(self._logdir, config_fn)
         save_config(r.config, self._log, config_file)
+        self._cfg = r.config
+        _random.seed(self._cfg.seed)
         self._fit()
 
     def _fit(self):

--- a/gluoncv/pipelines/estimator/base_estimator.py
+++ b/gluoncv/pipelines/estimator/base_estimator.py
@@ -1,0 +1,60 @@
+"""Base Estimator"""
+import os
+import logging
+from datetime import datetime
+from sacred.commands import _format_config, save_config, print_config
+# from sacred.settings import SETTINGS
+# SETTINGS.CONFIG.READ_ONLY_CONFIG = False
+
+def _fullname(o):
+    module = o.__class__.__module__
+    if module is None or module == str.__class__.__module__:
+        return o.__class__.__name__
+    return module + '.' + o.__class__.__name__
+
+def _get_config():
+    pass
+
+def set_default(ex):
+    def _apply(cls):
+        # docstring
+        cls.__doc__ = str(cls.__doc__) if cls.__doc__ else ''
+        cls.__doc__ += ("\n\nParameters\n"
+                        "----------\n"
+                        "config : str, dict\n"
+                        "  Config used to override default configurations. \n"
+                        "  If `str`, assume config file (.yml, .yaml) is used. \n"
+                        "logger : logger, default is `None`.\n"
+                        "  If not `None`, will use default logging object.\n"
+                        "logdir : str, default is None.\n"
+                        "  Directory for saving logs. If `None`, current working directory is used.\n")
+        cls.__doc__ += '\nDefault configurations: \n----------\n'
+        ex.command(_get_config, unobserved=True)
+        r = ex.run('_get_config', options={'--loglevel': 50})
+        if 'seed' in r.config:
+            r.config.pop('seed')
+        cls.__doc__ += str("\n".join(_format_config(r.config, r.config_modifications).splitlines()[1:]))
+        # default config
+        cls._ex = ex
+        return cls
+    return _apply
+
+
+class BaseEstimator:
+    def __init__(self, config, logger=None, logdir=None):
+        self._ex.add_config(config)
+        r = self._ex.run('_get_config', options={'--loglevel': 50})
+        self._cfg = r.config
+        self._log = logger if logger is not None else logging.getLogger(__name__)
+        self._logdir = os.path.abspath(logdir) if logdir else os.getcwd()
+
+    def fit(self):
+        r = self._ex.run('_get_config', options={'--loglevel': 50})
+        print_config(r)
+        config_fn = _fullname(self) + datetime.now().strftime("-%m-%d-%Y-%H-%M-%S.yaml")
+        config_file = os.path.join(self._logdir, config_fn)
+        save_config(r.config, self._log, config_file)
+        self._fit()
+
+    def _fit(self):
+        raise NotImplementedError

--- a/gluoncv/pipelines/estimator/base_estimator.py
+++ b/gluoncv/pipelines/estimator/base_estimator.py
@@ -50,7 +50,6 @@ class BaseEstimator:
         self._log = logger if logger is not None else logging.getLogger(__name__)
         self._logdir = os.path.abspath(logdir) if logdir else os.getcwd()
 
-    def fit(self):
         # finalize the config
         r = self._ex.run('_get_config', options={'--loglevel': 50})
         print_config(r)
@@ -59,6 +58,8 @@ class BaseEstimator:
         save_config(r.config, self._log, config_file)
         self._cfg = r.config
         _random.seed(self._cfg.seed)
+
+    def fit(self):
         self._fit()
 
     def _fit(self):

--- a/gluoncv/pipelines/estimator/center_net.py
+++ b/gluoncv/pipelines/estimator/center_net.py
@@ -11,7 +11,6 @@ from ...data.batchify import Tuple, Stack, Pad
 from ...utils.metrics import COCODetectionMetric
 from ...utils.metrics.accuracy import Accuracy
 from ...utils import LRScheduler, LRSequential
-from ...utils import random as _random
 from ...model_zoo.center_net import get_center_net
 from ...loss import *
 

--- a/gluoncv/pipelines/estimator/center_net.py
+++ b/gluoncv/pipelines/estimator/center_net.py
@@ -1,0 +1,59 @@
+"""CenterNet Estimator"""
+import os
+import warnings
+import tempfile
+import mxnet as mx
+from mxnet import gluon
+from ...data import COCODetection, VOCDetection
+from ...data.transforms.presets.center_net import CenterNetDefaultTrainTransform
+from ...data.transforms.presets.center_net import CenterNetDefaultValTransform, get_post_transform
+from ...data.batchify import Tuple, Stack, Pad
+from ...utils.metrics import COCODetectionMetric
+from ...utils.metrics.accuracy import Accuracy
+from ...utils import LRScheduler, LRSequential
+from ...utils import random as _random
+from ...model_zoo.center_net import get_center_net
+from ...loss import *
+
+from ..data.coco_detection import coco_detection
+from .base_estimator import BaseEstimator, set_default
+from .common import train_hyperparams
+
+from sacred import Experiment
+
+ex = Experiment('center_net_default', ingredients=[coco_detection, train_hyperparams])
+
+@coco_detection.config
+def update_coco_detection():
+    data_shape = (512, 512)  # override coco config for center_net
+
+@coco_detection.capture
+def load_dataset(root, train_splits, valid_splits, valid_skip_empty, data_shape, cleanup):
+    train_dataset = COCODetection(root=os.path.join(root, 'coco'), splits=train_splits)
+    val_dataset = COCODetection(root=os.path.join(root, 'coco'),
+                                splits=valid_splits, skip_empty=valid_skip_empty)
+    val_metric = COCODetectionMetric(val_dataset,
+                                     tempfile.NamedTemporaryFile('w', delete=False).name,
+                                     cleanup=cleanup,
+                                     data_shape=data_shape,
+                                     post_affine=get_post_transform)
+    return train_dataset, val_dataset, val_metric
+
+@ex.config
+def model():
+    base_network = 'dla34_deconv_dcnv2'
+
+@set_default(ex)
+class CenterNetEstimator(BaseEstimator):
+    def __init__(self, config, logger=None, logdir=None):
+        super(CenterNetEstimator, self).__init__(config, logger, logdir)
+        # print(self._cfg)
+
+    def _fit(self):
+        pass
+
+@ex.automain
+def main(_config, _log):
+    # main is the commandline entry for user w/o coding
+    c = CenterNetEstimator(_config, _log)
+    c.fit()

--- a/gluoncv/pipelines/estimator/common.py
+++ b/gluoncv/pipelines/estimator/common.py
@@ -1,0 +1,15 @@
+"""Common training hyperparameters"""
+from sacred import Ingredient
+
+train_hyperparams = Ingredient('train_hyperparams')
+
+@train_hyperparams.config
+def cfg():
+    gpus = (0, 1, 2, 3)          # gpu individual ids, not necessarily consecutive
+    num_workers = 16             # cpu workers, the larger the more processes used
+    pretrained_base = True       # use pre-trained weights from ImageNet
+    transfer_from = None
+    batch_size = 32
+    epochs = 3
+    resume = ''
+    start_epoch = 0

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ requirements = [
     'portalocker',
     'Pillow',
     'scipy',
+    'sacred',
 ]
 if with_cython:
     _NP_INCLUDE_DIRS = np.get_include()


### PR DESCRIPTION
An alternative implementation related to https://github.com/dmlc/gluon-cv/pull/1323 which is better(IMO) than #1323 .

- Easier to reuse common configurations(ingredients)
- Much simpler config file and command line integration during the experimenting phase
- prettier config with comments preserved!

Example

```python
from sacred import Experiment

ex = Experiment('center_net_default', ingredients=[coco_detection, train_hyperparams])

@coco_detection.config
def update_coco_detection():
    data_shape = (512, 512)  # override coco config for center_net

@coco_detection.capture
def load_dataset(root, train_splits, valid_splits, valid_skip_empty, data_shape, cleanup):
    train_dataset = COCODetection(root=os.path.join(root, 'coco'), splits=train_splits)
    val_dataset = COCODetection(root=os.path.join(root, 'coco'),
                                splits=valid_splits, skip_empty=valid_skip_empty)
    val_metric = COCODetectionMetric(val_dataset,
                                     tempfile.NamedTemporaryFile('w', delete=False).name,
                                     cleanup=cleanup,
                                     data_shape=data_shape,
                                     post_affine=get_post_transform)
    return train_dataset, val_dataset, val_metric

@ex.config
def model():
    base_network = 'dla34_deconv_dcnv2'

@set_default(ex)
class CenterNetEstimator(BaseEstimator):
    def __init__(self, config, logger=None, logdir=None):
        super(CenterNetEstimator, self).__init__(config, logger, logdir)
        # print(self._cfg)

    def _fit(self):
        pass

@ex.automain
def main(_config, _log):
    # main is the commandline entry for user w/o coding
    c = CenterNetEstimator(_config, _log)
    c.fit()
```

### One time configuration
First of all, a util function that returns the default arguments for this particular estimator is provided so that you don't have to repetitively write the docs for each argument. Though there's no excellent solution so far to inject comments into the docstring or yaml file.

### Automatic docstring generation
A decorator for injecting the default arguments into the BaseEstimator with lots of helper functions is provided. The `__doc__` will be generated by reading the default values from the config.

For example, call help(estimator) of above example will produce:

```
class CenterNetEstimator(gluoncv.pipelines.base.BaseEstimator)
 |  CenterNetEstimator(config=None, reporter=None, logdir=None)
 |
 |  CenterNet Estimator.
 |
Parameters
----------
config : str, dict
  Config used to override default configurations.
  If `str`, assume config file (.yml, .yaml) is used.
logger : logger, default is `None`.
  If not `None`, will use default logging object.
logdir : str, default is None.
  Directory for saving logs. If `None`, current working directory is used.

Default configurations:
----------
  base_network = 'dla34_deconv_dcnv2'
  coco_detection:
    cleanup = True
    data_shape = [512, 512]          # override coco config for center_net
    root = '/Users/zhiz/.mxnet/datasets'
    train_splits = 'instances_train2017'
    valid_skip_empty = False
    valid_splits = 'instances_val2017'
  train_hyperparams:
    batch_size = 32
    epochs = 3
    gpus = [0, 1, 2, 3]              # gpu individual ids, not necessarily consecutive
    num_workers = 16                 # cpu workers, the larger the more processes used
    pretrained_base = True           # use pre-trained weights from ImageNet
    resume = ''
    start_epoch = 0
    transfer_from = None
```

### Parse configurations from yaml file or command line
The `automain` entry can be used to easily accept config file or command line overrides

```
python -m gluoncv.pipelines.estimator.center_net print_config with config.yaml
```
which produce 
```
Configuration (modified, added, typechanged, doc):
  base_network = 'dla34_deconv_dcnv2'
  config_filename = 'config1.yaml'
  seed = 927480057                   # the random seed for this experiment
  coco_detection:
  1 base_network: '123'
    cleanup = True
    data_shape = [512, 512]          # override coco config for center_net
    root = '/Users/zhiz/.mxnet/datasets'
    train_splits = 'instances_train2017'
    valid_skip_empty = False
    valid_splits = 'instances_val2017'
  train_hyperparams:
    batch_size = 32
    epochs = 3
    gpus = [0, 1, 2, 3]              # gpu individual ids, not necessarily consecutive
    num_workers = 16                 # cpu workers, the larger the more processes used
    pretrained_base = True           # use pre-trained weights from ImageNet
    resume = ''
    start_epoch = 0
    transfer_from = None
```

or custom overrides
```
python -m gluoncv.pipelines.estimator.center_net print_config with 'train_hyperparams.batch_size=128'
```

```
Configuration (modified, added, typechanged, doc):
  base_network = 'dla34_deconv_dcnv2'
  config_filename = 'config1.yaml'
  seed = 927480057                   # the random seed for this experiment
  coco_detection:
  1 base_network: '123'
    cleanup = True
    data_shape = [512, 512]          # override coco config for center_net
    root = '/Users/zhiz/.mxnet/datasets'
    train_splits = 'instances_train2017'
    valid_skip_empty = False
    valid_splits = 'instances_val2017'
  train_hyperparams:
    batch_size = 128
    epochs = 3
    gpus = [0, 1, 2, 3]              # gpu individual ids, not necessarily consecutive
    num_workers = 16                 # cpu workers, the larger the more processes used
    pretrained_base = True           # use pre-trained weights from ImageNet
    resume = ''
    start_epoch = 0
    transfer_from = None
```

### Finalize config and dump to yaml file
To ensure that we don't modify the config by accident, we can call `finalize_config`, this will also save the yaml file to `logdir` for reference.
The generated 'xxx_module.xxxEstimator-06-02-2020-23-12-03.yml' file looks like this:

```yaml
base_network: dla34_deconv_dcnv2
coco_detection:
  cleanup: true
  data_shape:
  - 1024
  - 512
  root: /Users/zhiz/.mxnet/datasets
  train_splits: instances_train2017
  valid_skip_empty: false
  valid_splits: instances_val2017
seed: 772107811
train_hyperparams:
  batch_size: 32
  epochs: 3
  gpus:
  - 0
  - 1
  - 2
  - 3
  - 4
  num_workers: 32
  pretrained_base: true
  resume: ''
  start_epoch: 0
  transfer_from: null
```


