### PR TITLE
Fix build docs exit condition

### DIFF
--- a/.github/workflows/build_docs.sh
+++ b/.github/workflows/build_docs.sh
@@ -21,6 +21,11 @@ export MXNET_CUDNN_AUTOTUNE_DEFAULT=0
 cd docs 
 make html
 COMMAND_EXIT_CODE=$?
+
+if [ $COMMAND_EXIT_CODE -ne 0 ]; then
+    exit COMMAND_EXIT_CODE
+fi
+
 sed -i.bak 's/33\\,150\\,243/23\\,141\\,201/g' build/html/_static/material-design-lite-1.3.0/material.blue-deep_orange.min.css;
 sed -i.bak 's/2196f3/178dc9/g' build/html/_static/sphinx_materialdesign_theme.css;
 sed -i.bak 's/pre{padding:1rem;margin:1.5rem\\s0;overflow:auto;overflow-y:hidden}/pre{padding:1rem;margin:1.5rem 0;overflow:auto;overflow-y:scroll}/g' build/html/_static/sphinx_materialdesign_theme.css
@@ -34,4 +39,3 @@ else
 	echo "Uploaded doc to http://gluon-vision-staging.s3-website-us-west-2.amazonaws.com/PR-$PR_NUMBER/$COMMIT_SHA/index.html"
 	echo $GIT_REPO: $BRANCH
 fi;
-exit $COMMAND_EXIT_CODE


### PR DESCRIPTION
s3 bucket shouldn't be synced if doc was failed to build. This would cause the website to be inaccessible under such condition.