### PR TITLE
warmup scheduler for action video torch

### DIFF
--- a/gluoncv/torch/engine/config.py
+++ b/gluoncv/torch/engine/config.py
@@ -53,6 +53,8 @@ _C.CONFIG.TRAIN.LR_POLICY: 'Cosine'
 _C.CONFIG.TRAIN.LR_MILESTONE = [40, 80]
 # Exponential decay factor.
 _C.CONFIG.TRAIN.STEP = 0.1
+# Use warm up scheduler or not.
+_C.CONFIG.TRAIN.USE_WARMUP: False
 # Gradually warm up the SOLVER.BASE_LR over this number of epochs.
 _C.CONFIG.TRAIN.WARMUP_EPOCHS: 34
 # The start learning rate of the warm up.

--- a/gluoncv/torch/utils/lr_policy.py
+++ b/gluoncv/torch/utils/lr_policy.py
@@ -59,7 +59,7 @@ class GradualWarmupScheduler(_LRScheduler):
                 self.after_scheduler.step(metrics, epoch - self.total_epoch)
 
     def step(self, epoch=None, metrics=None):
-        if isinstance(self.after_scheduler) != ReduceLROnPlateau:
+        if not isinstance(self.after_scheduler, ReduceLROnPlateau):
             if self.finished and self.after_scheduler:
                 if epoch is None:
                     self.after_scheduler.step(None)

--- a/scripts/action-recognition/configuration/i3d_slow_resnet101_f16s4_kinetics400.yaml
+++ b/scripts/action-recognition/configuration/i3d_slow_resnet101_f16s4_kinetics400.yaml
@@ -19,6 +19,7 @@ CONFIG:
     LR: 0.01
     MOMENTUM: 0.9
     W_DECAY: 1e-4
+    USE_WARMUP: True
     WARMUP_EPOCHS: 34
     LR_POLICY: 'Cosine'
     WARMUP_END_LR: 0.1

--- a/scripts/action-recognition/configuration/i3d_slow_resnet101_f32s2_kinetics400.yaml
+++ b/scripts/action-recognition/configuration/i3d_slow_resnet101_f32s2_kinetics400.yaml
@@ -19,6 +19,7 @@ CONFIG:
     LR: 0.01
     MOMENTUM: 0.9
     W_DECAY: 1e-4
+    USE_WARMUP: True
     WARMUP_EPOCHS: 34
     LR_POLICY: 'Cosine'
     WARMUP_END_LR: 0.1

--- a/scripts/action-recognition/configuration/i3d_slow_resnet101_f8s8_kinetics400.yaml
+++ b/scripts/action-recognition/configuration/i3d_slow_resnet101_f8s8_kinetics400.yaml
@@ -19,6 +19,7 @@ CONFIG:
     LR: 0.01
     MOMENTUM: 0.9
     W_DECAY: 1e-4
+    USE_WARMUP: True
     WARMUP_EPOCHS: 34
     LR_POLICY: 'Cosine'
     WARMUP_END_LR: 0.1

--- a/scripts/action-recognition/configuration/i3d_slow_resnet50_f16s4_kinetics400.yaml
+++ b/scripts/action-recognition/configuration/i3d_slow_resnet50_f16s4_kinetics400.yaml
@@ -19,6 +19,7 @@ CONFIG:
     LR: 0.01
     MOMENTUM: 0.9
     W_DECAY: 1e-4
+    USE_WARMUP: True
     WARMUP_EPOCHS: 34
     LR_POLICY: 'Cosine'
     WARMUP_END_LR: 0.1

--- a/scripts/action-recognition/configuration/i3d_slow_resnet50_f32s2_kinetics400.yaml
+++ b/scripts/action-recognition/configuration/i3d_slow_resnet50_f32s2_kinetics400.yaml
@@ -19,6 +19,7 @@ CONFIG:
     LR: 0.01
     MOMENTUM: 0.9
     W_DECAY: 1e-4
+    USE_WARMUP: True
     WARMUP_EPOCHS: 34
     LR_POLICY: 'Cosine'
     WARMUP_END_LR: 0.1

--- a/scripts/action-recognition/configuration/i3d_slow_resnet50_f8s8_kinetics400.yaml
+++ b/scripts/action-recognition/configuration/i3d_slow_resnet50_f8s8_kinetics400.yaml
@@ -19,6 +19,7 @@ CONFIG:
     LR: 0.01
     MOMENTUM: 0.9
     W_DECAY: 1e-4
