### PR TITLE
remove dependencies on AutoGluon non-core functions

### DIFF
--- a/gluoncv/auto/estimators/__init__.py
+++ b/gluoncv/auto/estimators/__init__.py
@@ -1,6 +1,6 @@
 """Estimator implementations"""
-# from .ssd import SSDEstimator
-# from .yolo import YOLOEstimator
-# from .faster_rcnn import FasterRCNNEstimator
-# from .mask_rcnn import MaskRCNNEstimator
-# from .center_net import CenterNetEstimator
+from .ssd import SSDEstimator
+from .yolo import YOLOEstimator
+from .faster_rcnn import FasterRCNNEstimator
+from .mask_rcnn import MaskRCNNEstimator
+from .center_net import CenterNetEstimator

--- a/gluoncv/auto/estimators/faster_rcnn/utils.py
+++ b/gluoncv/auto/estimators/faster_rcnn/utils.py
@@ -9,8 +9,6 @@ from ....data.transforms.presets.rcnn import FasterRCNNDefaultValTransform
 from ....utils.metrics.coco_detection import COCODetectionMetric
 from ....utils.metrics.voc_detection import VOC07MApMetric
 
-from autogluon.task.object_detection.dataset.voc import CustomVOCDetectionBase
-
 try:
     import horovod.mxnet as hvd
 except ImportError:
@@ -107,10 +105,10 @@ def _get_dataset(dataset, args):
         # filename_zip = ag.download('https://autogluon.s3.amazonaws.com/datasets/tiny_motorbike.zip', path=root)
         # filename = ag.unzip(filename_zip, root=root)
         # data_root = os.path.join(root, filename)
-        train_dataset = CustomVOCDetectionBase(classes=('motorbike',), root=args.dataset_root + 'tiny_motorbike',
-                                               splits=[('', 'trainval')])
-        val_dataset = CustomVOCDetectionBase(classes=('motorbike',), root=args.dataset_root + 'tiny_motorbike',
-                                             splits=[('', 'test')])
+        train_dataset = gdata.CustomVOCDetectionBase(classes=('motorbike',), root=args.dataset_root + 'tiny_motorbike',
+                                                     splits=[('', 'trainval')])
+        val_dataset = gdata.CustomVOCDetectionBase(classes=('motorbike',), root=args.dataset_root + 'tiny_motorbike',
+                                                   splits=[('', 'test')])
         val_metric = VOC07MApMetric(iou_thresh=0.5, class_names=val_dataset.classes)
     elif dataset.lower() in ['clipart', 'comic', 'watercolor']:
         root = os.path.join('~', '.mxnet', 'datasets', dataset.lower())

--- a/gluoncv/auto/estimators/ssd/utils.py
+++ b/gluoncv/auto/estimators/ssd/utils.py
@@ -11,9 +11,6 @@ from ....data.transforms.presets.ssd import SSDDefaultValTransform
 from ....data.transforms.presets.ssd import SSDDALIPipeline
 from ....utils.metrics.voc_detection import VOC07MApMetric
 from ....utils.metrics.coco_detection import COCODetectionMetric
-from ....utils.metrics.accuracy import Accuracy
-
-from autogluon.task.object_detection.dataset.voc import CustomVOCDetectionBase
 
 try:
     import horovod.mxnet as hvd
@@ -40,10 +37,10 @@ def _get_dataset(dataset, args):
         # filename_zip = ag.download('https://autogluon.s3.amazonaws.com/datasets/tiny_motorbike.zip', path=root)
         # filename = ag.unzip(filename_zip, root=root)
         # data_root = os.path.join(root, filename)
