### PR TITLE
reduce memory by disable multiprocessing

### DIFF
--- a/docs/tutorials/action_recognition/dive_deep_i3d_kinetics400.py
+++ b/docs/tutorials/action_recognition/dive_deep_i3d_kinetics400.py
@@ -93,7 +93,7 @@ transform_train = transforms.Compose([
 # Batch Size for Each GPU
 per_device_batch_size = 5
 # Number of data loader workers
-num_workers = 8
+num_workers = 0
 # Calculate effective total batch size
 batch_size = per_device_batch_size * num_gpus
 

--- a/docs/tutorials/action_recognition/dive_deep_slowfast_kinetics400.py
+++ b/docs/tutorials/action_recognition/dive_deep_slowfast_kinetics400.py
@@ -93,7 +93,7 @@ transform_train = transforms.Compose([
 # Batch Size for Each GPU
 per_device_batch_size = 5
 # Number of data loader workers
-num_workers = 2
+num_workers = 0
 # Calculate effective total batch size
 batch_size = per_device_batch_size * num_gpus
 

--- a/docs/tutorials/action_recognition/dive_deep_tsn_ucf101.py
+++ b/docs/tutorials/action_recognition/dive_deep_tsn_ucf101.py
@@ -105,7 +105,7 @@ transform_train = transforms.Compose([
 # Batch Size for Each GPU
 per_device_batch_size = 5
 # Number of data loader workers
-num_workers = 8
+num_workers = 0
 # Calculate effective total batch size
 batch_size = per_device_batch_size * num_gpus
 

--- a/docs/tutorials/action_recognition/finetune_custom.py
+++ b/docs/tutorials/action_recognition/finetune_custom.py
@@ -103,7 +103,7 @@ num_gpus = 1
 ctx = [mx.gpu(i) for i in range(num_gpus)]
 transform_train = video.VideoGroupTrainTransform(size=(224, 224), scale_ratios=[1.0, 0.8], mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])
 per_device_batch_size = 5
-num_workers = 8
+num_workers = 0
 batch_size = per_device_batch_size * num_gpus
 
 train_dataset = VideoClsCustom(root=os.path.expanduser('~/.mxnet/datasets/ucf101/rawframes'),


### PR DESCRIPTION
Fix flacky doc build issue: out of memory. 

@bryanyzhu FYI, it's the workaround for sticking with the existing g4 instances. We may need to upgrade the CI instance types in the future.