+    USE_WARMUP: True
     WARMUP_EPOCHS: 34
     LR_POLICY: 'Cosine'
     WARMUP_END_LR: 0.1

--- a/scripts/action-recognition/configuration/r2plus1d_v1_resnet18_kinetics400.yaml
+++ b/scripts/action-recognition/configuration/r2plus1d_v1_resnet18_kinetics400.yaml
@@ -19,6 +19,7 @@ CONFIG:
     LR: 0.001
     MOMENTUM: 0.9
     W_DECAY: 1e-4
+    USE_WARMUP: True
     WARMUP_EPOCHS: 34
     LR_POLICY: 'Cosine'
     WARMUP_END_LR: 0.1

--- a/scripts/action-recognition/configuration/r2plus1d_v1_resnet34_kinetics400.yaml
+++ b/scripts/action-recognition/configuration/r2plus1d_v1_resnet34_kinetics400.yaml
@@ -19,6 +19,7 @@ CONFIG:
     LR: 0.001
     MOMENTUM: 0.9
     W_DECAY: 1e-4
+    USE_WARMUP: True
     WARMUP_EPOCHS: 34
     LR_POLICY: 'Cosine'
     WARMUP_END_LR: 0.1

--- a/scripts/action-recognition/configuration/r2plus1d_v1_resnet50_kinetics400.yaml
+++ b/scripts/action-recognition/configuration/r2plus1d_v1_resnet50_kinetics400.yaml
@@ -19,6 +19,7 @@ CONFIG:
     LR: 0.001
     MOMENTUM: 0.9
     W_DECAY: 1e-4
+    USE_WARMUP: True
     WARMUP_EPOCHS: 34
     LR_POLICY: 'Cosine'
     WARMUP_END_LR: 0.1

--- a/scripts/action-recognition/configuration/r2plus1d_v2_resnet152_kinetics400.yaml
+++ b/scripts/action-recognition/configuration/r2plus1d_v2_resnet152_kinetics400.yaml
@@ -19,6 +19,7 @@ CONFIG:
     LR: 0.001
     MOMENTUM: 0.9
     W_DECAY: 1e-4
+    USE_WARMUP: True
     WARMUP_EPOCHS: 34
     LR_POLICY: 'Cosine'
     WARMUP_END_LR: 0.1

--- a/scripts/action-recognition/configuration/slowfast_4x16_resnet50_kinetics400.yaml
+++ b/scripts/action-recognition/configuration/slowfast_4x16_resnet50_kinetics400.yaml
@@ -19,6 +19,7 @@ CONFIG:
     LR: 0.01
     MOMENTUM: 0.9
     W_DECAY: 1e-4
+    USE_WARMUP: True
     WARMUP_EPOCHS: 34
     LR_POLICY: 'Cosine'
     WARMUP_END_LR: 0.1

--- a/scripts/action-recognition/configuration/slowfast_8x8_resnet101_kinetics400.yaml
+++ b/scripts/action-recognition/configuration/slowfast_8x8_resnet101_kinetics400.yaml
@@ -19,6 +19,7 @@ CONFIG:
     LR: 0.01
     MOMENTUM: 0.9
     W_DECAY: 1e-4
+    USE_WARMUP: True
     WARMUP_EPOCHS: 34
     LR_POLICY: 'Cosine'
     WARMUP_END_LR: 0.1

--- a/scripts/action-recognition/configuration/slowfast_8x8_resnet50_kinetics400.yaml
+++ b/scripts/action-recognition/configuration/slowfast_8x8_resnet50_kinetics400.yaml
@@ -19,6 +19,7 @@ CONFIG:
     LR: 0.01
     MOMENTUM: 0.9
     W_DECAY: 1e-4
+    USE_WARMUP: True
     WARMUP_EPOCHS: 34
     LR_POLICY: 'Cosine'
     WARMUP_END_LR: 0.1


### PR DESCRIPTION
1. refine warmup logic, now using cfg.CONFIG.TRAIN.USE_WARMUP to control open warmup or not.
2. fix bug in gluoncv/torch/utils/lr_policy.py
3. change training configs
4. change ddp_train_pytorch and ddp_train_shortonly_pytorch, This is tested on ec2 machines