### PR TITLE
Fix all generator to support a memory leak fix

### DIFF
--- a/gluoncv/data/transforms/presets/center_net.py
+++ b/gluoncv/data/transforms/presets/center_net.py
@@ -1,5 +1,5 @@
 """Transforms described in https://arxiv.org/abs/1904.07850."""
-# pylint: disable=too-many-function-args disable=not-callable
+# pylint: disable=too-many-function-args,not-callable
 from __future__ import absolute_import
 import numpy as np
 import mxnet as mx
@@ -119,8 +119,8 @@ class CenterNetDefaultTrainTransform(object):
         self._height = height
         self._num_class = num_class
         self._scale_factor = scale_factor
-        self._mean = np.array(mean, dtype=np.float32).reshape(1, 1, 3)
-        self._std = np.array(std, dtype=np.float32).reshape(1, 1, 3)
+        self._mean = np.array(mean, dtype=np.float32).reshape((1, 1, 3))
+        self._std = np.array(std, dtype=np.float32).reshape((1, 1, 3))
         self._data_rng = np.random.RandomState(123)
         self._eig_val = np.array([0.2141788, 0.01817699, 0.00341571],
                                  dtype=np.float32)
@@ -209,8 +209,8 @@ class CenterNetDefaultValTransform(object):
     def __init__(self, width, height, mean=(0.485, 0.456, 0.406), std=(0.229, 0.224, 0.225)):
         self._width = width
         self._height = height
-        self._mean = np.array(mean, dtype=np.float32).reshape(1, 1, 3)
-        self._std = np.array(std, dtype=np.float32).reshape(1, 1, 3)
+        self._mean = np.array(mean, dtype=np.float32).reshape((1, 1, 3))
+        self._std = np.array(std, dtype=np.float32).reshape((1, 1, 3))
 
     def __call__(self, src, label):
         """Apply transform to validation image/label."""

--- a/gluoncv/data/transforms/presets/center_net.py
+++ b/gluoncv/data/transforms/presets/center_net.py
@@ -129,10 +129,19 @@ class CenterNetDefaultTrainTransform(object):
             [-0.5832747, 0.00994535, -0.81221408],
             [-0.56089297, 0.71832671, 0.41158938]
         ], dtype=np.float32)
+        self._internal_target_generator = None
+        self._target_width = width // scale_factor
+        self._target_height = height // scale_factor
 
