### PR TITLE
Improve video train.py

### DIFF
--- a/gluoncv/data/video_custom/classification.py
+++ b/gluoncv/data/video_custom/classification.py
@@ -163,9 +163,9 @@ class VideoClsCustom(dataset.Dataset):
                 video_name = '{}.{}'.format(directory, self.video_ext)
             if self.use_decord:
                 if self.data_aug == 'v1':
-                    decord_vr = self.decord.VideoReader(video_name, width=self.new_width, height=self.new_height)
+                    decord_vr = self.decord.VideoReader(video_name, width=self.new_width, height=self.new_height, num_threads=1)
                 else:
-                    decord_vr = self.decord.VideoReader(video_name)
+                    decord_vr = self.decord.VideoReader(video_name, num_threads=1)
                 duration = len(decord_vr)
             else:
                 mmcv_vr = self.mmcv.VideoReader(video_name)

--- a/scripts/action-recognition/train_recognizer.py
+++ b/scripts/action-recognition/train_recognizer.py
@@ -158,6 +158,10 @@ def parse_args():
                         help='different types of data augmentation pipelines. Supports v1, v2, v3 and v4.')
     parser.add_argument('--train-only', action='store_true',
                         help='if set to True, no evaluation is performed during training. Only save the last epoch model to speed up training.')
+    parser.add_argument('--more-fix-crop', action='store_false',
+                        help='if set to True, enable fixed corner cropping with more corners.')
+    parser.add_argument('--max-distort', type=int, default=1,
+                        help='maximum image aspect ratio distortion allowed during data augmentation. default is 1')
     opt = parser.parse_args()
     return opt
 
@@ -177,6 +181,7 @@ def get_data_loader(opt, batch_size, num_workers, logger, kvstore=None):
     if opt.data_aug == 'v1':
         # GluonCV style, not keeping aspect ratio, multi-scale crop
         transform_train = video.VideoGroupTrainTransform(size=(input_size, input_size), scale_ratios=scale_ratios,
+                                                         more_fix_crop=opt.more_fix_crop, max_distort=opt.max_distort,
                                                          mean=default_mean, std=default_std)
         transform_test = video.VideoGroupValTransform(size=input_size,
                                                       mean=default_mean, std=default_std)

--- a/scripts/action-recognition/train_recognizer.py
+++ b/scripts/action-recognition/train_recognizer.py
@@ -156,6 +156,8 @@ def parse_args():
                         help='number of crops for each image. default is 1')
     parser.add_argument('--data-aug', type=str, default='v1',
                         help='different types of data augmentation pipelines. Supports v1, v2, v3 and v4.')
+    parser.add_argument('--train-only', action='store_true',
+                        help='if set to True, no evaluation is performed during training. Only save the last epoch model to speed up training.')
     opt = parser.parse_args()
     return opt
 
@@ -505,32 +507,33 @@ def main():
             throughput = int(batch_size * i /(time.time() - tic))
             mx.ndarray.waitall()
 
-            if opt.kvstore is not None and epoch == opt.resume_epoch:
-                kv.init(111111, nd.zeros(1))
-                kv.init(555555, nd.zeros(1))
-                kv.init(999999, nd.zeros(1))
-
-            if opt.kvstore is not None:
-                acc_top1_val, acc_top5_val, loss_val = test(ctx, val_data, kv)
-            else:
-                acc_top1_val, acc_top5_val, loss_val = test(ctx, val_data)
-
             logger.info('[Epoch %03d] training: %s=%f\t loss=%f' % (epoch, train_metric_name, train_metric_score*100, train_loss_epoch/num_train_iter))
             logger.info('[Epoch %03d] speed: %d samples/sec\ttime cost: %f' % (epoch, throughput, time.time()-tic))
-            logger.info('[Epoch %03d] validation: acc-top1=%f acc-top5=%f loss=%f' % (epoch, acc_top1_val*100, acc_top5_val*100, loss_val))
-
             sw.add_scalar(tag='train_loss_epoch', value=train_loss_epoch/num_train_iter, global_step=epoch)
-            sw.add_scalar(tag='val_loss_epoch', value=loss_val, global_step=epoch)
-            sw.add_scalar(tag='val_acc_top1_epoch', value=acc_top1_val*100, global_step=epoch)
 
-            if acc_top1_val > best_val_score:
-                best_val_score = acc_top1_val
-                net.save_parameters('%s/%.4f-%s-%s-%03d-best.params'%(opt.save_dir, best_val_score, opt.dataset, model_name, epoch))
-                trainer.save_states('%s/%.4f-%s-%s-%03d-best.states'%(opt.save_dir, best_val_score, opt.dataset, model_name, epoch))
-            else:
-                if opt.save_frequency and opt.save_dir and (epoch + 1) % opt.save_frequency == 0:
-                    net.save_parameters('%s/%s-%s-%03d.params'%(opt.save_dir, opt.dataset, model_name, epoch))
-                    trainer.save_states('%s/%s-%s-%03d.states'%(opt.save_dir, opt.dataset, model_name, epoch))
+            if not opt.train_only:
+                if opt.kvstore is not None and epoch == opt.resume_epoch:
+                    kv.init(111111, nd.zeros(1))
+                    kv.init(555555, nd.zeros(1))
+                    kv.init(999999, nd.zeros(1))
+
+                if opt.kvstore is not None:
+                    acc_top1_val, acc_top5_val, loss_val = test(ctx, val_data, kv)
+                else:
+                    acc_top1_val, acc_top5_val, loss_val = test(ctx, val_data)
+
+                logger.info('[Epoch %03d] validation: acc-top1=%f acc-top5=%f loss=%f' % (epoch, acc_top1_val*100, acc_top5_val*100, loss_val))
+                sw.add_scalar(tag='val_loss_epoch', value=loss_val, global_step=epoch)
+                sw.add_scalar(tag='val_acc_top1_epoch', value=acc_top1_val*100, global_step=epoch)
+
+                if acc_top1_val > best_val_score:
+                    best_val_score = acc_top1_val
+                    net.save_parameters('%s/%.4f-%s-%s-%03d-best.params'%(opt.save_dir, best_val_score, opt.dataset, model_name, epoch))
+                    trainer.save_states('%s/%.4f-%s-%s-%03d-best.states'%(opt.save_dir, best_val_score, opt.dataset, model_name, epoch))
+                else:
+                    if opt.save_frequency and opt.save_dir and (epoch + 1) % opt.save_frequency == 0:
+                        net.save_parameters('%s/%s-%s-%03d.params'%(opt.save_dir, opt.dataset, model_name, epoch))
+                        trainer.save_states('%s/%s-%s-%03d.states'%(opt.save_dir, opt.dataset, model_name, epoch))
 
         # save the last model
         net.save_parameters('%s/%s-%s-%03d.params'%(opt.save_dir, opt.dataset, model_name, opt.num_epochs-1))


### PR DESCRIPTION
This PR adds two things for video action recognition training,

1. Add `num_thread=1` to Decord video reading, this can speed up training by 5%. This requires the most recent version of Decord.

2. Add `train_only` option, only save the last trained model to save some time on evaluating every epoch. 