### PR TITLE
[Auto]Fix loading gpu trained estimator on cpu machine

### DIFF
--- a/gluoncv/auto/estimators/base_estimator.py
+++ b/gluoncv/auto/estimators/base_estimator.py
@@ -265,6 +265,8 @@ class BaseEstimator:
         valid_gpus = []
         try:
             import torch
+            if not torch.cuda.is_available():
+                return valid_gpus
             for gid in gpu_ids:
                 try:
                     _ = torch.zeros(1, device=f'cuda:{gid}')

--- a/gluoncv/auto/estimators/torch_image_classification/torch_image_classification.py
+++ b/gluoncv/auto/estimators/torch_image_classification/torch_image_classification.py
@@ -795,17 +795,16 @@ class TorchImageClassificationEstimator(BaseEstimator):
         except:
             pass
         model_state_dict = d.get('model_state_dict', None)
+        net_pickle = d.get('net_pickle', None)
         if model_state_dict:
-            net_pickle = d.get('net_pickle', None)
-            if net_pickle:
-                est.net = pickle.loads(net_pickle)
+            est._init_network(load_only=True)
+            net_state_dict = est._reconstruct_state_dict(model_state_dict)
+            if isinstance(est.net, torch.nn.DataParallel):
+                est.net.module.load_state_dict(net_state_dict)
             else:
-                est._init_network(load_only=True)
-                net_state_dict = est._reconstruct_state_dict(model_state_dict)
-                if isinstance(est.net, torch.nn.DataParallel):
-                    est.net.module.load_state_dict(net_state_dict)
-                else:
-                    est.net.load_state_dict(net_state_dict)
+                est.net.load_state_dict(net_state_dict)
+        elif net_pickle:
+            est.net = pickle.loads(net_pickle)
         optimizer_state_dict = d.get('optimizer_state_dict', None)
         if optimizer_state_dict:
             est._init_trainer()

--- a/gluoncv/auto/estimators/torch_image_classification/torch_image_classification.py
+++ b/gluoncv/auto/estimators/torch_image_classification/torch_image_classification.py
@@ -28,6 +28,7 @@ from .default import TorchImageClassificationCfg
 from .utils import resolve_data_config, update_cfg, optimizer_kwargs, \
                    create_scheduler, rmse, create_optimizer_v2a
 from ..utils import EarlyStopperOnPlateau
+from ..utils import _suggest_load_context
 from ..conf import _BEST_CHECKPOINT_FILE
 from ..base_estimator import BaseEstimator, set_default
 from ....utils.filesystem import try_import
@@ -752,87 +753,81 @@ class TorchImageClassificationEstimator(BaseEstimator):
             new_state_dict[name] = v
         return new_state_dict
 
-    # pylint: disable=redefined-outer-name, reimported
-    def __getstate__(self):
-        d = self.__dict__.copy()
-        try:
-            import torch
-            net = d.pop('net', None)
-            model_ema = d.pop('_model_ema', None)
-            optimizer = d.pop('_optimizer', None)
-            loss_scaler = d.pop('_loss_scaler', None)
-            save_state = {}
-            if net is not None:
-                if not self._custom_net:
-                    if isinstance(net, torch.nn.DataParallel):
-                        save_state['state_dict'] = get_state_dict(net.module, unwrap_model)
-                    else:
-                        save_state['state_dict'] = get_state_dict(net, unwrap_model)
+    def save(self, filename):
+        d = dict()
+        current_states = self.__dict__.copy()
+        if self.net:
+            if not self._custom_net:
+                if isinstance(self.net, torch.nn.DataParallel):
+                    d['model_state_dict'] = get_state_dict(self.net.module, unwrap_model)
                 else:
