### PR TITLE
Add doublehead_rcnn detection module

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,3 +190,5 @@ If you feel our code or models helps in your research, kindly cite our papers:
   year={2020}
 }
 ```
+
+## Detection

--- a/README.md
+++ b/README.md
@@ -190,5 +190,3 @@ If you feel our code or models helps in your research, kindly cite our papers:
   year={2020}
 }
 ```
-
-## Detection

--- a/gluoncv/model_zoo/model_zoo.py
+++ b/gluoncv/model_zoo/model_zoo.py
@@ -137,6 +137,7 @@ _models = {
     'faster_rcnn_resnet50_v1b_voc': faster_rcnn_resnet50_v1b_voc,
     'mask_rcnn_resnet18_v1b_coco': mask_rcnn_resnet18_v1b_coco,
     'faster_rcnn_resnet50_v1b_coco': faster_rcnn_resnet50_v1b_coco,
+    'doublehead_rcnn_resnet50_v1b_voc': doublehead_rcnn_resnet50_v1b_voc,
     'faster_rcnn_fpn_resnet50_v1b_coco': faster_rcnn_fpn_resnet50_v1b_coco,
     'faster_rcnn_fpn_syncbn_resnet50_v1b_coco': faster_rcnn_fpn_syncbn_resnet50_v1b_coco,
     'faster_rcnn_fpn_syncbn_resnest50_coco': faster_rcnn_fpn_syncbn_resnest50_coco,

--- a/gluoncv/model_zoo/rcnn/faster_rcnn/__init__.py
+++ b/gluoncv/model_zoo/rcnn/faster_rcnn/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import
 
 from .faster_rcnn import *
+from .doublehead_rcnn import *
 from .predefined_models import *
 from .rcnn_target import RCNNTargetGenerator, RCNNTargetSampler
 from .data_parallel import ForwardBackwardTask

--- a/gluoncv/model_zoo/rcnn/faster_rcnn/doublehead_rcnn.py
+++ b/gluoncv/model_zoo/rcnn/faster_rcnn/doublehead_rcnn.py
@@ -1,0 +1,644 @@
+"""
+Double Head Faster RCNN Model.
+Rethinking Classification and Localization for Object Detection.
+"""
+
+# pylint: disable=not-callable
+from __future__ import absolute_import
+
+import os
+
+import mxnet as mx
+from mxnet import autograd
+from mxnet.gluon import nn
+from mxnet.gluon.contrib.nn import SyncBatchNorm
+from mxnet.gluon.nn import BatchNorm
+from mxnet.gluon.block import HybridBlock
+
+from .rcnn_target import RCNNTargetSampler, RCNNTargetGenerator
+from ..rcnn import custom_rcnn_fpn
+from ....model_zoo.rcnn import RCNN
+from ....model_zoo.rcnn.rpn import RPN
+
+__all__ = ['FasterRCNN', 'get_doublehead_rcnn', 'custom_faster_rcnn_fpn']
+
+# Helpers
+def _conv3x3(channels, stride, in_channels):
+    return nn.Conv2D(channels, kernel_size=3, strides=stride, padding=1,
+                     use_bias=False, in_channels=in_channels)
+
+class BottleneckV1(HybridBlock):
+    r"""Bottleneck V1 from `"Deep Residual Learning for Image Recognition"
+    <http://arxiv.org/abs/1512.03385>`_ paper.
+    This is used for ResNet V1 for 50, 101, 152 layers.
+    """
+    def __init__(self, channels, stride, downsample=True, in_channels=0,
+                 last_gamma=False, norm_layer=BatchNorm, norm_kwargs=None, **kwargs):
+        super(BottleneckV1, self).__init__(**kwargs)
+        self.body = nn.HybridSequential(prefix='')
+        self.body.add(nn.Conv2D(channels // 4, kernel_size=1, strides=stride))
+        self.body.add(nn.Activation('relu'))
+        self.body.add(_conv3x3(channels // 4, 1, channels // 4))
+        self.body.add(nn.Activation('relu'))
+        self.body.add(nn.Conv2D(channels, kernel_size=1, strides=1))
+        if downsample:
+            self.downsample = nn.HybridSequential(prefix='')
+            self.downsample.add(nn.Conv2D(channels, kernel_size=1, strides=stride,
+                                          use_bias=False, in_channels=in_channels))
+        else:
+            self.downsample = None
+
+    def hybrid_forward(self, F, x):
+        residual = x
+        x = self.body(x)
+        if self.downsample:
+            residual = self.downsample(residual)
+        x = F.Activation(x + residual, act_type='relu')
+        return x
+
+class FasterRCNN(RCNN):
+    r"""Faster RCNN network.
+
+    Parameters
+    ----------
+    features : gluon.HybridBlock
+        Base feature extractor before feature pooling layer.
+    top_features : gluon.HybridBlock
+        Tail feature extractor after feature pooling layer.
+    classes : iterable of str
+        Names of categories, its length is ``num_class``.
+    box_features : gluon.HybridBlock, default is None
+        feature head for transforming shared ROI output (top_features) for box prediction.
+        If set to None, global average pooling will be used.
+    short : int, default is 600.
+        Input image short side size.
+    max_size : int, default is 1000.
+        Maximum size of input image long side.
+    min_stage : int, default is 4
+        Minimum stage NO. for FPN stages.
+    max_stage : int, default is 4
+        Maximum stage NO. for FPN stages.
+    train_patterns : str, default is None.
+        Matching pattern for trainable parameters.
+    nms_thresh : float, default is 0.3.
+        Non-maximum suppression threshold. You can specify < 0 or > 1 to disable NMS.
+    nms_topk : int, default is 400
+        Apply NMS to top k detection results, use -1 to disable so that every Detection
+        result is used in NMS.
+    roi_mode : str, default is align
+        ROI pooling mode. Currently support 'pool' and 'align'.
+    roi_size : tuple of int, length 2, default is (14, 14)
+        (height, width) of the ROI region.
+    strides : int/tuple of ints, default is 16
+        Feature map stride with respect to original image.
+        This is usually the ratio between original image size and feature map size.
+        For FPN, use a tuple of ints.
+    clip : float, default is None
+        Clip bounding box prediction to to prevent exponentiation from overflowing.
+    rpn_channel : int, default is 1024
+        number of channels used in RPN convolutional layers.
+    base_size : int
+        The width(and height) of reference anchor box.
+    scales : iterable of float, default is (8, 16, 32)
+        The areas of anchor boxes.
+        We use the following form to compute the shapes of anchors:
+
+        .. math::
+
+            width_{anchor} = size_{base} \times scale \times \sqrt{ 1 / ratio}
+            height_{anchor} = size_{base} \times scale \times \sqrt{ratio}
+
+    ratios : iterable of float, default is (0.5, 1, 2)
+        The aspect ratios of anchor boxes. We expect it to be a list or tuple.
+    alloc_size : tuple of int
+        Allocate size for the anchor boxes as (H, W).
+        Usually we generate enough anchors for large feature map, e.g. 128x128.
+        Later in inference we can have variable input sizes,
+        at which time we can crop corresponding anchors from this large
+        anchor map so we can skip re-generating anchors for each input.
+    rpn_train_pre_nms : int, default is 12000
+        Filter top proposals before NMS in training of RPN.
+    rpn_train_post_nms : int, default is 2000
+        Return top proposal results after NMS in training of RPN.
+        Will be set to rpn_train_pre_nms if it is larger than rpn_train_pre_nms.
+    rpn_test_pre_nms : int, default is 6000
+        Filter top proposals before NMS in testing of RPN.
+    rpn_test_post_nms : int, default is 300
+        Return top proposal results after NMS in testing of RPN.
+        Will be set to rpn_test_pre_nms if it is larger than rpn_test_pre_nms.
+    rpn_nms_thresh : float, default is 0.7
+        IOU threshold for NMS. It is used to remove overlapping proposals.
+    rpn_num_sample : int, default is 256
+        Number of samples for RPN targets.
+    rpn_pos_iou_thresh : float, default is 0.7
+        Anchor with IOU larger than ``pos_iou_thresh`` is regarded as positive samples.
+    rpn_neg_iou_thresh : float, default is 0.3
+        Anchor with IOU smaller than ``neg_iou_thresh`` is regarded as negative samples.
+        Anchors with IOU in between ``pos_iou_thresh`` and ``neg_iou_thresh`` are
+        ignored.
+    rpn_pos_ratio : float, default is 0.5
+        ``pos_ratio`` defines how many positive samples (``pos_ratio * num_sample``) is
+        to be sampled.
+    rpn_box_norm : array-like of size 4, default is (1., 1., 1., 1.)
+        Std value to be divided from encoded values.
+    rpn_min_size : int, default is 16
+        Proposals whose size is smaller than ``min_size`` will be discarded.
+    per_device_batch_size : int, default is 1
+        Batch size for each device during training.
+    num_sample : int, default is 128
+        Number of samples for RCNN targets.
+    pos_iou_thresh : float, default is 0.5
+        Proposal whose IOU larger than ``pos_iou_thresh`` is regarded as positive samples.
+    pos_ratio : float, default is 0.25
+        ``pos_ratio`` defines how many positive samples (``pos_ratio * num_sample``) is
+        to be sampled.
+    max_num_gt : int, default is 300
+        Maximum ground-truth number for each example. This is only an upper bound, not
+        necessarily very precise. However, using a very big number may impact the training speed.
+    additional_output : boolean, default is False
+        ``additional_output`` is only used for Mask R-CNN to get internal outputs.
+    force_nms : bool, default is False
+        Appy NMS to all categories, this is to avoid overlapping detection results from different
+        categories.
+    minimal_opset : bool, default is `False`
+        We sometimes add special operators to accelerate training/inference, however, for exporting
+        to third party compilers we want to utilize most widely used operators.
+        If `minimal_opset` is `True`, the network will use a minimal set of operators good
+        for e.g., `TVM`.
+
+    Attributes
+    ----------
+    classes : iterable of str
+        Names of categories, its length is ``num_class``.
+    num_class : int
+        Number of positive categories.
+    short : int
+        Input image short side size.
+    max_size : int
+        Maximum size of input image long side.
+    train_patterns : str
+        Matching pattern for trainable parameters.
+    nms_thresh : float
+        Non-maximum suppression threshold. You can specify < 0 or > 1 to disable NMS.
+    nms_topk : int
+        Apply NMS to top k detection results, use -1 to disable so that every Detection
+         result is used in NMS.
+    force_nms : bool
+        Appy NMS to all categories, this is to avoid overlapping detection results
+        from different categories.
+    rpn_target_generator : gluon.Block
+        Generate training targets with cls_target, box_target, and box_mask.
+    target_generator : gluon.Block
+        Generate training targets with boxes, samples, matches, gt_label and gt_box.
+
+    """
+
+    def __init__(self, features, top_features, classes, box_features=None,
+                 short=600, max_size=1000, min_stage=4, max_stage=4, train_patterns=None,
+                 nms_thresh=0.3, nms_topk=400, post_nms=100, roi_mode='align', roi_size=(14, 14), strides=16,
+                 clip=None, rpn_channel=1024, base_size=16, scales=(8, 16, 32),
+                 ratios=(0.5, 1, 2), alloc_size=(128, 128), rpn_nms_thresh=0.7,
+                 rpn_train_pre_nms=12000, rpn_train_post_nms=2000, rpn_test_pre_nms=6000,
+                 rpn_test_post_nms=300, rpn_min_size=16, per_device_batch_size=1, num_sample=128,
+                 pos_iou_thresh=0.5, pos_ratio=0.25, max_num_gt=300, additional_output=False,
+                 force_nms=False, minimal_opset=False, **kwargs):
+        super(FasterRCNN, self).__init__(
+            features=features, top_features=top_features, classes=classes,
+            box_features=box_features, short=short, max_size=max_size,
+            train_patterns=train_patterns, nms_thresh=nms_thresh, nms_topk=nms_topk, post_nms=post_nms,
+            roi_mode=roi_mode, roi_size=roi_size, strides=strides, clip=clip, force_nms=force_nms,
+            minimal_opset=minimal_opset, **kwargs)
+        if max_stage - min_stage > 1 and isinstance(strides, (int, float)):
+            raise ValueError('Multi level detected but strides is of a single number:', strides)
+
+        if rpn_train_post_nms > rpn_train_pre_nms:
+            rpn_train_post_nms = rpn_train_pre_nms
+        if rpn_test_post_nms > rpn_test_pre_nms:
+            rpn_test_post_nms = rpn_test_pre_nms
+
+        self.ashape = alloc_size[0]
+        self._min_stage = min_stage
+        self._max_stage = max_stage
+        self.num_stages = max_stage - min_stage + 1
+        if self.num_stages > 1:
+            assert len(scales) == len(strides) == self.num_stages, \
+                "The num_stages (%d) must match number of scales (%d) and strides (%d)" \
+                % (self.num_stages, len(scales), len(strides))
+        self._batch_size = per_device_batch_size
+        self._num_sample = num_sample
+        self._rpn_test_post_nms = rpn_test_post_nms
+        if minimal_opset:
+            self._target_generator = None
+        else:
+            self._target_generator = lambda: RCNNTargetGenerator(self.num_class,
+                                                                 int(num_sample * pos_ratio),
+                                                                 self._batch_size)
+
+        self._additional_output = additional_output
+        with self.name_scope():
+            self.rpn = RPN(
+                channels=rpn_channel, strides=strides, base_size=base_size,
+                scales=scales, ratios=ratios, alloc_size=alloc_size,
+                clip=clip, nms_thresh=rpn_nms_thresh, train_pre_nms=rpn_train_pre_nms,
+                train_post_nms=rpn_train_post_nms, test_pre_nms=rpn_test_pre_nms,
+                test_post_nms=rpn_test_post_nms, min_size=rpn_min_size,
+                multi_level=self.num_stages > 1, per_level_nms=False,
+                minimal_opset=minimal_opset)
+            self.sampler = RCNNTargetSampler(num_image=self._batch_size,
+                                             num_proposal=rpn_train_post_nms, num_sample=num_sample,
+                                             pos_iou_thresh=pos_iou_thresh, pos_ratio=pos_ratio,
+                                             max_num_gt=max_num_gt)
+            # double head branch with class and box
+            self.class_features = nn.HybridSequential(prefix='double_fc_')
+            with self.class_features.name_scope():
+                for _ in range(2):
+                    self.class_features.add(nn.Dense(1024, weight_initializer=mx.init.Normal(0.01)))
+                    self.class_features.add(nn.Activation('relu'))
+
+            self.newbox_features = nn.HybridSequential(prefix='double_')
+            with self.newbox_features.name_scope():
+                for _ in range(2):
+                    self.newbox_features.add(BottleneckV1(channels=1024, stride=1))
+
+    @property
+    def target_generator(self):
+        """Returns stored target generator
+
+        Returns
+        -------
+        mxnet.gluon.HybridBlock
+            The RCNN target generator
+
+        """
+        if self._target_generator is None:
+            raise ValueError("`minimal_opset` enabled, target generator is not available")
+        if not isinstance(self._target_generator, mx.gluon.Block):
+            self._target_generator = self._target_generator()
+            self._target_generator.initialize()
+        return self._target_generator
+
+    def reset_class(self, classes, reuse_weights=None):
+        """Reset class categories and class predictors.
+
+        Parameters
+        ----------
+        classes : iterable of str
+            The new categories. ['apple', 'orange'] for example.
+        reuse_weights : dict
+            A {new_integer : old_integer} or mapping dict or {new_name : old_name} mapping dict,
+            or a list of [name0, name1,...] if class names don't change.
+            This allows the new predictor to reuse the
+            previously trained weights specified.
+
+        Example
+        -------
+        >>> net = gluoncv.model_zoo.get_model('faster_rcnn_resnet50_v1b_coco', pretrained=True)
+        >>> # use direct name to name mapping to reuse weights
+        >>> net.reset_class(classes=['person'], reuse_weights={'person':'person'})
+        >>> # or use interger mapping, person is the 14th category in VOC
+        >>> net.reset_class(classes=['person'], reuse_weights={0:14})
+        >>> # you can even mix them
+        >>> net.reset_class(classes=['person'], reuse_weights={'person':14})
+        >>> # or use a list of string if class name don't change
+        >>> net.reset_class(classes=['person'], reuse_weights=['person'])
+
+        """
+        super(FasterRCNN, self).reset_class(classes, reuse_weights)
+        self._target_generator = lambda: RCNNTargetGenerator(self.num_class, self.sampler._max_pos,
+                                                             self._batch_size)
+
+    def _pyramid_roi_feats(self, F, features, rpn_rois, roi_size, strides, roi_mode='align',
+                           roi_canonical_scale=224.0, sampling_ratio=2, eps=1e-6):
+        """Assign rpn_rois to specific FPN layers according to its area
+           and then perform `ROIPooling` or `ROIAlign` to generate final
+           region proposals aggregated features.
+        Parameters
+        ----------
+        features : list of mx.ndarray or mx.symbol
+            Features extracted from FPN base network
+        rpn_rois : mx.ndarray or mx.symbol
+            (N, 5) with [[batch_index, x1, y1, x2, y2], ...] like
+        roi_size : tuple
+            The size of each roi with regard to ROI-Wise operation
+            each region proposal will be roi_size spatial shape.
+        strides : tuple e.g. [4, 8, 16, 32]
+            Define the gap between each feature in feature map in the original image space.
+        roi_mode : str, default is align
+            ROI pooling mode. Currently support 'pool' and 'align'.
+        roi_canonical_scale : float, default is 224.0
+            Hyperparameters for the RoI-to-FPN level mapping heuristic.
+        sampling_ratio : int, default is 2
+            number of inputs samples to take for each output
+            sample. 0 to take samples densely.
+        Returns
+        -------
+        Pooled roi features aggregated according to its roi_level
+        """
+        max_stage = self._max_stage
+        if self._max_stage > 5:  # do not use p6 for RCNN
+            max_stage = self._max_stage - 1
+        _, x1, y1, x2, y2 = F.split(rpn_rois, axis=-1, num_outputs=5)
+        h = y2 - y1 + 1
+        w = x2 - x1 + 1
+        roi_level = F.floor(4 + F.log2(F.sqrt(w * h) / roi_canonical_scale + eps))
+        roi_level = F.squeeze(F.clip(roi_level, self._min_stage, max_stage))
+        # [2,2,..,3,3,...,4,4,...,5,5,...] ``Prohibit swap order here``
+        # roi_level_sorted_args = F.argsort(roi_level, is_ascend=True)
+        # roi_level = F.sort(roi_level, is_ascend=True)
+        # rpn_rois = F.take(rpn_rois, roi_level_sorted_args, axis=0)
+        pooled_roi_feats = []
+        for i, l in enumerate(range(self._min_stage, max_stage + 1)):
+            if roi_mode == 'pool':
+                # Pool features with all rois first, and then set invalid pooled features to zero,
+                # at last ele-wise add together to aggregate all features.
+                pooled_feature = F.ROIPooling(features[i], rpn_rois, roi_size, 1. / strides[i])
+                pooled_feature = F.where(roi_level == l, pooled_feature,
+                                         F.zeros_like(pooled_feature))
+            elif roi_mode == 'align':
+                if 'box_encode' in F.contrib.__dict__ and 'box_decode' in F.contrib.__dict__:
+                    # TODO(jerryzcn): clean this up for once mx 1.6 is released.
+                    masked_rpn_rois = F.where(roi_level == l, rpn_rois, F.ones_like(rpn_rois) * -1.)
+                    pooled_feature = F.contrib.ROIAlign(features[i], masked_rpn_rois, roi_size,
+                                                        1. / strides[i],
+                                                        sample_ratio=sampling_ratio)
+                else:
+                    pooled_feature = F.contrib.ROIAlign(features[i], rpn_rois, roi_size,
+                                                        1. / strides[i],
+                                                        sample_ratio=sampling_ratio)
+                    pooled_feature = F.where(roi_level == l, pooled_feature,
+                                             F.zeros_like(pooled_feature))
+            else:
+                raise ValueError("Invalid roi mode: {}".format(roi_mode))
+            pooled_roi_feats.append(pooled_feature)
+        # Ele-wise add to aggregate all pooled features
+        pooled_roi_feats = F.ElementWiseSum(*pooled_roi_feats)
+        # Sort all pooled features by asceding order
+        # [2,2,..,3,3,...,4,4,...,5,5,...]
+        # pooled_roi_feats = F.take(pooled_roi_feats, roi_level_sorted_args)
+        # pooled roi feats (B*N, C, 7, 7), N = N2 + N3 + N4 + N5 = num_roi, C=256 in ori paper
+        return pooled_roi_feats
+
+    # pylint: disable=arguments-differ
+    def hybrid_forward(self, F, x, gt_box=None, gt_label=None):
+        """Forward Faster-RCNN network.
+
+        The behavior during training and inference is different.
+
+        Parameters
+        ----------
+        x : mxnet.nd.NDArray or mxnet.symbol
+            The network input tensor.
+        gt_box : type, only required during training
+            The ground-truth bbox tensor with shape (B, N, 4).
+        gt_label : type, only required during training
+            The ground-truth label tensor with shape (B, 1, 4).
+
+        Returns
+        -------
+        (ids, scores, bboxes)
+            During inference, returns final class id, confidence scores, bounding
+            boxes.
+
+        """
+
+        def _split(x, axis, num_outputs, squeeze_axis):
+            x = F.split(x, axis=axis, num_outputs=num_outputs, squeeze_axis=squeeze_axis)
+            if isinstance(x, list):
+                return x
+            else:
+                return [x]
+
+        feat = self.features(x)
+        if not isinstance(feat, (list, tuple)):
+            feat = [feat]
+
+        # RPN proposals
+        if autograd.is_training():
+            rpn_score, rpn_box, raw_rpn_score, raw_rpn_box, anchors = \
+                self.rpn(F.zeros_like(x), *feat)
+            rpn_box, samples, matches = self.sampler(rpn_box, rpn_score, gt_box)
+        else:
+            _, rpn_box = self.rpn(F.zeros_like(x), *feat)
+
+        # create batchid for roi
+        num_roi = self._num_sample if autograd.is_training() else self._rpn_test_post_nms
+        batch_size = self._batch_size if autograd.is_training() else 1
+        with autograd.pause():
+            roi_batchid = F.arange(0, batch_size)
+            roi_batchid = F.repeat(roi_batchid, num_roi)
+            # remove batch dim because ROIPooling require 2d input
+            rpn_roi = F.concat(*[roi_batchid.reshape((-1, 1)), rpn_box.reshape((-1, 4))], dim=-1)
+            rpn_roi = F.stop_gradient(rpn_roi)
+
+        if self.num_stages > 1:
+            # using FPN
+            pooled_feat = self._pyramid_roi_feats(F, feat, rpn_roi, self._roi_size,
+                                                  self._strides, roi_mode=self._roi_mode)
+        else:
+            # ROI features
+            if self._roi_mode == 'pool':
+                pooled_feat = F.ROIPooling(feat[0], rpn_roi, self._roi_size, 1. / self._strides)
+            elif self._roi_mode == 'align':
+                pooled_feat = F.contrib.ROIAlign(feat[0], rpn_roi, self._roi_size,
+                                                 1. / self._strides, sample_ratio=2)
+            else:
+                raise ValueError("Invalid roi mode: {}".format(self._roi_mode))
+
+        # RCNN prediction
+        if self.top_features is not None:
+            top_feat = self.top_features(pooled_feat)
+        else:
+            top_feat = pooled_feat
+        if self.box_features is None:
+            cls_feat = self.class_features(top_feat)
+            box_feat = self.newbox_features(top_feat)   # 512* 1024 * 7 * 7
+            box_feat = F.contrib.AdaptiveAvgPooling2D(box_feat, output_size=1)
+            # box_feat = F.contrib.AdaptiveAvgPooling2D(top_feat, output_size=1)
+        else:
+            box_feat = self.box_features(top_feat)
+        cls_pred = self.class_predictor(cls_feat)
+        # cls_pred (B * N, C) -> (B, N, C)
+        cls_pred = cls_pred.reshape((batch_size, num_roi, self.num_class + 1))
+
+        # no need to convert bounding boxes in training, just return
+        if autograd.is_training():
+            cls_targets, box_targets, box_masks, indices = \
+                self.target_generator(rpn_box, samples, matches, gt_label, gt_box)
+            box_feat = F.reshape(box_feat.expand_dims(0), (batch_size, -1, 0))
+            box_pred = self.box_predictor(F.concat(
+                *[F.take(F.slice_axis(box_feat, axis=0, begin=i, end=i + 1).squeeze(),
+                         F.slice_axis(indices, axis=0, begin=i, end=i + 1).squeeze())
+                  for i in range(batch_size)], dim=0))
+            # box_pred (B * N, C * 4) -> (B, N, C, 4)
+            box_pred = box_pred.reshape((batch_size, -1, self.num_class, 4))
+            if self._additional_output:
+                return (cls_pred, box_pred, rpn_box, samples, matches, raw_rpn_score, raw_rpn_box,
+                        anchors, cls_targets, box_targets, box_masks, top_feat, indices)
+            return (cls_pred, box_pred, rpn_box, samples, matches, raw_rpn_score, raw_rpn_box,
+                    anchors, cls_targets, box_targets, box_masks, indices)
+
+        box_pred = self.box_predictor(box_feat)
+        # box_pred (B * N, C * 4) -> (B, N, C, 4)
+        box_pred = box_pred.reshape((batch_size, num_roi, self.num_class, 4))
+        # cls_ids (B, N, C), scores (B, N, C)
+        cls_ids, scores = self.cls_decoder(F.softmax(cls_pred, axis=-1))
+        # cls_ids, scores (B, N, C) -> (B, C, N) -> (B, C, N, 1)
+        cls_ids = cls_ids.transpose((0, 2, 1)).reshape((0, 0, 0, 1))
+        scores = scores.transpose((0, 2, 1)).reshape((0, 0, 0, 1))
+        # box_pred (B, N, C, 4) -> (B, C, N, 4)
+        box_pred = box_pred.transpose((0, 2, 1, 3))
+
+        # rpn_boxes (B, N, 4) -> B * (1, N, 4)
+        rpn_boxes = _split(rpn_box, axis=0, num_outputs=batch_size, squeeze_axis=False)
+        # cls_ids, scores (B, C, N, 1) -> B * (C, N, 1)
+        cls_ids = _split(cls_ids, axis=0, num_outputs=batch_size, squeeze_axis=True)
+        scores = _split(scores, axis=0, num_outputs=batch_size, squeeze_axis=True)
+        # box_preds (B, C, N, 4) -> B * (C, N, 4)
+        box_preds = _split(box_pred, axis=0, num_outputs=batch_size, squeeze_axis=True)
+
+        # per batch predict, nms, each class has topk outputs
+        results = []
+        for rpn_box, cls_id, score, box_pred in zip(rpn_boxes, cls_ids, scores, box_preds):
+            # box_pred (C, N, 4) rpn_box (1, N, 4) -> bbox (C, N, 4)
+            bbox = self.box_decoder(box_pred, rpn_box)
+            # res (C, N, 6)
+            res = F.concat(*[cls_id, score, bbox], dim=-1)
+            if self.force_nms:
+                # res (1, C*N, 6), to allow cross-catogory suppression
+                res = res.reshape((1, -1, 0))
+            # res (C, self.nms_topk, 6)
+            res = F.contrib.box_nms(
+                res, overlap_thresh=self.nms_thresh, topk=self.nms_topk, valid_thresh=0.0001,
+                id_index=0, score_index=1, coord_start=2, force_suppress=self.force_nms)
+            # res (C * self.nms_topk, 6)
+            res = res.reshape((-3, 0))
+            results.append(res)
+
+        # result B * (C * topk, 6) -> (B, C * topk, 6)
+        result = F.stack(*results, axis=0)
+        ids = F.slice_axis(result, axis=-1, begin=0, end=1)
+        scores = F.slice_axis(result, axis=-1, begin=1, end=2)
+        bboxes = F.slice_axis(result, axis=-1, begin=2, end=6)
+        if self._additional_output:
+            return ids, scores, bboxes, feat
+        return ids, scores, bboxes
+
+
+def get_doublehead_rcnn(name, dataset, pretrained=False, ctx=mx.cpu(),
+                    root=os.path.join('~', '.mxnet', 'models'), **kwargs):
+    r"""Utility function to return faster rcnn networks.
+
+    Parameters
+    ----------
+    name : str
+        Model name.
+    dataset : str
+        The name of dataset.
+    pretrained : bool or str
+        Boolean value controls whether to load the default pretrained weights for model.
+        String value represents the hashtag for a certain version of pretrained weights.
+    ctx : mxnet.Context
+        Context such as mx.cpu(), mx.gpu(0).
+    root : str
+        Model weights storing path.
+
+    Returns
+    -------
+    mxnet.gluon.HybridBlock
+        The Faster-RCNN network.
+
+    """
+    net = FasterRCNN(minimal_opset=pretrained, **kwargs)
+    if pretrained:
+        from ....model_zoo.model_store import get_model_file
+        full_name = '_'.join(('faster_rcnn', name, dataset))
+        net.load_parameters(get_model_file(full_name, tag=pretrained, root=root), ctx=ctx,
+                            ignore_extra=True, allow_missing=True)
+        net.collect_params(select='normalizedperclassboxcenterencoder*').initialize()
+    else:
+        for v in net.collect_params().values():
+            try:
+                v.reset_ctx(ctx)
+            except ValueError:
+                pass
+    return net
+
+
+def custom_faster_rcnn_fpn(classes, transfer=None, dataset='custom', pretrained_base=True,
+                           base_network_name='resnet18_v1b', norm_layer=nn.BatchNorm,
+                           norm_kwargs=None, sym_norm_layer=None, sym_norm_kwargs=None,
+                           num_fpn_filters=256, num_box_head_conv=4, num_box_head_conv_filters=256,
+                           num_box_head_dense_filters=1024, **kwargs):
+    r"""Faster RCNN model with resnet base network and FPN on custom dataset.
+
+    Parameters
+    ----------
+    classes : iterable of str
+        Names of custom foreground classes. `len(classes)` is the number of foreground classes.
+    transfer : str or None
+        Dataset from witch to transfer from. If not `None`, will try to reuse pre-trained weights
+        from faster RCNN networks trained on other dataset, specified by the parameter.
+    dataset : str, default 'custom'
+        Dataset name attached to the network name
+    pretrained_base : bool or str
+        Boolean value controls whether to load the default pretrained weights for model.
+        String value represents the hashtag for a certain version of pretrained weights.
+    base_network_name : str, default 'resnet18_v1b'
+        base network for mask RCNN. Currently support: 'resnet18_v1b', 'resnet50_v1b',
+        and 'resnet101_v1d'
+    norm_layer : nn.HybridBlock, default nn.BatchNorm
+        Gluon normalization layer to use. Default is frozen batch normalization layer.
+    norm_kwargs : dict
+        Keyword arguments for gluon normalization layer
+    sym_norm_layer : nn.SymbolBlock, default `None`
+        Symbol normalization layer to use in FPN. This is due to FPN being implemented using
+        SymbolBlock. Default is `None`, meaning no normalization layer will be used in FPN.
+    sym_norm_kwargs : dict
+        Keyword arguments for symbol normalization layer used in FPN.
+    num_fpn_filters : int, default 256
+        Number of filters for FPN output layers.
+    num_box_head_conv : int, default 4
+        Number of convolution layers to use in box head if batch normalization is not frozen.
+    num_box_head_conv_filters : int, default 256
+        Number of filters for convolution layers in box head.
+        Only applicable if batch normalization is not frozen.
+    num_box_head_dense_filters : int, default 1024
+        Number of hidden units for the last fully connected layer in box head.
+    ctx : Context, default CPU
+        The context in which to load the pretrained weights.
+    root : str, default '~/.mxnet/models'
+        Location for keeping the model parameters.
+
+    Returns
+    -------
+    mxnet.gluon.HybridBlock
+        Hybrid faster RCNN network.
+    """
+    use_global_stats = norm_layer is nn.BatchNorm
+    train_patterns = '|'.join(['.*dense', '.*rpn', '.*down(2|3|4)_conv', '.*layers(2|3|4)_conv',
+                               'P']) if use_global_stats \
+        else '(?!.*moving)'  # excluding symbol bn moving mean and var'''
+
+    if transfer is None:
+        features, top_features, box_features = \
+            custom_rcnn_fpn(pretrained_base, base_network_name, norm_layer, norm_kwargs,
+                            sym_norm_layer, sym_norm_kwargs, num_fpn_filters, num_box_head_conv,
+                            num_box_head_conv_filters, num_box_head_dense_filters)
+        return get_faster_rcnn(
+            name='fpn_' + base_network_name, dataset=dataset, features=features,
+            top_features=top_features, classes=classes, box_features=box_features,
+            train_patterns=train_patterns, **kwargs)
+    else:
+        from ....model_zoo import get_model
+        module_list = ['fpn']
+        num_devices = 0
+        if norm_layer is SyncBatchNorm:
+            module_list.append('syncbn')
+            num_devices = norm_kwargs['num_devices']
+        net = get_model(
+            '_'.join(['faster_rcnn'] + module_list + [base_network_name, str(transfer)]),
+            pretrained=True, per_device_batch_size=kwargs['per_device_batch_size'],
+            num_devices=num_devices)
+        reuse_classes = [x for x in classes if x in net.classes]
+        net.reset_class(classes, reuse_weights=reuse_classes)
+    return net

--- a/gluoncv/model_zoo/rcnn/faster_rcnn/doublehead_rcnn.py
+++ b/gluoncv/model_zoo/rcnn/faster_rcnn/doublehead_rcnn.py
@@ -1,14 +1,11 @@
 """
 Double Head Faster RCNN Model. https://arxiv.org/abs/1904.06493
-{
- title={Rethinking Classification and Localization for Object Detection},
- author={Wu, Yue and Chen, Yinpeng and Yuan, Lu and Liu, Zicheng and Wang, Lijuan and Li, Hongzhi and Fu, Yun},
- booktitle={Proceedings of the IEEE Conference on Computer Vision and Pattern Recognition},
- year={2020}
-}
-Autuor. SSK. 
+title={Rethinking Classification and Localization for Object Detection},
+author={Wu, Yue and Chen, Yinpeng and Yuan},
+booktitle={Proceedings of the IEEE Conference on Computer Vision and Pattern Recognition},
+year={2020}
+The gluoncv verison author={SSK}, 
 """
-
 # pylint: disable=not-callable
 from __future__ import absolute_import
 

--- a/gluoncv/model_zoo/rcnn/faster_rcnn/doublehead_rcnn.py
+++ b/gluoncv/model_zoo/rcnn/faster_rcnn/doublehead_rcnn.py
@@ -1,8 +1,8 @@
 # pylint: disable=not-callable
 """
 Double Head Faster RCNN Model. https://arxiv.org/abs/1904.06493
-title={Rethinking Classification and Localization for Object Detection},
-author={Wu, Yue and Chen, Yinpeng and Yuan},
+title={Rethinking Classification and Localization for Object Detection}
+author={Wu, Yue and Chen, Yinpeng and Yuan}
 booktitle={Proceedings of the IEEE Conference on Computer Vision and Pattern Recognition}
 year={2020}
 The gluoncv verison author={SSK}

--- a/gluoncv/model_zoo/rcnn/faster_rcnn/doublehead_rcnn.py
+++ b/gluoncv/model_zoo/rcnn/faster_rcnn/doublehead_rcnn.py
@@ -622,7 +622,7 @@ def custom_faster_rcnn_fpn(classes, transfer=None, dataset='custom', pretrained_
             custom_rcnn_fpn(pretrained_base, base_network_name, norm_layer, norm_kwargs,
                             sym_norm_layer, sym_norm_kwargs, num_fpn_filters, num_box_head_conv,
                             num_box_head_conv_filters, num_box_head_dense_filters)
-        return get_faster_rcnn(
+        return get_doublehead_rcnn(
             name='fpn_' + base_network_name, dataset=dataset, features=features,
             top_features=top_features, classes=classes, box_features=box_features,
             train_patterns=train_patterns, **kwargs)

--- a/gluoncv/model_zoo/rcnn/faster_rcnn/doublehead_rcnn.py
+++ b/gluoncv/model_zoo/rcnn/faster_rcnn/doublehead_rcnn.py
@@ -1,6 +1,12 @@
 """
-Double Head Faster RCNN Model.
-Rethinking Classification and Localization for Object Detection.
+Double Head Faster RCNN Model. https://arxiv.org/abs/1904.06493
+{
+ title={Rethinking Classification and Localization for Object Detection},
+ author={Wu, Yue and Chen, Yinpeng and Yuan, Lu and Liu, Zicheng and Wang, Lijuan and Li, Hongzhi and Fu, Yun},
+ booktitle={Proceedings of the IEEE Conference on Computer Vision and Pattern Recognition},
+ year={2020}
+}
+Autuor. SSK. 
 """
 
 # pylint: disable=not-callable

--- a/gluoncv/model_zoo/rcnn/faster_rcnn/doublehead_rcnn.py
+++ b/gluoncv/model_zoo/rcnn/faster_rcnn/doublehead_rcnn.py
@@ -1,12 +1,12 @@
+# pylint: disable=not-callable
 """
 Double Head Faster RCNN Model. https://arxiv.org/abs/1904.06493
 title={Rethinking Classification and Localization for Object Detection},
 author={Wu, Yue and Chen, Yinpeng and Yuan},
-booktitle={Proceedings of the IEEE Conference on Computer Vision and Pattern Recognition},
+booktitle={Proceedings of the IEEE Conference on Computer Vision and Pattern Recognition}
 year={2020}
-The gluoncv verison author={SSK}, 
+The gluoncv verison author={SSK}
 """
-# pylint: disable=not-callable
 from __future__ import absolute_import
 
 import os

--- a/scripts/detection/faster_rcnn/train_doublehead_rcnn.py
+++ b/scripts/detection/faster_rcnn/train_doublehead_rcnn.py
@@ -1,0 +1,667 @@
+"""Train Doublehead-RCNN end to end."""
+import argparse
+import os
+
+# disable autotune
+os.environ['MXNET_CUDNN_AUTOTUNE_DEFAULT'] = '0'
+os.environ['MXNET_GPU_MEM_POOL_TYPE'] = 'Round'
+os.environ['MXNET_GPU_MEM_POOL_ROUND_LINEAR_CUTOFF'] = '26'
+os.environ['MXNET_EXEC_BULK_EXEC_MAX_NODE_TRAIN_FWD'] = '999'
+os.environ['MXNET_EXEC_BULK_EXEC_MAX_NODE_TRAIN_BWD'] = '25'
+os.environ['MXNET_GPU_COPY_NTHREADS'] = '1'
+os.environ['MXNET_OPTIMIZER_AGGREGATION_SIZE'] = '54'
+
+import logging
+import time
+import numpy as np
+import mxnet as mx
+from mxnet import gluon
+from mxnet.contrib import amp
+import gluoncv as gcv
+
+gcv.utils.check_version('0.7.0')
+from gluoncv import data as gdata
+from gluoncv import utils as gutils
+from gluoncv.model_zoo import get_model
+from gluoncv.data.batchify import FasterRCNNTrainBatchify, Tuple, Append
+from gluoncv.data.transforms.presets.rcnn import FasterRCNNDefaultTrainTransform, \
+    FasterRCNNDefaultValTransform
+from gluoncv.utils.metrics.voc_detection import VOC07MApMetric
+from gluoncv.utils.metrics.coco_detection import COCODetectionMetric
+from gluoncv.utils.parallel import Parallel
+from gluoncv.utils.metrics.rcnn import RPNAccMetric, RPNL1LossMetric, RCNNAccMetric, \
+    RCNNL1LossMetric
+from gluoncv.model_zoo.rcnn.faster_rcnn.data_parallel import ForwardBackwardTask
+
+try:
+    import horovod.mxnet as hvd
+except ImportError:
+    hvd = None
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='Train Faster-RCNN networks e2e.')
+    parser.add_argument('--network', type=str, default='resnet50_v1b',
+                        choices=['resnet18_v1b', 'resnet50_v1b', 'resnet101_v1d',
+                                 'resnest50', 'resnest101', 'resnest269'],
+                        help="Base network name which serves as feature extraction base.")
+    parser.add_argument('--dataset', type=str, default='voc',
+                        help='Training dataset. Now support voc and coco.')
+    parser.add_argument('--num-workers', '-j', dest='num_workers', type=int,
+                        default=4, help='Number of data workers, you can use larger '
+                                        'number to accelerate data loading, '
+                                        'if your CPU and GPUs are powerful.')
+    parser.add_argument('--batch-size', type=int, default=1, help='Training mini-batch size.')
+    parser.add_argument('--gpus', type=str, default='0',
+                        help='Training with GPUs, you can specify 1,3 for example.')
+    parser.add_argument('--epochs', type=str, default='',
+                        help='Training epochs.')
+    parser.add_argument('--resume', type=str, default='',
+                        help='Resume from previously saved parameters if not None. '
+                             'For example, you can resume from ./faster_rcnn_xxx_0123.params')
+    parser.add_argument('--start-epoch', type=int, default=0,
+                        help='Starting epoch for resuming, default is 0 for new training.'
+                             'You can specify it to 100 for example to start from 100 epoch.')
+    parser.add_argument('--lr', type=str, default='',
+                        help='Learning rate, default is 0.001 for voc single gpu training.')
+    parser.add_argument('--lr-decay', type=float, default=0.1,
+                        help='decay rate of learning rate. default is 0.1.')
+    parser.add_argument('--lr-decay-epoch', type=str, default='',
+                        help='epochs at which learning rate decays. default is 14,20 for voc.')
+    parser.add_argument('--lr-warmup', type=str, default='',
+                        help='warmup iterations to adjust learning rate, default is 0 for voc.')
+    parser.add_argument('--lr-warmup-factor', type=float, default=1. / 3.,
+                        help='warmup factor of base lr.')
+    parser.add_argument('--momentum', type=float, default=0.9,
+                        help='SGD momentum, default is 0.9')
+    parser.add_argument('--wd', type=str, default='',
+                        help='Weight decay, default is 5e-4 for voc')
+    parser.add_argument('--log-interval', type=int, default=100,
+                        help='Logging mini-batch interval. Default is 100.')
+    parser.add_argument('--save-prefix', type=str, default='',
+                        help='Saving parameter prefix')
+    parser.add_argument('--save-interval', type=int, default=1,
+                        help='Saving parameters epoch interval, best model will always be saved.')
+    parser.add_argument('--val-interval', type=int, default=1,
+                        help='Epoch interval for validation, increase the number will reduce the '
+                             'training time if validation is slow.')
+    parser.add_argument('--seed', type=int, default=233,
+                        help='Random seed to be fixed.')
+    parser.add_argument('--verbose', dest='verbose', action='store_true',
+                        help='Print helpful debugging info once set.')
+    parser.add_argument('--mixup', action='store_true', help='Use mixup training.')
+    parser.add_argument('--no-mixup-epochs', type=int, default=20,
+                        help='Disable mixup training if enabled in the last N epochs.')
+
+    # Norm layer options
+    parser.add_argument('--norm-layer', type=str, default=None, choices=[None, 'syncbn'],
+                        help='Type of normalization layer to use. '
+                             'If set to None, backbone normalization layer will be frozen,'
+                             ' and no normalization layer will be used in R-CNN. '
+                             'Currently supports \'syncbn\', and None, default is None.'
+                             'Note that if horovod is enabled, sync bn will not work correctly.')
+
+    # Loss options
+    parser.add_argument('--rpn-smoothl1-rho', type=float, default=1. / 9.,
+                        help='RPN box regression transition point from L1 to L2 loss.'
+                             'Set to 0.0 to make the loss simply L1.')
+    parser.add_argument('--rcnn-smoothl1-rho', type=float, default=1.,
+                        help='RCNN box regression transition point from L1 to L2 loss.'
+                             'Set to 0.0 to make the loss simply L1.')
+
+    # FPN options
+    parser.add_argument('--use-fpn', action='store_true',
+                        help='Whether to use feature pyramid network.')
+
+    # Performance options
+    parser.add_argument('--disable-hybridization', action='store_true',
+                        help='Whether to disable hybridize the model. '
+                             'Memory usage and speed will decrese.')
+    parser.add_argument('--static-alloc', action='store_true',
+                        help='Whether to use static memory allocation. Memory usage will increase.')
+    parser.add_argument('--amp', action='store_true',
+                        help='Use MXNet AMP for mixed precision training.')
+    parser.add_argument('--horovod', action='store_true',
+                        help='Use MXNet Horovod for distributed training. Must be run with OpenMPI. '
+                             '--gpus is ignored when using --horovod.')
+    parser.add_argument('--executor-threads', type=int, default=1,
+                        help='Number of threads for executor for scheduling ops. '
+                             'More threads may incur higher GPU memory footprint, '
+                             'but may speed up throughput. Note that when horovod is used, '
+                             'it is set to 1.')
+    parser.add_argument('--kv-store', type=str, default='nccl',
+                        help='KV store options. local, device, nccl, dist_sync, dist_device_sync, '
+                             'dist_async are available.')
+
+    # Advanced options. Expert Only!! Currently non-FPN model is not supported!!
+    # Default setting is for MS-COCO.
+    # The following options are only used if --custom-model is enabled
+    subparsers = parser.add_subparsers(dest='custom_model')
+    custom_model_parser = subparsers.add_parser(
+        'custom-model',
+        help='Use custom Faster R-CNN w/ FPN model. This is for expert only!'
+             ' You can modify model internal parameters here. Once enabled, '
+             'custom model options become available.')
+    custom_model_parser.add_argument(
+        '--no-pretrained-base', action='store_true', help='Disable pretrained base network.')
+    custom_model_parser.add_argument(
+        '--num-fpn-filters', type=int, default=256, help='Number of filters in FPN output layers.')
+    custom_model_parser.add_argument(
+        '--num-box-head-conv', type=int, default=4,
+        help='Number of convolution layers to use in box head if '
+             'batch normalization is not frozen.')
+    custom_model_parser.add_argument(
+        '--num-box-head-conv-filters', type=int, default=256,
+        help='Number of filters for convolution layers in box head.'
+             ' Only applicable if batch normalization is not frozen.')
+    custom_model_parser.add_argument(
+        '--num_box_head_dense_filters', type=int, default=1024,
+        help='Number of hidden units for the last fully connected layer in '
+             'box head.')
+    custom_model_parser.add_argument(
+        '--image-short', type=str, default='800',
+        help='Short side of the image. Pass a tuple to enable random scale augmentation.')
+    custom_model_parser.add_argument(
+        '--image-max-size', type=int, default=1333,
+        help='Max size of the longer side of the image.')
+    custom_model_parser.add_argument(
+        '--nms-thresh', type=float, default=0.5,
+        help='Non-maximum suppression threshold for R-CNN. '
+             'You can specify < 0 or > 1 to disable NMS.')
+    custom_model_parser.add_argument(
+        '--nms-topk', type=int, default=-1,
+        help='Apply NMS to top k detection results in R-CNN. '
+             'Set to -1 to disable so that every Detection result is used in NMS.')
+    custom_model_parser.add_argument(
+        '--post-nms', type=int, default=-1,
+        help='Only return top `post_nms` detection results, the rest is discarded.'
+             ' Set to -1 to return all detections.')
+    custom_model_parser.add_argument(
+        '--roi-mode', type=str, default='align', choices=['align', 'pool'],
+        help='ROI pooling mode. Currently support \'pool\' and \'align\'.')
+    custom_model_parser.add_argument(
+        '--roi-size', type=str, default='7,7',
+        help='The output spatial size of ROI layer. eg. ROIAlign, ROIPooling')
+    custom_model_parser.add_argument(
+        '--strides', type=str, default='4,8,16,32,64',
+        help='Feature map stride with respect to original image. '
+             'This is usually the ratio between original image size and '
+             'feature map size. Since the custom model uses FPN, it is a list of ints')
+    custom_model_parser.add_argument(
+        '--clip', type=float, default=4.14,
+        help='Clip bounding box transformation predictions '
+             'to prevent exponentiation from overflowing')
+    custom_model_parser.add_argument(
+        '--rpn-channel', type=int, default=256,
+        help='Number of channels used in RPN convolution layers.')
+    custom_model_parser.add_argument(
+        '--anchor-base-size', type=int, default=16,
+        help='The width(and height) of reference anchor box.')
+    custom_model_parser.add_argument(
+        '--anchor-aspect-ratio', type=str, default='0.5,1,2',
+        help='The aspect ratios of anchor boxes.')
+    custom_model_parser.add_argument(
+        '--anchor-scales', type=str, default='2,4,8,16,32',
+        help='The scales of anchor boxes with respect to base size. '
+             'We use the following form to compute the shapes of anchors: '
+             'anchor_width = base_size * scale * sqrt(1 / ratio)'
+             'anchor_height = base_size * scale * sqrt(ratio)')
+    custom_model_parser.add_argument(
+        '--anchor-alloc-size', type=str, default='384,384',
+        help='Allocate size for the anchor boxes as (H, W). '
+             'We generate enough anchors for large feature map, e.g. 384x384. '
+             'During inference we can have variable input sizes, '
+             'at which time we can crop corresponding anchors from this large '
+             'anchor map so we can skip re-generating anchors for each input. ')
+    custom_model_parser.add_argument(
+        '--rpn-nms-thresh', type=float, default='0.7',
+        help='Non-maximum suppression threshold for RPN.')
+    custom_model_parser.add_argument(
+        '--rpn-train-pre-nms', type=int, default=12000,
+        help='Filter top proposals before NMS in RPN training.')
+    custom_model_parser.add_argument(
+        '--rpn-train-post-nms', type=int, default=2000,
+        help='Return top proposal results after NMS in RPN training. '
+             'Will be set to rpn_train_pre_nms if it is larger than '
+             'rpn_train_pre_nms.')
+    custom_model_parser.add_argument(
+        '--rpn-test-pre-nms', type=int, default=6000,
+        help='Filter top proposals before NMS in RPN testing.')
+    custom_model_parser.add_argument(
+        '--rpn-test-post-nms', type=int, default=1000,
+        help='Return top proposal results after NMS in RPN testing. '
+             'Will be set to rpn_test_pre_nms if it is larger than rpn_test_pre_nms.')
+    custom_model_parser.add_argument(
+        '--rpn-min-size', type=int, default=1,
+        help='Proposals whose size is smaller than ``min_size`` will be discarded.')
+    custom_model_parser.add_argument(
+        '--rcnn-num-samples', type=int, default=512, help='Number of samples for RCNN training.')
+    custom_model_parser.add_argument(
+        '--rcnn-pos-iou-thresh', type=float, default=0.5,
+        help='Proposal whose IOU larger than ``pos_iou_thresh`` is '
+             'regarded as positive samples for R-CNN.')
+    custom_model_parser.add_argument(
+        '--rcnn-pos-ratio', type=float, default=0.25,
+        help='``pos_ratio`` defines how many positive samples '
+             '(``pos_ratio * num_sample``) is to be sampled for R-CNN.')
+    custom_model_parser.add_argument(
+        '--max-num-gt', type=int, default=100,
+        help='Maximum ground-truth number for each example. This is only an upper bound, not'
+             'necessarily very precise. However, using a very big number may impact the '
+             'training speed.')
+
+    args = parser.parse_args()
+
+    if args.horovod:
+        if hvd is None:
+            raise SystemExit("Horovod not found, please check if you installed it correctly.")
+        hvd.init()
+
+    if args.dataset == 'voc':
+        args.epochs = int(args.epochs) if args.epochs else 20
+        args.lr_decay_epoch = args.lr_decay_epoch if args.lr_decay_epoch else '14,20'
+        args.lr = float(args.lr) if args.lr else 0.001
+        args.lr_warmup = args.lr_warmup if args.lr_warmup else -1
+        args.wd = float(args.wd) if args.wd else 5e-4
+    elif args.dataset == 'coco':
+        args.epochs = int(args.epochs) if args.epochs else 26
+        args.lr_decay_epoch = args.lr_decay_epoch if args.lr_decay_epoch else '17,23'
+        args.lr = float(args.lr) if args.lr else 0.00125
+        args.lr_warmup = args.lr_warmup if args.lr_warmup else 1000
+        args.wd = float(args.wd) if args.wd else 1e-4
+
+    def str_args2num_args(arguments, args_name, num_type):
+        try:
+            ret = [num_type(x) for x in arguments.split(',')]
+            if len(ret) == 1:
+                return ret[0]
+            return ret
+        except ValueError:
+            raise ValueError('invalid value for', args_name, arguments)
+
+    if args.custom_model:
+        args.image_short = str_args2num_args(args.image_short, '--image-short', int)
+        args.roi_size = str_args2num_args(args.roi_size, '--roi-size', int)
+        args.strides = str_args2num_args(args.strides, '--strides', int)
+        args.anchor_aspect_ratio = str_args2num_args(args.anchor_aspect_ratio,
+                                                     '--anchor-aspect-ratio', float)
+        args.anchor_scales = str_args2num_args(args.anchor_scales, '--anchor-scales', float)
+        args.anchor_alloc_size = str_args2num_args(args.anchor_alloc_size,
+                                                   '--anchor-alloc-size', int)
+    if args.amp and args.norm_layer == 'syncbn':
+        raise NotImplementedError('SyncBatchNorm currently does not support AMP.')
+
+    return args
+
+def get_dataset(dataset, args):
+    if dataset.lower() == 'voc':
+        train_dataset = gdata.VOCDetection(
+            splits=[(2007, 'trainval'), (2012, 'trainval')])
+        val_dataset = gdata.VOCDetection(
+            splits=[(2007, 'test')])
+        val_metric = VOC07MApMetric(iou_thresh=0.5, class_names=val_dataset.classes)
+    elif dataset.lower() in ['clipart', 'comic', 'watercolor']:
+        root = os.path.join('~', '.mxnet', 'datasets', dataset.lower())
+        train_dataset = gdata.CustomVOCDetection(root=root, splits=[('', 'train')],
+                                                 generate_classes=True)
+        val_dataset = gdata.CustomVOCDetection(root=root, splits=[('', 'test')],
+                                               generate_classes=True)
+        val_metric = VOC07MApMetric(iou_thresh=0.5, class_names=val_dataset.classes)
+    elif dataset.lower() == 'coco':
+        train_dataset = gdata.COCODetection(splits='instances_train2017', use_crowd=False)
+        val_dataset = gdata.COCODetection(splits='instances_val2017', skip_empty=False)
+        val_metric = COCODetectionMetric(val_dataset, args.save_prefix + '_eval', cleanup=True)
+    else:
+        raise NotImplementedError('Dataset: {} not implemented.'.format(dataset))
+    if args.mixup:
+        from gluoncv.data.mixup import detection
+        train_dataset = detection.MixupDetection(train_dataset)
+    return train_dataset, val_dataset, val_metric
+
+
+def get_dataloader(net, train_dataset, val_dataset, train_transform, val_transform, batch_size,
+                   num_shards, args):
+    """Get dataloader."""
+    train_bfn = FasterRCNNTrainBatchify(net, num_shards)
+    if hasattr(train_dataset, 'get_im_aspect_ratio'):
+        im_aspect_ratio = train_dataset.get_im_aspect_ratio()
+    else:
+        im_aspect_ratio = [1.] * len(train_dataset)
+    train_sampler = \
+        gcv.data.sampler.SplitSortedBucketSampler(im_aspect_ratio, batch_size,
+                                                num_parts=hvd.size() if args.horovod else 1,
+                                                part_index=hvd.rank() if args.horovod else 0,
+                                                shuffle=True)
+    train_loader = mx.gluon.data.DataLoader(train_dataset.transform(
+        train_transform(net.short, net.max_size, net, ashape=net.ashape, multi_stage=args.use_fpn)),
+        batch_sampler=train_sampler, batchify_fn=train_bfn, num_workers=args.num_workers)
+    val_bfn = Tuple(*[Append() for _ in range(3)])
+    short = net.short[-1] if isinstance(net.short, (tuple, list)) else net.short
+    # validation use 1 sample per device
+    val_loader = mx.gluon.data.DataLoader(
+        val_dataset.transform(val_transform(short, net.max_size)), num_shards, False,
+        batchify_fn=val_bfn, last_batch='keep', num_workers=args.num_workers)
+    return train_loader, val_loader
+
+
+def save_params(net, logger, best_map, current_map, epoch, save_interval, prefix):
+    current_map = float(current_map)
+    if current_map > best_map[0]:
+        logger.info('[Epoch {}] mAP {} higher than current best {} saving to {}'.format(
+            epoch, current_map, best_map, '{:s}_best.params'.format(prefix)))
+        best_map[0] = current_map
+        net.save_parameters('{:s}_best.params'.format(prefix))
+        with open(prefix + '_best_map.log', 'a') as f:
+            f.write('{:04d}:\t{:.4f}\n'.format(epoch, current_map))
+    if save_interval and (epoch + 1) % save_interval == 0:
+        logger.info('[Epoch {}] Saving parameters to {}'.format(
+            epoch, '{:s}_{:04d}_{:.4f}.params'.format(prefix, epoch, current_map)))
+        net.save_parameters('{:s}_{:04d}_{:.4f}.params'.format(prefix, epoch, current_map))
+
+
+def split_and_load(batch, ctx_list):
+    """Split data to 1 batch each device."""
+    new_batch = []
+    for i, data in enumerate(batch):
+        if isinstance(data, (list, tuple)):
+            new_data = [x.as_in_context(ctx) for x, ctx in zip(data, ctx_list)]
+        else:
+            new_data = [data.as_in_context(ctx_list[0])]
+        new_batch.append(new_data)
+    return new_batch
+
+
+def validate(net, val_data, ctx, eval_metric, args):
+    """Test on validation dataset."""
+    clipper = gcv.nn.bbox.BBoxClipToImage()
+    eval_metric.reset()
+    if not args.disable_hybridization:
+        # input format is differnet than training, thus rehybridization is needed.
+        net.hybridize(static_alloc=args.static_alloc)
+    for batch in val_data:
+        batch = split_and_load(batch, ctx_list=ctx)
+        det_bboxes = []
+        det_ids = []
+        det_scores = []
+        gt_bboxes = []
+        gt_ids = []
+        gt_difficults = []
+        for x, y, im_scale in zip(*batch):
+            # get prediction results
+            ids, scores, bboxes = net(x)
+            det_ids.append(ids)
+            det_scores.append(scores)
+            # clip to image size
+            det_bboxes.append(clipper(bboxes, x))
+            # rescale to original resolution
+            im_scale = im_scale.reshape((-1)).asscalar()
+            det_bboxes[-1] *= im_scale
+            # split ground truths
+            gt_ids.append(y.slice_axis(axis=-1, begin=4, end=5))
+            gt_bboxes.append(y.slice_axis(axis=-1, begin=0, end=4))
+            gt_bboxes[-1] *= im_scale
+            gt_difficults.append(y.slice_axis(axis=-1, begin=5, end=6) if y.shape[-1] > 5 else None)
+
+        # update metric
+        for det_bbox, det_id, det_score, gt_bbox, gt_id, gt_diff in zip(det_bboxes, det_ids,
+                                                                        det_scores, gt_bboxes,
+                                                                        gt_ids, gt_difficults):
+            eval_metric.update(det_bbox, det_id, det_score, gt_bbox, gt_id, gt_diff)
+    return eval_metric.get()
+
+
+def get_lr_at_iter(alpha, lr_warmup_factor=1. / 3.):
+    return lr_warmup_factor * (1 - alpha) + alpha
+
+
+def train(net, train_data, val_data, eval_metric, batch_size, ctx, args):
+    """Training pipeline"""
+    args.kv_store = 'device' if (args.amp and 'nccl' in args.kv_store) else args.kv_store
+    kv = mx.kvstore.create(args.kv_store)
+    net.collect_params().setattr('grad_req', 'null')
+    net.collect_train_params().setattr('grad_req', 'write')
+    optimizer_params = {'learning_rate': args.lr, 'wd': args.wd, 'momentum': args.momentum}
+    if args.amp:
+        optimizer_params['multi_precision'] = True
+    if args.horovod:
+        hvd.broadcast_parameters(net.collect_params(), root_rank=0)
+        trainer = hvd.DistributedTrainer(
+            net.collect_train_params(),  # fix batchnorm, fix first stage, etc...
+            'sgd',
+            optimizer_params)
+    else:
+        trainer = gluon.Trainer(
+            net.collect_train_params(),  # fix batchnorm, fix first stage, etc...
+            'sgd',
+            optimizer_params,
+            update_on_kvstore=(False if args.amp else None), kvstore=kv)
+
+    if args.amp:
+        amp.init_trainer(trainer)
+
+    # lr decay policy
+    lr_decay = float(args.lr_decay)
+    lr_steps = sorted([float(ls) for ls in args.lr_decay_epoch.split(',') if ls.strip()])
+    lr_warmup = float(args.lr_warmup)  # avoid int division
+
+    # TODO(zhreshold) losses?
+    rpn_cls_loss = mx.gluon.loss.SigmoidBinaryCrossEntropyLoss(from_sigmoid=False)
+    rpn_box_loss = mx.gluon.loss.HuberLoss(rho=args.rpn_smoothl1_rho)  # == smoothl1
+    rcnn_cls_loss = mx.gluon.loss.SoftmaxCrossEntropyLoss()
+    rcnn_box_loss = mx.gluon.loss.HuberLoss(rho=args.rcnn_smoothl1_rho)  # == smoothl1
+    metrics = [mx.metric.Loss('RPN_Conf'),
+               mx.metric.Loss('RPN_SmoothL1'),
+               mx.metric.Loss('RCNN_CrossEntropy'),
+               mx.metric.Loss('RCNN_SmoothL1'), ]
+
+    rpn_acc_metric = RPNAccMetric()
+    rpn_bbox_metric = RPNL1LossMetric()
+    rcnn_acc_metric = RCNNAccMetric()
+    rcnn_bbox_metric = RCNNL1LossMetric()
+    metrics2 = [rpn_acc_metric, rpn_bbox_metric, rcnn_acc_metric, rcnn_bbox_metric]
+
+    # set up logger
+    logging.basicConfig()
+    logger = logging.getLogger()
+    logger.setLevel(logging.INFO)
+    log_file_path = args.save_prefix + '_train.log'
+    log_dir = os.path.dirname(log_file_path)
+    if log_dir and not os.path.exists(log_dir):
+        os.makedirs(log_dir)
+    fh = logging.FileHandler(log_file_path)
+    logger.addHandler(fh)
+    if args.custom_model:
+        logger.info('Custom model enabled. Expert Only!! Currently non-FPN model is not supported!!'
+                    ' Default setting is for MS-COCO.')
+    logger.info(args)
+
+    if args.verbose:
+        logger.info('Trainable parameters:')
+        logger.info(net.collect_train_params().keys())
+    logger.info('Start training from [Epoch {}]'.format(args.start_epoch))
+    best_map = [0]
+    for epoch in range(args.start_epoch, args.epochs):
+        rcnn_task = ForwardBackwardTask(net, trainer, rpn_cls_loss, rpn_box_loss, rcnn_cls_loss,
+                                        rcnn_box_loss, mix_ratio=1.0, amp_enabled=args.amp)
+        executor = Parallel(args.executor_threads, rcnn_task) if not args.horovod else None
+        mix_ratio = 1.0
+        if not args.disable_hybridization:
+            net.hybridize(static_alloc=args.static_alloc)
+        if args.mixup:
+            # TODO(zhreshold) only support evenly mixup now, target generator needs to be modified otherwise
+            train_data._dataset._data.set_mixup(np.random.uniform, 0.5, 0.5)
+            mix_ratio = 0.5
+            if epoch >= args.epochs - args.no_mixup_epochs:
+                train_data._dataset._data.set_mixup(None)
+                mix_ratio = 1.0
+        while lr_steps and epoch >= lr_steps[0]:
+            new_lr = trainer.learning_rate * lr_decay
+            lr_steps.pop(0)
+            trainer.set_learning_rate(new_lr)
+            logger.info("[Epoch {}] Set learning rate to {}".format(epoch, new_lr))
+        for metric in metrics:
+            metric.reset()
+        tic = time.time()
+        btic = time.time()
+        base_lr = trainer.learning_rate
+        rcnn_task.mix_ratio = mix_ratio
+        for i, batch in enumerate(train_data):
+            if epoch == 0 and i <= lr_warmup:
+                # adjust based on real percentage
+                new_lr = base_lr * get_lr_at_iter(i / lr_warmup, args.lr_warmup_factor)
+                if new_lr != trainer.learning_rate:
+                    if i % args.log_interval == 0:
+                        logger.info(
+                            '[Epoch 0 Iteration {}] Set learning rate to {}'.format(i, new_lr))
+                    trainer.set_learning_rate(new_lr)
+            batch = split_and_load(batch, ctx_list=ctx)
+            metric_losses = [[] for _ in metrics]
+            add_losses = [[] for _ in metrics2]
+            if executor is not None:
+                for data in zip(*batch):
+                    executor.put(data)
+            for j in range(len(ctx)):
+                if executor is not None:
+                    result = executor.get()
+                else:
+                    result = rcnn_task.forward_backward(list(zip(*batch))[0])
+                if (not args.horovod) or hvd.rank() == 0:
+                    for k in range(len(metric_losses)):
+                        metric_losses[k].append(result[k])
+                    for k in range(len(add_losses)):
+                        add_losses[k].append(result[len(metric_losses) + k])
+            trainer.step(batch_size)
+
+            for metric, record in zip(metrics, metric_losses):
+                metric.update(0, record)
+            for metric, records in zip(metrics2, add_losses):
+                for pred in records:
+                    metric.update(pred[0], pred[1])
+
+            # update metrics
+            if (not args.horovod or hvd.rank() == 0) and args.log_interval \
+                    and not (i + 1) % args.log_interval:
+                msg = ','.join(
+                    ['{}={:.3f}'.format(*metric.get()) for metric in metrics + metrics2])
+                logger.info('[Epoch {}][Batch {}], Speed: {:.3f} samples/sec, {}'.format(
+                    epoch, i, args.log_interval * args.batch_size / (time.time() - btic), msg))
+                btic = time.time()
+
+        if (not args.horovod) or hvd.rank() == 0:
+            msg = ','.join(['{}={:.3f}'.format(*metric.get()) for metric in metrics])
+            logger.info('[Epoch {}] Training cost: {:.3f}, {}'.format(
+                epoch, (time.time() - tic), msg))
+            if not (epoch + 1) % args.val_interval:
+                # consider reduce the frequency of validation to save time
+                map_name, mean_ap = validate(net, val_data, ctx, eval_metric, args)
+                val_msg = '\n'.join(['{}={}'.format(k, v) for k, v in zip(map_name, mean_ap)])
+                logger.info('[Epoch {}] Validation: \n{}'.format(epoch, val_msg))
+                current_map = float(mean_ap[-1])
+            else:
+                current_map = 0.
+            save_params(net, logger, best_map, current_map, epoch, args.save_interval,
+                        args.save_prefix)
+
+
+if __name__ == '__main__':
+    import sys
+
+    sys.setrecursionlimit(1100)
+    args = parse_args()
+    # fix seed for mxnet, numpy and python builtin random generator.
+    gutils.random.seed(args.seed)
+
+    if args.amp:
+        amp.init()
+
+    # training contexts
+    if args.horovod:
+        ctx = [mx.gpu(hvd.local_rank())]
+    else:
+        ctx = [mx.gpu(int(i)) for i in args.gpus.split(',') if i.strip()]
+        ctx = ctx if ctx else [mx.cpu()]
+
+    # training data
+    train_dataset, val_dataset, eval_metric = get_dataset(args.dataset, args)
+
+    # network
+    kwargs = {}
+    module_list = []
+    if args.use_fpn:
+        module_list.append('fpn')
+    if args.norm_layer is not None:
+        module_list.append(args.norm_layer)
+        if args.norm_layer == 'syncbn':
+            kwargs['num_devices'] = len(ctx)
+
+    num_gpus = hvd.size() if args.horovod else len(ctx)
+    net_name = '_'.join(('doublehead_rcnn', *module_list, args.network, args.dataset))
+    if args.custom_model:
+        args.use_fpn = True
+        net_name = '_'.join(('custom_faster_rcnn_fpn', args.network, args.dataset))
+        if args.norm_layer == 'syncbn':
+            norm_layer = gluon.contrib.nn.SyncBatchNorm
+            norm_kwargs = {'num_devices': len(ctx)}
+            sym_norm_layer = mx.sym.contrib.SyncBatchNorm
+            sym_norm_kwargs = {'ndev': len(ctx)}
+        elif args.norm_layer == 'gn':
+            norm_layer = gluon.nn.GroupNorm
+            norm_kwargs = {'groups': 8}
+            sym_norm_layer = mx.sym.GroupNorm
+            sym_norm_kwargs = {'groups': 8}
+        else:
+            norm_layer = gluon.nn.BatchNorm
+            norm_kwargs = None
+            sym_norm_layer = None
+            sym_norm_kwargs = None
+        classes = train_dataset.CLASSES
+        net = get_model('custom_faster_rcnn_fpn', classes=classes, transfer=None,
+                        dataset=args.dataset, pretrained_base=not args.no_pretrained_base,
+                        base_network_name=args.network, norm_layer=norm_layer,
+                        norm_kwargs=norm_kwargs, sym_norm_kwargs=sym_norm_kwargs,
+                        num_fpn_filters=args.num_fpn_filters,
+                        num_box_head_conv=args.num_box_head_conv,
+                        num_box_head_conv_filters=args.num_box_head_conv_filters,
+                        num_box_head_dense_filters=args.num_box_head_dense_filters,
+                        short=args.image_short, max_size=args.image_max_size, min_stage=2,
+                        max_stage=6, nms_thresh=args.nms_thresh, nms_topk=args.nms_topk,
+                        post_nms=args.post_nms, roi_mode=args.roi_mode, roi_size=args.roi_size,
+                        strides=args.strides, clip=args.clip, rpn_channel=args.rpn_channel,
+                        base_size=args.anchor_base_size, scales=args.anchor_scales,
+                        ratios=args.anchor_aspect_ratio, alloc_size=args.anchor_alloc_size,
+                        rpn_nms_thresh=args.rpn_nms_thresh,
+                        rpn_train_pre_nms=args.rpn_train_pre_nms,
+                        rpn_train_post_nms=args.rpn_train_post_nms,
+                        rpn_test_pre_nms=args.rpn_test_pre_nms,
+                        rpn_test_post_nms=args.rpn_test_post_nms, rpn_min_size=args.rpn_min_size,
+                        per_device_batch_size=args.batch_size // num_gpus,
+                        num_sample=args.rcnn_num_samples, pos_iou_thresh=args.rcnn_pos_iou_thresh,
+                        pos_ratio=args.rcnn_pos_ratio, max_num_gt=args.max_num_gt)
+    else:
+        net = get_model(net_name, pretrained_base=True,
+                        per_device_batch_size=args.batch_size // num_gpus, **kwargs)
+    args.save_prefix += net_name
+    if args.resume.strip():
+        net.load_parameters(args.resume.strip(), ignore_extra=True)
+    else:
+        for param in net.collect_params().values():
+            if param._data is not None:
+                continue
+            param.initialize()
+    net.collect_params().reset_ctx(ctx)
+
+    if args.amp:
+        # Cast both weights and gradients to 'float16'
+        net.cast('float16')
+        # These layers don't support type 'float16'
+        net.collect_params('.*batchnorm.*').setattr('dtype', 'float32')
+        net.collect_params('.*normalizedperclassboxcenterencoder.*').setattr('dtype', 'float32')
+
+    # dataloader
+    batch_size = args.batch_size // num_gpus if args.horovod else args.batch_size
+    train_data, val_data = get_dataloader(
+        net, train_dataset, val_dataset, FasterRCNNDefaultTrainTransform,
+        FasterRCNNDefaultValTransform, batch_size, len(ctx), args)
+
+    # training
+    train(net, train_data, val_data, eval_metric, batch_size, ctx, args)


### PR DESCRIPTION
Double Head Faster RCNN model from the paper. 
(2019). Rethinking Classification and Localization for Object Detection.
Models of VOC dataset are evaluated with native resolutions with shorter side >= 600 but longer side <= 1000 without changing aspect ratios.

| detection module | map | 
| ----- | ----- | 
| faster_rcnn_resnet50_v1b_voc | 78.3 |
| doublehead_rcnn_resnet50_v1b_voc| 81.0 | 