-        from ....model_zoo.center_net.target_generator import CenterNetTargetGenerator
-        self._target_generator = CenterNetTargetGenerator(
-            num_class, width // scale_factor, height // scale_factor)
+    @property
+    def _target_generator(self):
+        if self._internal_target_generator is None:
+            from ....model_zoo.center_net.target_generator import CenterNetTargetGenerator
+            self._internal_target_generator = CenterNetTargetGenerator(
+                self._num_class, self._target_width, self._target_height)
+            return self._internal_target_generator
+        else:
+            return self._internal_target_generator
 
     def __call__(self, src, label):
         """Apply transform to training image/label."""

--- a/gluoncv/data/transforms/presets/center_net.py
+++ b/gluoncv/data/transforms/presets/center_net.py
@@ -1,5 +1,5 @@
 """Transforms described in https://arxiv.org/abs/1904.07850."""
-# pylint: disable=too-many-function-args
+# pylint: disable=too-many-function-args disable=not-callable
 from __future__ import absolute_import
 import numpy as np
 import mxnet as mx

--- a/gluoncv/data/transforms/presets/rcnn.py
+++ b/gluoncv/data/transforms/presets/rcnn.py
@@ -1,4 +1,5 @@
 """Transforms for RCNN series."""
+# pylint: disable=not-callable
 from __future__ import absolute_import
 
 import copy

--- a/gluoncv/data/transforms/presets/rcnn.py
+++ b/gluoncv/data/transforms/presets/rcnn.py
@@ -149,11 +149,20 @@ class FasterRCNNDefaultTrainTransform(object):
         self._max_size = max_size
         self._mean = mean
         self._std = std
+        self._box_norm = box_norm
         self._anchors = None
         self._multi_stage = multi_stage
         self._random_resize = isinstance(self._short, (tuple, list))
+        self._num_sample = num_sample
+        self._pos_iou_thresh = pos_iou_thresh
+        self._neg_iou_thresh = neg_iou_thresh
+        self._pos_ratio = pos_ratio
         self._flip_p = flip_p
+        self._internal_target_generator = None
+        self._net_none = False
+        self._kwargs = kwargs
         if net is None:
+            self._net_none = True
             return
 
         # use fake data to generate fixed anchors for target generation
@@ -177,11 +186,20 @@ class FasterRCNNDefaultTrainTransform(object):
         if not hasattr(net, 'features'):
             raise ValueError("Cannot find features in network, it is a Faster-RCNN network?")
         self._feat_sym = net.features(mx.sym.var(name='data'))
-        from ....model_zoo.rcnn.rpn.rpn_target import RPNTargetGenerator
-        self._target_generator = RPNTargetGenerator(
-            num_sample=num_sample, pos_iou_thresh=pos_iou_thresh,
-            neg_iou_thresh=neg_iou_thresh, pos_ratio=pos_ratio,
-            stds=box_norm, **kwargs)
+
+    @property
+    def _target_generator(self):
+        if self._internal_target_generator is None:
+            if self._net_none:
+                return None
+            from ....model_zoo.rcnn.rpn.rpn_target import RPNTargetGenerator
+            self._internal_target_generator = RPNTargetGenerator(
+                num_sample=self._num_sample, pos_iou_thresh=self._pos_iou_thresh,
+                neg_iou_thresh=self._neg_iou_thresh, pos_ratio=self._pos_ratio,
+                stds=self._box_norm, **self._kwargs)
+            return self._internal_target_generator
+        else:
+            return self._internal_target_generator
 
     def __call__(self, src, label):
         """Apply transform to training image/label."""
@@ -334,10 +352,19 @@ class MaskRCNNDefaultTrainTransform(object):
         self._max_size = max_size
         self._mean = mean
         self._std = std
+        self._box_norm = box_norm
         self._anchors = None
         self._multi_stage = multi_stage
         self._random_resize = isinstance(self._short, (tuple, list))
+        self._num_sample = num_sample
+        self._pos_iou_thresh = pos_iou_thresh
+        self._neg_iou_thresh = neg_iou_thresh
+        self._pos_ratio = pos_ratio
+        self._internal_target_generator = None
+        self._net_none = False
+        self._kwargs = kwargs
         if net is None:
+            self._net_none = True
             return
 
         # use fake data to generate fixed anchors for target generation
@@ -358,11 +385,20 @@ class MaskRCNNDefaultTrainTransform(object):
         if not hasattr(net, 'features'):
             raise ValueError("Cannot find features in network, it is a Mask RCNN network?")
         self._feat_sym = net.features(mx.sym.var(name='data'))
-        from ....model_zoo.rcnn.rpn.rpn_target import RPNTargetGenerator
-        self._target_generator = RPNTargetGenerator(
-            num_sample=num_sample, pos_iou_thresh=pos_iou_thresh,
-            neg_iou_thresh=neg_iou_thresh, pos_ratio=pos_ratio,
-            stds=box_norm, **kwargs)
+
+    @property
+    def _target_generator(self):
+        if self._internal_target_generator is None:
+            if self._net_none:
+                return None
+            from ....model_zoo.rcnn.rpn.rpn_target import RPNTargetGenerator
+            self._internal_target_generator = RPNTargetGenerator(
+                num_sample=self._num_sample, pos_iou_thresh=self._pos_iou_thresh,
+                neg_iou_thresh=self._neg_iou_thresh, pos_ratio=self._pos_ratio,
+                stds=self._box_norm, **self._kwargs)
+            return self._internal_target_generator
+        else:
+            return self._internal_target_generator
 
     def __call__(self, src, label, segm):
         """Apply transform to training image/label."""

--- a/gluoncv/data/transforms/presets/simple_pose.py
+++ b/gluoncv/data/transforms/presets/simple_pose.py
@@ -50,20 +50,31 @@ class SimplePoseDefaultTrainTransform(object):
                  sigma=2, mean=(0.485, 0.456, 0.406), std=(0.229, 0.224, 0.225),
                  random_flip=True, scale_factor=0.25, rotation_factor=30,
                  **kwargs):
-        from ....model_zoo.simple_pose.pose_target import SimplePoseGaussianTargetGenerator
-        self._target_generator = SimplePoseGaussianTargetGenerator(
-            num_joints, (image_size[1], image_size[0]), (heatmap_size[1], heatmap_size[0]), sigma)
+        self._internal_target_generator = None
         self._num_joints = num_joints
         self._image_size = image_size
         self._joint_pairs = joint_pairs
         self._height = image_size[0]
         self._width = image_size[1]
+        self._heatmap_height = heatmap_size[0]
+        self._heatmap_width = heatmap_size[1]
+        self._sigma = sigma
         self._mean = mean
         self._std = std
         self._random_flip = random_flip
         self._scale_factor = scale_factor
         self._rotation_factor = rotation_factor
         self._aspect_ratio = float(self._width) / self._height
+
+    @property
+    def _target_generator(self):
+        if self._internal_target_generator is None:
+            from ....model_zoo.simple_pose.pose_target import SimplePoseGaussianTargetGenerator
+            self._internal_target_generator = SimplePoseGaussianTargetGenerator(
+                self._num_joints, (self._width, self._height), (self._heatmap_width, self._heatmap_height), self._sigma)
+            return self._internal_target_generator
+        else:
+            return self._internal_target_generator
 
     def __call__(self, src, label, img_path):
         cv2 = try_import_cv2()

--- a/gluoncv/data/transforms/presets/ssd.py
+++ b/gluoncv/data/transforms/presets/ssd.py
@@ -1,4 +1,5 @@
 """Transforms described in https://arxiv.org/abs/1512.02325."""