-                    net_pickle = pickle.dumps(net)
-                    save_state['net_pickle'] = net_pickle
-            if optimizer is not None:
-                save_state['optimizer'] = optimizer.state_dict()
-            if loss_scaler is not None:
-                save_state[loss_scaler.state_dict_key] = loss_scaler.state_dict()
-            if model_ema is not None:
-                save_state['state_dict_ema'] = get_state_dict(model_ema, unwrap_model)
-        except ImportError:
-            pass
-        d['save_state'] = save_state
-        d['_logger'] = None
-        d['_reporter'] = None
-        return d
+                    d['model_state_dict'] = get_state_dict(self.net, unwrap_model)
+            else:
+                net_pickle = pickle.dumps(self.net)
+                d['net_pickle'] = net_pickle
+            self.net = None
+        if self._optimizer:
+            d['optimizer_state_dict'] = self._optimizer.state_dict()
+            self._optimizer = None
+        if hasattr(self, '_loss_scaler') and self._loss_scaler:
+            d[self._loss_scaler.state_dict_key] = self._loss_scaler.state_dict()
+            d['_loss_scaler_state_dict_key'] = self._loss_scaler.state_dict_key
+        if self._model_ema:
+            d['ema_state_dict'] = get_state_dict(self._model_ema, unwrap_model)
+            self._model_ema = None
+        self._logger = None
+        self._reporter = None
+        d['estimator'] = self
+        torch.save(d, filename)
+        self.__dict__.update(current_states)
 
-    def __setstate__(self, state):
-        save_state = state.pop('save_state', None)
-        self.__dict__.update(state)
+    @classmethod
+    def load(cls, filename, ctx='auto'):
+        d = torch.load(filename, map_location=torch.device('cpu'))
+        est = d.pop('estimator')
         # logger
-        self._logger = logging.getLogger(state.get('_name', self.__class__.__name__))
-        self._logger.setLevel(logging.ERROR)
+        est._logger = logging.getLogger(cls.__name__)
+        est._logger.setLevel(logging.ERROR)
         try:
-            fh = logging.FileHandler(self._log_file)
-            self._logger.addHandler(fh)
+            fh = logging.FileHandler(est._log_file)
+            est._logger.addHandler(fh)
         #pylint: disable=bare-except
         except:
             pass
-        if not save_state:
-            self.net = None
-            self._optimizer = None
-            self._logger.setLevel(logging.INFO)
-            return
-        try:
-            import torch
-            self.net = None
-            self._optimizer = None
-            if self._custom_net:
-                if save_state.get('net_pickle', None):
-                    self.net = pickle.loads(save_state['net_pickle'])
+        model_state_dict = d.get('model_state_dict', None)
+        if model_state_dict:
+            net_pickle = d.get('net_pickle', None)
+            if net_pickle:
+                est.net = pickle.loads(net_pickle)
             else:
-                if save_state.get('state_dict', None):
-                    self._init_network(load_only=True)
-                    net_state_dict = self._reconstruct_state_dict(save_state['state_dict'])
-                    if isinstance(self.net, torch.nn.DataParallel):
-                        self.net.module.load_state_dict(net_state_dict)
-                    else:
-                        self.net.load_state_dict(net_state_dict)
-            if save_state.get('optimizer', None):
-                self._init_trainer()
-                self._optimizer.load_state_dict(save_state['optimizer'])
-            if hasattr(self, '_loss_scaler') and self._loss_scaler and self._loss_scaler.state_dict_key in save_state:
-                loss_scaler_dict = save_state[self._loss_scaler.state_dict_key]
-                self._loss_scaler.load_state_dict(loss_scaler_dict)
-            if save_state.get('state_dict_ema', None):
-                self._init_model_ema()
-                model_ema_dict = save_state.get('state_dict_ema')
-                model_ema_dict = self._reconstruct_state_dict(model_ema_dict)
-                if isinstance(self.net, torch.nn.DataParallel):
-                    self._model_ema.module.module.load_state_dict(model_ema_dict)
+                est._init_network(load_only=True)
+                net_state_dict = est._reconstruct_state_dict(model_state_dict)
+                if isinstance(est.net, torch.nn.DataParallel):
+                    est.net.module.load_state_dict(net_state_dict)
                 else:
