### PR TITLE
fix conflict between kitti utils and mxnet version

### DIFF
--- a/gluoncv/data/kitti/kitti_utils.py
+++ b/gluoncv/data/kitti/kitti_utils.py
@@ -9,7 +9,6 @@ from collections import Counter
 import numpy as np
 
 import mxnet as mx
-from mxnet.util import is_np_array
 
 
 def load_velodyne_points(filename):
@@ -110,6 +109,8 @@ def generate_depth_map(calib_dir, velo_filename, cam=2, vel_depth=False):
 def dict_batchify_fn(data):
     """dict batchify function"""
     import mxnet.numpy as _mx_np
+    from mxnet.util import is_np_array
+
     if isinstance(data[0], mx.nd.NDArray):
         return _mx_np.stack(data) if is_np_array() else mx.nd.stack(*data)
     elif isinstance(data[0], dict):

--- a/gluoncv/model_zoo/rcnn/faster_rcnn/data_parallel.py
+++ b/gluoncv/model_zoo/rcnn/faster_rcnn/data_parallel.py
@@ -1,7 +1,6 @@
 """Data parallel task for Faster RCNN Model."""
 
 from mxnet import autograd
-from mxnet.contrib import amp
 
 from gluoncv.utils.parallel import Parallelizable
 
@@ -77,6 +76,7 @@ class ForwardBackwardTask(Parallelizable):
             rcnn_l1_loss_metric = [[box_targets, box_masks], [box_pred]]
 
             if self.amp_enabled:
+                from mxnet.contrib import amp
                 with amp.scale_loss(total_loss, self._optimizer) as scaled_losses:
                     autograd.backward(scaled_losses)
             else:

--- a/gluoncv/model_zoo/rcnn/mask_rcnn/data_parallel.py
+++ b/gluoncv/model_zoo/rcnn/mask_rcnn/data_parallel.py
@@ -2,7 +2,6 @@
 
 import mxnet as mx
 from mxnet import autograd
-from mxnet.contrib import amp
 
 from gluoncv.utils.parallel import Parallelizable
 
@@ -97,6 +96,7 @@ class ForwardBackwardTask(Parallelizable):
             rcnn_fgmask_metric = [[mask_targets, mask_masks], [mask_pred]]
 
             if self.amp_enabled:
+                from mxnet.contrib import amp
                 with amp.scale_loss(total_loss, self._optimizer) as scaled_losses:
                     autograd.backward(scaled_losses)
             else:


### PR DESCRIPTION
This PR is to fix issue #1423 . Basically, `is_np_array` is a new feature in mxnet 1.6 and later versions. If users install mxnet 1.5 or before, gluoncv will show import error. Move this import into the function will avoid this issue. 

Also, move `amp` in `rcnn` inside the function. Mixed precision training is merged in mxnet 1.5. Previous mxnet version does not support amp.