### PR TITLE
Sharding of data for Horovod distributed training for SSD and YOLOv3

### DIFF
--- a/gluoncv/data/pascal_voc/detection.py
+++ b/gluoncv/data/pascal_voc/detection.py
@@ -54,6 +54,7 @@ class VOCDetection(VisionDataset):
                  transform=None, index_map=None, preload_label=True):
         super(VOCDetection, self).__init__(root)
         self._im_shapes = {}
+        self._im_aspect_ratios = None
         self._root = os.path.expanduser(root)
         self._transform = transform
         self._splits = splits
@@ -150,6 +151,16 @@ class VOCDetection(VisionDataset):
         """Preload all labels into memory."""
         logging.debug("Preloading %s labels into memory...", str(self))
         return [self._load_label(idx) for idx in range(len(self))]
+
+    def get_im_aspect_ratio(self):
+        """Return the aspect ratio of each image in the order of the raw data."""
+        if self._im_aspect_ratios is not None:
+            return self._im_aspect_ratios
+        self._im_aspect_ratios = [None] * len(self._im_shapes)
+        for i, im_shape in self._im_shapes.items():
+            self._im_aspect_ratios[i] = 1.0 * im_shape[0] / im_shape[1]
+
+        return self._im_aspect_ratios
 
 
 class CustomVOCDetection(VOCDetection):

--- a/scripts/detection/ssd/train_ssd.py
+++ b/scripts/detection/ssd/train_ssd.py
@@ -126,9 +126,15 @@ def get_dataloader(net, train_dataset, val_dataset, data_shape, batch_size, num_
         _, _, anchors = net(mx.nd.zeros((1, 3, height, width), ctx))
     anchors = anchors.as_in_context(mx.cpu())
     batchify_fn = Tuple(Stack(), Stack(), Stack())  # stack image, cls_targets, box_targets
+    train_sampler = \
+        gcv.nn.sampler.SplitSortedBucketSampler(train_dataset.get_im_aspect_ratio(),
+                                                batch_size,
+                                                num_parts=hvd.size() if args.horovod else 1,
+                                                part_index=hvd.rank() if args.horovod else 0,
+                                                shuffle=True)
     train_loader = gluon.data.DataLoader(
         train_dataset.transform(SSDDefaultTrainTransform(width, height, anchors)),
-        batch_size, True, batchify_fn=batchify_fn, last_batch='rollover', num_workers=num_workers)
+        batch_sampler=train_sampler, batchify_fn=batchify_fn, num_workers=num_workers)
     val_batchify_fn = Tuple(Stack(), Pad(pad_val=-1))
     val_loader = gluon.data.DataLoader(
         val_dataset.transform(SSDDefaultValTransform(width, height)),
@@ -347,7 +353,7 @@ def train(net, train_data, val_data, eval_metric, ctx, args):
             name2, loss2 = smoothl1_metric.get()
             logger.info('[Epoch {}] Training cost: {:.3f}, {}={:.3f}, {}={:.3f}'.format(
                 epoch, (time.time()-tic), name1, loss1, name2, loss2))
-            if (epoch % args.val_interval == 0) or (args.save_interval and epoch % args.save_interval == 0):
+            if ((epoch + 1) % args.val_interval == 0) or (args.save_interval and epoch % args.save_interval == 0):
                 # consider reduce the frequency of validation to save time
                 map_name, mean_ap = validate(net, val_data, ctx, eval_metric)
                 val_msg = '\n'.join(['{}={}'.format(k, v) for k, v in zip(map_name, mean_ap)])

--- a/scripts/detection/ssd/train_ssd.py
+++ b/scripts/detection/ssd/train_ssd.py
@@ -345,15 +345,17 @@ def train(net, train_data, val_data, eval_metric, ctx, args):
                     name1, loss1 = ce_metric.get()
                     name2, loss2 = smoothl1_metric.get()
                     logger.info('[Epoch {}][Batch {}], Speed: {:.3f} samples/sec, {}={:.3f}, {}={:.3f}'.format(
-                        epoch, i, args.batch_size/(time.time()-btic), name1, loss1, name2, loss2))
-                btic = time.time()
+                        epoch, i, args.log_interval * args.batch_size / (time.time() - btic),
+                        name1, loss1, name2, loss2))
+                    btic = time.time()
 
         if (not args.horovod or hvd.rank() == 0):
             name1, loss1 = ce_metric.get()
             name2, loss2 = smoothl1_metric.get()
             logger.info('[Epoch {}] Training cost: {:.3f}, {}={:.3f}, {}={:.3f}'.format(
                 epoch, (time.time()-tic), name1, loss1, name2, loss2))
-            if ((epoch + 1) % args.val_interval == 0) or (args.save_interval and epoch % args.save_interval == 0):
+            if ((epoch + 1) % args.val_interval == 0) or \
+                    (args.save_interval and (epoch + 1) % args.save_interval == 0):
                 # consider reduce the frequency of validation to save time
                 map_name, mean_ap = validate(net, val_data, ctx, eval_metric)
                 val_msg = '\n'.join(['{}={}'.format(k, v) for k, v in zip(map_name, mean_ap)])

--- a/scripts/detection/yolo/train_yolo3.py
+++ b/scripts/detection/yolo/train_yolo3.py
@@ -313,8 +313,10 @@ def train(net, train_data, val_data, eval_metric, ctx, args):
                     name3, loss3 = scale_metrics.get()
                     name4, loss4 = cls_metrics.get()
                     logger.info('[Epoch {}][Batch {}], LR: {:.2E}, Speed: {:.3f} samples/sec, {}={:.3f}, {}={:.3f}, {}={:.3f}, {}={:.3f}'.format(
-                        epoch, i, trainer.learning_rate, args.batch_size/(time.time()-btic), name1, loss1, name2, loss2, name3, loss3, name4, loss4))
-                btic = time.time()
+                        epoch, i, trainer.learning_rate,
+                        args.log_interval * args.batch_size / (time.time() - btic),
+                        name1, loss1, name2, loss2, name3, loss3, name4, loss4))
+                    btic = time.time()
 
         if (not args.horovod or hvd.rank() == 0):
             name1, loss1 = obj_metrics.get()


### PR DESCRIPTION
- Data was not sharded across GPUs when running Horovod distributed Training. This PR will fix that issue.
- Fixed the issue with the `validation` condition where it was doing validation at epoch 0 irrespective of `--val-interval`.
- Fixed the calculation of throughput based on `--log-interval`. 
- Tested the functionality with and without horovod for first few batches.