-                    self._model_ema.module.load_state_dict(model_ema_dict)
-        except ImportError:
-            pass
-        self._logger.setLevel(logging.INFO)
+                    est.net.load_state_dict(net_state_dict)
+        optimizer_state_dict = d.get('optimizer_state_dict', None)
+        if optimizer_state_dict:
+            est._init_trainer()
+            est._optimizer.load_state_dict(optimizer_state_dict)
+        if hasattr(est, '_loss_scaler') and est._loss_scaler:
+            loss_scaler_state_dict_key = d.get('loss_scaler_state_dict')
+            loss_scaler_dict = d.get(loss_scaler_state_dict_key, None)
+            if loss_scaler_dict:
+                est._loss_scaler.load_state_dict(loss_scaler_dict)
+        ema_state_dict = d.get('ema_state_dict', None)
+        est._init_model_ema()
+        if ema_state_dict:
+            ema_state_dict = est._reconstruct_state_dict(ema_state_dict)
+            if isinstance(est.net, torch.nn.DataParallel):
+                est._model_ema.module.module.load_state_dict(ema_state_dict)
+            else:
+                est._model_ema.module.load_state_dict(ema_state_dict)
+        new_ctx = _suggest_load_context(est.net, ctx, est.ctx)
+        est.reset_ctx(new_ctx)
+        est._logger.setLevel(logging.INFO)
+        return est
+
 
 class ImageListDataset(torch.utils.data.Dataset):
     """An internal image list dataset for batch predict"""

--- a/gluoncv/auto/estimators/torch_image_classification/torch_image_classification.py
+++ b/gluoncv/auto/estimators/torch_image_classification/torch_image_classification.py
@@ -831,85 +831,10 @@ class TorchImageClassificationEstimator(BaseEstimator):
     # pylint: disable=redefined-outer-name, reimported
     def __getstate__(self):
         d = self.__dict__.copy()
-        # try:
-        #     import torch
-        #     net = d.pop('net', None)
-        #     model_ema = d.pop('_model_ema', None)
-        #     optimizer = d.pop('_optimizer', None)
-        #     loss_scaler = d.pop('_loss_scaler', None)
-        #     save_state = {}
-        #     if net is not None:
-        #         if not self._custom_net:
-        #             if isinstance(net, torch.nn.DataParallel):
-        #                 save_state['state_dict'] = get_state_dict(net.module, unwrap_model)
-        #             else:
-        #                 save_state['state_dict'] = get_state_dict(net, unwrap_model)
-        #         else:
-        #             net_pickle = pickle.dumps(net)
-        #             save_state['net_pickle'] = net_pickle
-        #     if optimizer is not None:
-        #         save_state['optimizer'] = optimizer.state_dict()
-        #     if loss_scaler is not None:
-        #         save_state[loss_scaler.state_dict_key] = loss_scaler.state_dict()
-        #     if model_ema is not None:
-        #         save_state['state_dict_ema'] = get_state_dict(model_ema, unwrap_model)
-        # except ImportError:
-        #     pass
-        # d['save_state'] = save_state
-        # d['_logger'] = None
-        # d['_reporter'] = None
         return d
 
     def __setstate__(self, state):
         self.__dict__.update(state)
