### PR TITLE
Properly set context for detector network

### DIFF
--- a/gluoncv/model_zoo/smot/general_detector.py
+++ b/gluoncv/model_zoo/smot/general_detector.py
@@ -88,7 +88,7 @@ class GeneralDetector:
         self.ctx = mx.gpu(gpu_id)
 
         self.net = get_net(classes=COCODetection.CLASSES,
-                           ctx=mx.gpu(0),
+                           ctx=self.ctx,
                            model_name=model_name,
                            use_pretrained=use_pretrained,
                            param_path=param_path)


### PR DESCRIPTION
I was trying to run SMOT concurrently with multiple GPUs when I hit this error:
```
mxNetError: Check failed: inputs[i]->ctx() == default_ctx (gpu(0) vs. gpu(1))
```