### PR TITLE
Move trainer.step() before metric.update to overlap between backward pass and allreduce

### DIFF
--- a/scripts/detection/faster_rcnn/train_faster_rcnn.py
+++ b/scripts/detection/faster_rcnn/train_faster_rcnn.py
@@ -531,12 +531,13 @@ def train(net, train_data, val_data, eval_metric, batch_size, ctx, args):
                         metric_losses[k].append(result[k])
                     for k in range(len(add_losses)):
                         add_losses[k].append(result[len(metric_losses) + k])
+            trainer.step(batch_size)
+
             for metric, record in zip(metrics, metric_losses):
                 metric.update(0, record)
             for metric, records in zip(metrics2, add_losses):
                 for pred in records:
                     metric.update(pred[0], pred[1])
-            trainer.step(batch_size)
 
             # update metrics
             if (not args.horovod or hvd.rank() == 0) and args.log_interval \


### PR DESCRIPTION
- The `metric.update()` is a sync call and it was preventing the overlap between communication and computation since it was present between `loss.backward()` and `trainer.step()`.
- Moved the `metric.update()` after  `trainer.step()` to overlap  communication and computation. Hence, the correct order is `forward pass -> calculate loss -> backward pass -> allreduce -> metric update`.
- Also fixed minor error in the `train_mask_rcnn.py` script.