-        # save_state = state.pop('save_state', None)
-        # self.__dict__.update(state)
-        # # logger
-        # self._logger = logging.getLogger(state.get('_name', self.__class__.__name__))
-        # self._logger.setLevel(logging.ERROR)
-        # try:
-        #     fh = logging.FileHandler(self._log_file)
-        #     self._logger.addHandler(fh)
-        # #pylint: disable=bare-except
-        # except:
-        #     pass
-        # if not save_state:
-        #     self.net = None
-        #     self._optimizer = None
-        #     self._logger.setLevel(logging.INFO)
-        #     return
-        # try:
-        #     import torch
-        #     self.net = None
-        #     self._optimizer = None
-        #     if self._custom_net:
-        #         if save_state.get('net_pickle', None):
-        #             self.net = pickle.loads(save_state['net_pickle'])
-        #     else:
-        #         if save_state.get('state_dict', None):
-        #             self._init_network(load_only=True)
-        #             net_state_dict = self._reconstruct_state_dict(save_state['state_dict'])
-        #             if isinstance(self.net, torch.nn.DataParallel):
-        #                 self.net.module.load_state_dict(net_state_dict)
-        #             else:
-        #                 self.net.load_state_dict(net_state_dict)
-        #     if save_state.get('optimizer', None):
-        #         self._init_trainer()
-        #         self._optimizer.load_state_dict(save_state['optimizer'])
-        #     if hasattr(self, '_loss_scaler') and self._loss_scaler and self._loss_scaler.state_dict_key in save_state:
-        #         loss_scaler_dict = save_state[self._loss_scaler.state_dict_key]
-        #         self._loss_scaler.load_state_dict(loss_scaler_dict)
-        #     if save_state.get('state_dict_ema', None):
-        #         self._init_model_ema()
-        #         model_ema_dict = save_state.get('state_dict_ema')
-        #         model_ema_dict = self._reconstruct_state_dict(model_ema_dict)
-        #         if isinstance(self.net, torch.nn.DataParallel):
-        #             self._model_ema.module.module.load_state_dict(model_ema_dict)
-        #         else:
-        #             self._model_ema.module.load_state_dict(model_ema_dict)
-        # except ImportError:
-        #     pass
-        # self._logger.setLevel(logging.INFO)
 
 class ImageListDataset(torch.utils.data.Dataset):
     """An internal image list dataset for batch predict"""

--- a/gluoncv/auto/estimators/torch_image_classification/torch_image_classification.py
+++ b/gluoncv/auto/estimators/torch_image_classification/torch_image_classification.py
@@ -828,6 +828,88 @@ class TorchImageClassificationEstimator(BaseEstimator):
         est._logger.setLevel(logging.INFO)
         return est
 