-        train_dataset = CustomVOCDetectionBase(classes=('motorbike',), root=args.dataset_root + 'tiny_motorbike',
-                                               splits=[('', 'trainval')])
-        val_dataset = CustomVOCDetectionBase(classes=('motorbike',), root=args.dataset_root + 'tiny_motorbike',
-                                             splits=[('', 'test')])
+        train_dataset = gdata.CustomVOCDetectionBase(classes=('motorbike',), root=args.dataset_root + 'tiny_motorbike',
+                                                     splits=[('', 'trainval')])
+        val_dataset = gdata.CustomVOCDetectionBase(classes=('motorbike',), root=args.dataset_root + 'tiny_motorbike',
+                                                   splits=[('', 'test')])
         val_metric = VOC07MApMetric(iou_thresh=0.5, class_names=val_dataset.classes)
     elif dataset.lower() == 'coco':
         train_dataset = gdata.COCODetection(splits=['instances_train2017'])

--- a/gluoncv/auto/estimators/yolo/utils.py
+++ b/gluoncv/auto/estimators/yolo/utils.py
@@ -11,8 +11,6 @@ from ....data.transforms.presets.yolo import YOLO3DefaultValTransform
 from ....utils.metrics.voc_detection import VOC07MApMetric
 from ....utils.metrics.coco_detection import COCODetectionMetric
 
-from autogluon.task.object_detection.dataset.voc import CustomVOCDetectionBase
-
 
 def _get_dataset(dataset, args):
     if dataset.lower() == 'voc':
@@ -27,10 +25,10 @@ def _get_dataset(dataset, args):
         # filename_zip = ag.download('https://autogluon.s3.amazonaws.com/datasets/tiny_motorbike.zip', path=root)
         # filename = ag.unzip(filename_zip, root=root)
         # data_root = os.path.join(root, filename)
-        train_dataset = CustomVOCDetectionBase(classes=('motorbike',), root=args.dataset_root + 'tiny_motorbike',
-                                               splits=[('', 'trainval')])
-        val_dataset = CustomVOCDetectionBase(classes=('motorbike',), root=args.dataset_root + 'tiny_motorbike',
-                                             splits=[('', 'test')])
+        train_dataset = gdata.CustomVOCDetectionBase(classes=('motorbike',), root=args.dataset_root + 'tiny_motorbike',
+                                                     splits=[('', 'trainval')])
+        val_dataset = gdata.CustomVOCDetectionBase(classes=('motorbike',), root=args.dataset_root + 'tiny_motorbike',
+                                                   splits=[('', 'test')])
         val_metric = VOC07MApMetric(iou_thresh=0.5, class_names=val_dataset.classes)
     elif dataset.lower() == 'coco':
         train_dataset = gdata.COCODetection(splits='instances_train2017', use_crowd=False)

--- a/gluoncv/auto/tasks/object_detection.py
+++ b/gluoncv/auto/tasks/object_detection.py
@@ -8,11 +8,7 @@ from autogluon.utils import collect_params
 
 from ... import utils as gutils
 from ..estimators.base_estimator import ConfigDict, BaseEstimator
-from ..estimators.ssd import SSDEstimator
-from ..estimators.faster_rcnn import FasterRCNNEstimator
-from ..estimators.yolo import YOLOEstimator
-from ..estimators.center_net import CenterNetEstimator
-# from gluoncv.auto.estimators import SSDEstimator, FasterRCNNEstimator, YOLOEstimator, CenterNetEstimator
+from ..estimators import SSDEstimator, FasterRCNNEstimator, YOLOEstimator, CenterNetEstimator
 from .utils import auto_suggest, auto_args, config_to_nested
 
 

--- a/gluoncv/auto/tasks/utils.py
+++ b/gluoncv/auto/tasks/utils.py
@@ -2,15 +2,10 @@ import copy
 import numpy as np
 
 import autogluon as ag
-from autogluon.task.object_detection.dataset.voc import CustomVOCDetectionBase
 
 from ... import data as gdata
 from ..estimators.base_estimator import BaseEstimator