+# pylint: disable=not-callable
 from __future__ import absolute_import
 import numpy as np
 import mxnet as mx

--- a/gluoncv/data/transforms/presets/ssd.py
+++ b/gluoncv/data/transforms/presets/ssd.py
@@ -133,13 +133,27 @@ class SSDDefaultTrainTransform(object):
         self._anchors = anchors
         self._mean = mean
         self._std = std
+        self._internal_target_generator = None
+        self._iou_thresh = iou_thresh
+        self._box_norm = box_norm
+        self._kwargs = kwargs
+        self._anchors_none = False
         if anchors is None:
+            self._anchors_none = True
             return
 
+    @property
+    def _target_generator(self):
         # since we do not have predictions yet, so we ignore sampling here
-        from ....model_zoo.ssd.target import SSDTargetGenerator
-        self._target_generator = SSDTargetGenerator(
-            iou_thresh=iou_thresh, stds=box_norm, negative_mining_ratio=-1, **kwargs)
+        if self._internal_target_generator is None:
+            if self._anchors_none:
+                return None
+            from ....model_zoo.ssd.target import SSDTargetGenerator
+            self._internal_target_generator = SSDTargetGenerator(
+                iou_thresh=self._iou_thresh, stds=self._box_norm, negative_mining_ratio=-1, **self._kwargs)
+            return self._internal_target_generator
+        else:
+            return self._internal_target_generator
 
     def __call__(self, src, label):
         """Apply transform to training image/label."""

--- a/gluoncv/data/transforms/presets/yolo.py
+++ b/gluoncv/data/transforms/presets/yolo.py
@@ -135,9 +135,13 @@ class YOLO3DefaultTrainTransform(object):
         self._mean = mean
         self._std = std
         self._mixup = mixup
-        self._target_generator = None
+        self._internal_target_generator = None
+        self._net_none = False
         if net is None:
+            self._net_none = True
             return
+        self._num_classes = len(net.classes)
+        self._kwargs = kwargs
 
         # in case network has reset_ctx to gpu
         self._fake_x = mx.nd.zeros((1, 3, height, width))
@@ -145,10 +149,20 @@ class YOLO3DefaultTrainTransform(object):
         net.collect_params().reset_ctx(mx.cpu())
         with autograd.train_mode():
             _, self._anchors, self._offsets, self._feat_maps, _, _, _, _ = net(self._fake_x)
-        from ....model_zoo.yolo.yolo_target import YOLOV3PrefetchTargetGenerator
-        self._target_generator = YOLOV3PrefetchTargetGenerator(
-            num_class=len(net.classes), **kwargs)
+        
         net.collect_params().reset_ctx(old_ctx)
+
+    @property
+    def _target_generator(self):
+        if self._internal_target_generator is None:
+            if self._net_none:
+                return None
+            from ....model_zoo.yolo.yolo_target import YOLOV3PrefetchTargetGenerator
+            self._internal_target_generator = YOLOV3PrefetchTargetGenerator(
+                num_class=self._num_classes, **self._kwargs)
+            return self._internal_target_generator
+        else:
+            return self._internal_target_generator
 
     def __call__(self, src, label):
         """Apply transform to training image/label."""

--- a/gluoncv/data/transforms/presets/yolo.py
+++ b/gluoncv/data/transforms/presets/yolo.py
@@ -1,7 +1,6 @@
 """Transforms for YOLO series."""
-# pylint: ddisable=not-callable
+# pylint: disable=not-callable
 from __future__ import absolute_import
-import copy
 import numpy as np
 import mxnet as mx
 from mxnet import autograd
@@ -150,7 +149,6 @@ class YOLO3DefaultTrainTransform(object):
         net.collect_params().reset_ctx(mx.cpu())
         with autograd.train_mode():
             _, self._anchors, self._offsets, self._feat_maps, _, _, _, _ = net(self._fake_x)
-        
         net.collect_params().reset_ctx(old_ctx)
 
     @property

--- a/gluoncv/data/transforms/presets/yolo.py
+++ b/gluoncv/data/transforms/presets/yolo.py
@@ -1,4 +1,5 @@
 """Transforms for YOLO series."""
+# pylint: ddisable=not-callable
 from __future__ import absolute_import
 import copy
 import numpy as np


### PR DESCRIPTION
I use a python property workaround to avoid the multiprocessing to pickle the ``` target generators```, which will cause error before, especially on Windows.
The error is associated with ```ForkingPickler``` of ```multiprocessing``` package of python and be usually like:
```cannot pickle 'weakref' object```
```EOFError: Ran out of input```
After the commit https://github.com/apache/incubator-mxnet/pull/18328 , some memory leak were fixed. The commit is ***critical*** so we need to merge it again in MXNet 1.7.x and 1.8.x.
The revert commits below can be committed again after this fix. We can do gluon-cv training correctly and safety later.
https://github.com/apache/incubator-mxnet/pull/18692
https://github.com/apache/incubator-mxnet/commit/04966902ec94a6387182aa1765a4aac6686d9cc5