+    # pylint: disable=redefined-outer-name, reimported
+    def __getstate__(self):
+        d = self.__dict__.copy()
+        # try:
+        #     import torch
+        #     net = d.pop('net', None)
+        #     model_ema = d.pop('_model_ema', None)
+        #     optimizer = d.pop('_optimizer', None)
+        #     loss_scaler = d.pop('_loss_scaler', None)
+        #     save_state = {}
+        #     if net is not None:
+        #         if not self._custom_net:
+        #             if isinstance(net, torch.nn.DataParallel):
+        #                 save_state['state_dict'] = get_state_dict(net.module, unwrap_model)
+        #             else:
+        #                 save_state['state_dict'] = get_state_dict(net, unwrap_model)
+        #         else:
+        #             net_pickle = pickle.dumps(net)
+        #             save_state['net_pickle'] = net_pickle
+        #     if optimizer is not None:
+        #         save_state['optimizer'] = optimizer.state_dict()
+        #     if loss_scaler is not None:
+        #         save_state[loss_scaler.state_dict_key] = loss_scaler.state_dict()
+        #     if model_ema is not None:
+        #         save_state['state_dict_ema'] = get_state_dict(model_ema, unwrap_model)
+        # except ImportError:
+        #     pass
+        # d['save_state'] = save_state
+        # d['_logger'] = None
+        # d['_reporter'] = None
+        return d
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        # save_state = state.pop('save_state', None)
+        # self.__dict__.update(state)
+        # # logger
+        # self._logger = logging.getLogger(state.get('_name', self.__class__.__name__))
+        # self._logger.setLevel(logging.ERROR)
+        # try:
+        #     fh = logging.FileHandler(self._log_file)
+        #     self._logger.addHandler(fh)
+        # #pylint: disable=bare-except
+        # except:
+        #     pass
+        # if not save_state:
+        #     self.net = None
+        #     self._optimizer = None
+        #     self._logger.setLevel(logging.INFO)
+        #     return
+        # try:
+        #     import torch
+        #     self.net = None
+        #     self._optimizer = None
+        #     if self._custom_net:
+        #         if save_state.get('net_pickle', None):
+        #             self.net = pickle.loads(save_state['net_pickle'])
+        #     else:
+        #         if save_state.get('state_dict', None):
+        #             self._init_network(load_only=True)
+        #             net_state_dict = self._reconstruct_state_dict(save_state['state_dict'])
+        #             if isinstance(self.net, torch.nn.DataParallel):
+        #                 self.net.module.load_state_dict(net_state_dict)
+        #             else:
+        #                 self.net.load_state_dict(net_state_dict)
+        #     if save_state.get('optimizer', None):
+        #         self._init_trainer()
+        #         self._optimizer.load_state_dict(save_state['optimizer'])
+        #     if hasattr(self, '_loss_scaler') and self._loss_scaler and self._loss_scaler.state_dict_key in save_state:
+        #         loss_scaler_dict = save_state[self._loss_scaler.state_dict_key]
+        #         self._loss_scaler.load_state_dict(loss_scaler_dict)
+        #     if save_state.get('state_dict_ema', None):
+        #         self._init_model_ema()
+        #         model_ema_dict = save_state.get('state_dict_ema')
+        #         model_ema_dict = self._reconstruct_state_dict(model_ema_dict)
+        #         if isinstance(self.net, torch.nn.DataParallel):
+        #             self._model_ema.module.module.load_state_dict(model_ema_dict)
+        #         else:
+        #             self._model_ema.module.load_state_dict(model_ema_dict)
+        # except ImportError:
+        #     pass
+        # self._logger.setLevel(logging.INFO)
 
 class ImageListDataset(torch.utils.data.Dataset):
     """An internal image list dataset for batch predict"""

--- a/gluoncv/auto/tasks/image_classification.py
+++ b/gluoncv/auto/tasks/image_classification.py
@@ -212,10 +212,7 @@ def _train_image_classification(args, reporter):
                 'time': time.time() - tic, 'train_acc': -1, 'valid_acc': -1}
 
     if estimator:
-        try:
-            result.update({'model_checkpoint': pickle.dumps(estimator)})
-        except pickle.PicklingError:
-            result.update({'model_checkpoint': estimator})
+        result.update({'model_checkpoint': estimator})
         result.update({'estimator': estimator_cls})
     return result
 

--- a/tests/auto/test_auto_tasks.py
+++ b/tests/auto/test_auto_tasks.py
@@ -11,7 +11,7 @@ OBJECT_DETECTION_TRAIN, OBJECT_DETECTION_VAL, OBJECT_DETECTION_TEST = OBJECT_DET
 
 def test_image_classification():
     from gluoncv.auto.tasks import ImageClassification
-    task = ImageClassification({'num_trials': 1, 'epochs': 1, 'batch_size': 8})
+    task = ImageClassification({'model': 'resnet18_v1', 'num_trials': 1, 'epochs': 1, 'batch_size': 8})
     classifier = task.fit(IMAGE_CLASS_DATASET)
     assert task.fit_summary().get('valid_acc', 0) > 0
     test_result = classifier.predict(IMAGE_CLASS_TEST)


### PR DESCRIPTION
Issue #:
https://github.com/awslabs/autogluon/issues/1426

Description:
autogluon users reported a bug where predictor trained on GPU machine is not loadable on a CPU machine.
The previous logic of loading uses pickle, which loads object from bottom down and internally calls torch.load before reaching TorchImageClassificationEstimator custom loading logic.
After refactor loading logic to use torch.load, this issue is solved.

Ideally, unit test should be added to cover such scenario. However, there's no way to disable gpu after torch has been loaded. Hence, impossible to test it on a single machine.