-from ..estimators.ssd import SSDEstimator
-from ..estimators.faster_rcnn import FasterRCNNEstimator
-from ..estimators.yolo import YOLOEstimator
-from ..estimators.center_net import CenterNetEstimator
-# from gluoncv.auto.estimators import SSDEstimator, FasterRCNNEstimator, YOLOEstimator, CenterNetEstimator
+from ..estimators import SSDEstimator, FasterRCNNEstimator, YOLOEstimator, CenterNetEstimator
 
 
 def auto_suggest(config, estimator):
@@ -23,9 +18,9 @@ def auto_suggest(config, estimator):
     if dataset_name == 'voc':
         train_dataset = gdata.VOCDetection(splits=[(2007, 'trainval'), (2012, 'trainval')])
     elif dataset_name == 'voc_tiny':
-        train_dataset = CustomVOCDetectionBase(classes=('motorbike',),
-                                               root=dataset_root + 'tiny_motorbike',
-                                               splits=[('', 'trainval')])
+        train_dataset = gdata.CustomVOCDetectionBase(classes=('motorbike',),
+                                                     root=dataset_root + 'tiny_motorbike',
+                                                     splits=[('', 'trainval')])
     elif dataset_name == 'coco':
         train_dataset = gdata.COCODetection(splits=['instances_train2017'])
     else:

--- a/gluoncv/data/__init__.py
+++ b/gluoncv/data/__init__.py
@@ -5,7 +5,7 @@ from . import transforms
 from . import batchify
 from .imagenet.classification import ImageNet, ImageNet1kAttr
 from .dataloader import DetectionDataLoader, RandomTransformDataLoader
-from .pascal_voc.detection import VOCDetection, CustomVOCDetection
+from .pascal_voc.detection import VOCDetection, CustomVOCDetection, CustomVOCDetectionBase
 from .mscoco.detection import COCODetection
 from .mscoco.detection import COCODetectionDALI
 from .mscoco.instance import COCOInstance

--- a/gluoncv/data/pascal_voc/detection.py
+++ b/gluoncv/data/pascal_voc/detection.py
@@ -177,3 +177,97 @@ class CustomVOCDetection(VOCDetection):
                             classes.add(item.text)
         classes = sorted(list(classes))
         return classes
