### PR TITLE
Fix get_model

### DIFF
--- a/gluoncv/model_zoo/danet.py
+++ b/gluoncv/model_zoo/danet.py
@@ -90,15 +90,15 @@ class DANetHead(HybridBlock):
         self.conv52.add(nn.Activation('relu'))
 
         self.conv6 = nn.HybridSequential()
-        self.conv6.add(nn.Dropout(0.1))
+        # self.conv6.add(nn.Dropout(0.1))
         self.conv6.add(nn.Conv2D(in_channels=512, channels=out_channels, kernel_size=1))
 
         self.conv7 = nn.HybridSequential()
-        self.conv7.add(nn.Dropout(0.1))
+        # self.conv7.add(nn.Dropout(0.1))
         self.conv7.add(nn.Conv2D(in_channels=512, channels=out_channels, kernel_size=1))
 
         self.conv8 = nn.HybridSequential()
-        self.conv8.add(nn.Dropout(0.1))
+        # self.conv8.add(nn.Dropout(0.1))
         self.conv8.add(nn.Conv2D(in_channels=512, channels=out_channels, kernel_size=1))
 
     def hybrid_forward(self, F, x):

--- a/gluoncv/model_zoo/model_zoo.py
+++ b/gluoncv/model_zoo/model_zoo.py
@@ -215,7 +215,7 @@ _models = {
     'resnext50_32x4d': resnext50_32x4d,
     'resnext101_32x4d': resnext101_32x4d,
     'resnext101_64x4d': resnext101_64x4d,
-    'resnext101b_64x4d': resnext101e_64x4d,
+    'resnext101e_64x4d': resnext101e_64x4d,
     'se_resnext50_32x4d': se_resnext50_32x4d,
     'se_resnext101_32x4d': se_resnext101_32x4d,
     'se_resnext101_64x4d': se_resnext101_64x4d,

--- a/gluoncv/model_zoo/resnext.py
+++ b/gluoncv/model_zoo/resnext.py
@@ -363,6 +363,7 @@ def resnext101_64x4d(**kwargs):
 
 
 def resnext101e_64x4d(**kwargs):
+    # pylint: disable=line-too-long
     r"""ResNext101e 64x4d model modified from
     `"Aggregated Residual Transformations for Deep Neural Network"
     <http://arxiv.org/abs/1611.05431>`_ paper.
@@ -388,6 +389,9 @@ def resnext101e_64x4d(**kwargs):
         for :class:`mxnet.gluon.contrib.nn.SyncBatchNorm`.
     """
     kwargs['use_se'] = False
+    if kwargs['pretrained']:
+        msg = 'GluonCV does not have pretrained weights for resnext101e_64x4d at this moment. Please set pretrained=False.'
+        raise RuntimeError(msg)
     return get_resnext(101, 64, 4, deep_stem=True, avg_down=True, **kwargs)
 
 
@@ -479,6 +483,7 @@ def se_resnext101_64x4d(**kwargs):
 
 
 def se_resnext101e_64x4d(**kwargs):
+    # pylint: disable=line-too-long
     r"""SE-ResNext101e 64x4d model modified from
     `"Aggregated Residual Transformations for Deep Neural Network"
     <http://arxiv.org/abs/1611.05431>`_ paper.
@@ -504,4 +509,7 @@ def se_resnext101e_64x4d(**kwargs):
         for :class:`mxnet.gluon.contrib.nn.SyncBatchNorm`.
     """
     kwargs['use_se'] = True
+    if kwargs['pretrained']:
+        msg = 'GluonCV does not have pretrained weights for resnext101e_64x4d at this moment. Please set pretrained=False.'
+        raise RuntimeError(msg)
     return get_resnext(101, 64, 4, deep_stem=True, avg_down=True, **kwargs)


### PR DESCRIPTION
1. This PR resolves the bug in getting model for `resnext101e_64x4d ` and `se_resnext101e_64x4d `. Previously, `resnext101e_64x4d` was directed to `resnext101_64x4d` pretrained weights so that loading weights is not successful. 
2. This PR also disables dropout in DANet to make sure pretrained model weights can be loaded correctly. Models with dropout are retraining, and updated in a later PR. 