+
+
+class CustomVOCDetectionBase(VOCDetection):
+    """Base class for custom Dataset which follows protocol/formatting of the well-known VOC object detection dataset.
+
+    Parameters
+    ----------
+    class: tuple of classes, default = None
+        We reuse the neural network weights if the corresponding class appears in the pretrained model.
+        Otherwise, we randomly initialize the neural network weights for new classes.
+    root : str, default '~/mxnet/datasets/voc'
+        Path to folder storing the dataset.
+    splits : list of tuples, default ((2007, 'trainval'), (2012, 'trainval'))
+        List of combinations of (year, name)
+        For years, candidates can be: 2007, 2012.
+        For names, candidates can be: 'train', 'val', 'trainval', 'test'.
+    transform : callable, default = None
+        A function that takes data and label and transforms them. Refer to
+        :doc:`./transforms` for examples.
+        A transform function for object detection should take label into consideration,
+        because any geometric modification will require label to be modified.
+    index_map : dict, default = None
+        By default, the 20 classes are mapped into indices from 0 to 19. We can
+        customize it by providing a str to int dict specifying how to map class
+        names to indices. This is only for advanced users, when you want to swap the orders
+        of class labels.
+    preload_label : bool, default = True
+        If True, then parse and load all labels into memory during
+        initialization. It often accelerate speed but require more memory
+        usage. Typical preloaded labels took tens of MB. You only need to disable it
+        when your dataset is extremely large.
+    """
+
+    def __init__(self, classes=None, root=os.path.join('~', '.mxnet', 'datasets', 'voc'),
+                 splits=((2007, 'trainval'), (2012, 'trainval')),
+                 transform=None, index_map=None, preload_label=True):
+
+        # update classes
+        if classes:
+            self._set_class(classes)
+        super(CustomVOCDetectionBase, self).__init__(root=root,
+                                                     splits=splits,
+                                                     transform=transform,
+                                                     index_map=index_map,
+                                                     preload_label=False),
+        self._items_new = [self._items[each_id] for each_id in range(len(self._items)) if self._check_valid(each_id)]
+        self._items = self._items_new
+        self._label_cache = self._preload_labels() if preload_label else None
+
+    @classmethod
+    def _set_class(cls, classes):
+        cls.CLASSES = classes
+
+    def _load_items(self, splits):
+        """Load individual image indices from splits."""
+        ids = []
+        for subfolder, name in splits:
+            root = os.path.join(self._root, subfolder) if subfolder else self._root
+            lf = os.path.join(root, 'ImageSets', 'Main', name + '.txt')
+            with open(lf, 'r') as f:
+                ids += [(root, line.strip()) for line in f.readlines()]
+        return ids
+
+    def _check_valid(self, idx):
+        """Parse xml file and return labels."""
+        img_id = self._items[idx]
+        anno_path = self._anno_path.format(*img_id)
+        root = ET.parse(anno_path).getroot()
+        size = root.find('size')
+        width = float(size.find('width').text)
+        height = float(size.find('height').text)
+        if idx not in self._im_shapes:
+            # store the shapes for later usage
+            self._im_shapes[idx] = (width, height)
+        label = []
+        for obj in root.iter('object'):
+            try:
+                difficult = int(obj.find('difficult').text)
+            except ValueError:
+                difficult = 0
+            cls_name = obj.find('name').text.strip().lower()
+            if cls_name not in self.classes:
+                continue
+            cls_id = self.index_map[cls_name]
+            xml_box = obj.find('bndbox')
+            xmin = (float(xml_box.find('xmin').text) - 1)
+            ymin = (float(xml_box.find('ymin').text) - 1)
+            xmax = (float(xml_box.find('xmax').text) - 1)
+            ymax = (float(xml_box.find('ymax').text) - 1)
+
+            if not ((0 <= xmin < width) and (0 <= ymin < height) and (xmin < xmax <= width) and (ymin < ymax <= height)):
+                return False
+
+        return True

--- a/scripts/detection/auto_detection/test_auto_detection.py
+++ b/scripts/detection/auto_detection/test_auto_detection.py
@@ -1,10 +1,6 @@
 import autogluon as ag
 
-from gluoncv.auto.estimators.ssd import SSDEstimator
-from gluoncv.auto.estimators.faster_rcnn import FasterRCNNEstimator
-from gluoncv.auto.estimators.yolo import YOLOEstimator
-from gluoncv.auto.estimators.center_net import CenterNetEstimator
-# from gluoncv.auto.estimators import SSDEstimator, FasterRCNNEstimator, YOLOEstimator, CenterNetEstimator
+from gluoncv.auto.estimators import SSDEstimator, FasterRCNNEstimator, YOLOEstimator, CenterNetEstimator
 from gluoncv.auto.tasks.object_detection import ObjectDetection
 
 

--- a/scripts/detection/auto_detection/train_auto_detection.py
+++ b/scripts/detection/auto_detection/train_auto_detection.py
@@ -4,11 +4,7 @@ import logging
 import autogluon as ag
 from mxnet import gluon
 
-from gluoncv.auto.estimators.ssd import SSDEstimator
-from gluoncv.auto.estimators.faster_rcnn import FasterRCNNEstimator
-from gluoncv.auto.estimators.yolo import YOLOEstimator
-from gluoncv.auto.estimators.center_net import CenterNetEstimator
-# from gluoncv.auto.estimators import SSDEstimator, FasterRCNNEstimator, YOLOEstimator, CenterNetEstimator
+from gluoncv.auto.estimators import SSDEstimator, FasterRCNNEstimator, YOLOEstimator, CenterNetEstimator
 from gluoncv.auto.tasks.object_detection import ObjectDetection
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Dependencies to AutoGluon non-core functions have been removed, CustomVOCDetectionBase is now implemented in GluonCV, and imported from gluoncv.data.pascal_voc.detection.